### PR TITLE
Remove min cosntraint for categories in CreateProduct validator

### DIFF
--- a/apps/backend/src/api/vendor/products/validators.ts
+++ b/apps/backend/src/api/vendor/products/validators.ts
@@ -503,7 +503,7 @@ export const VendorCreateProduct = z
     external_id: z.string().optional(),
     type_id: z.string().optional(),
     collection_id: z.string().optional(),
-    categories: z.array(IdAssociation).max(1).optional(),
+    categories: z.array(IdAssociation).optional(),
     tags: z.array(IdAssociation).optional(),
     options: z.array(CreateProductOption).optional(),
     variants: z.array(CreateProductVariant).optional(),


### PR DESCRIPTION
I don't understand why put this limitation in, I would assume the Vendor can link the product to more than one category. Specially if they select a deeply nested one, the product should be linked to all of the direct parents