### PR TITLE
Avoid passing additional_data to updateProductsWorkflow

### DIFF
--- a/apps/backend/src/api/vendor/products/[id]/route.ts
+++ b/apps/backend/src/api/vendor/products/[id]/route.ts
@@ -118,12 +118,14 @@ export const POST = async (
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  const { additional_data, ...update } = req.validatedBody
+
   const { result } = await updateProductsWorkflow(req.scope).run({
     input: {
       // @ts-expect-error: updateProductsWorkflow does not support null values
-      update: req.validatedBody,
+      update,
       selector: { id: req.params.id },
-      additional_data: req.validatedBody.additional_data,
+      additional_data
     }
   })
 


### PR DESCRIPTION
If you pass additional_data to vendor update product endpoint, this will fail, since the additional_data is incorrectly passed to updatedProductsWorkflow. Instead, we destructure to separate additional_data from the rest of the common update payload and pass it down correctly to the workflow.