### PR TITLE
Fix/query params vendor categories

### DIFF
--- a/apps/backend/src/api/vendor/product-categories/route.ts
+++ b/apps/backend/src/api/vendor/product-categories/route.ts
@@ -60,6 +60,7 @@ export const GET = async (
   const { data: product_categories, metadata } = await query.graph({
     entity: 'product_category',
     fields: req.queryConfig.fields,
+    filters: req.filterableFields,
     pagination: req.queryConfig.pagination
   })
 

--- a/apps/backend/src/api/vendor/product-categories/validators.ts
+++ b/apps/backend/src/api/vendor/product-categories/validators.ts
@@ -1,11 +1,7 @@
 import { z } from 'zod'
-
-import { createFindParams } from '@medusajs/medusa/api/utils/validators'
+import { AdminProductCategoriesParams } from '@medusajs/medusa/api/admin/product-categories/validators'
 
 export type VendorGetProductCategoriesParamsType = z.infer<
   typeof VendorGetProductCategoriesParams
 >
-export const VendorGetProductCategoriesParams = createFindParams({
-  limit: 50,
-  offset: 0
-})
+export const VendorGetProductCategoriesParams = AdminProductCategoriesParams


### PR DESCRIPTION
- Allows original query params for /vendor/product-categories GET validator. Useful for include_descendants_tree = true and parent_category_id = null for example, to create hierarchical data
  - This also makes the categoryCombobox in Vendor panel to work correctly, otherwise all categories are flattened
- Passes filterableFields to query, to allow filtering