### PR TITLE
Fix calculateCommissionLinesStep having udnefined computed totals values

### DIFF
--- a/apps/backend/src/workflows/commission/steps/calculate-commission-lines.ts
+++ b/apps/backend/src/workflows/commission/steps/calculate-commission-lines.ts
@@ -43,11 +43,10 @@ async function calculatePercentageCommission(
   currency: string,
   container: MedusaContainer
 ) {
-  // TODO: Check if this is valid
-  const taxValue = item.item_tax_total
+  const taxValue = item.tax_total
   const totalPrice = item.is_tax_inclusive
     ? item.item_total
-    : MathBN.add(item.item_subtotal, taxValue)
+    : MathBN.add(item.subtotal, taxValue)
 
   const commissionValue = MathBN.mult(
     rate.include_tax ? totalPrice : MathBN.sub(totalPrice, taxValue),
@@ -99,7 +98,10 @@ export const calculateCommissionLinesStep = createStep(
   async ({ order_id, seller_id }: StepInput, { container }) => {
     const orderService = container.resolve(Modules.ORDER)
     const order = await orderService.retrieveOrder(order_id, {
-      relations: ['items']
+      relations: ['items'],
+      // At least one of the computed totals fields should be requested in select, 
+      // in order for decorateTotals to be called
+      select: ['*', 'item_total'],
     })
 
     const query = container.resolve(ContainerRegistrationKeys.QUERY)


### PR DESCRIPTION
If one of the cmputed totals fields are not included in the select of OrderModule main service methods, then the order is not decorated with Totals.

![Captura de pantalla 2025-03-17 a la(s) 6 21 21 p  m](https://github.com/user-attachments/assets/4db929a2-942b-44d5-b9bb-de32d0ac6f66)

Also, corrected the names of the computed totals fields, when being accessed through the items relation.
