### PR TITLE
feat(mm2-388): allow to save products as draft

### DIFF
--- a/apps/backend/src/api/admin/requests/route.ts
+++ b/apps/backend/src/api/admin/requests/route.ts
@@ -70,10 +70,14 @@ export async function GET(
   res: MedusaResponse
 ): Promise<void> {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
   const { data: requests, metadata } = await query.graph({
     entity: 'request',
     fields: req.queryConfig.fields,
-    filters: req.filterableFields,
+    filters: {
+      ...req.filterableFields,
+      status: req.filterableFields.status || { $ne: 'draft' }
+    },
     pagination: req.queryConfig.pagination
   })
 

--- a/apps/backend/src/api/vendor/products/[id]/status/route.ts
+++ b/apps/backend/src/api/vendor/products/[id]/status/route.ts
@@ -1,7 +1,13 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from '@medusajs/framework'
-import { ContainerRegistrationKeys } from '@medusajs/framework/utils'
+import {
+  ContainerRegistrationKeys,
+  MedusaError
+} from '@medusajs/framework/utils'
 import { updateProductsWorkflow } from '@medusajs/medusa/core-flows'
 
+import { CONFIGURATION_MODULE } from '../../../../../modules/configuration'
+import ConfigurationModuleService from '../../../../../modules/configuration/service'
+import { ConfigurationRuleType } from '../../../../../modules/configuration/types'
 import { VendorUpdateProductStatusType } from '../../validators'
 
 /**
@@ -49,6 +55,20 @@ export const POST = async (
   res: MedusaResponse
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const configuration =
+    req.scope.resolve<ConfigurationModuleService>(CONFIGURATION_MODULE)
+
+  if (
+    req.validatedBody.status !== 'proposed' &&
+    (await configuration.isRuleEnabled(
+      ConfigurationRuleType.REQUIRE_PRODUCT_APPROVAL
+    ))
+  ) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      'This feature is disabled!'
+    )
+  }
 
   const { result } = await updateProductsWorkflow(req.scope).run({
     input: {

--- a/apps/backend/src/api/vendor/products/[id]/status/route.ts
+++ b/apps/backend/src/api/vendor/products/[id]/status/route.ts
@@ -59,7 +59,7 @@ export const POST = async (
     req.scope.resolve<ConfigurationModuleService>(CONFIGURATION_MODULE)
 
   if (
-    req.validatedBody.status !== 'proposed' &&
+    !['proposed', 'draft'].includes(req.validatedBody.status) &&
     (await configuration.isRuleEnabled(
       ConfigurationRuleType.REQUIRE_PRODUCT_APPROVAL
     ))

--- a/apps/backend/src/api/vendor/products/middlewares.ts
+++ b/apps/backend/src/api/vendor/products/middlewares.ts
@@ -231,10 +231,6 @@ export const vendorProductsMiddlewares: MiddlewareRoute[] = [
         entryPoint: sellerProductLink.entryPoint,
         filterField: 'product_id'
       }),
-      checkConfigurationRule(
-        ConfigurationRuleType.REQUIRE_PRODUCT_APPROVAL,
-        false
-      ),
       validateAndTransformBody(VendorUpdateProductStatus),
       validateAndTransformQuery(
         VendorGetProductParams,

--- a/apps/backend/src/api/vendor/products/validators.ts
+++ b/apps/backend/src/api/vendor/products/validators.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 
 import { AdditionalData } from '@medusajs/framework/types'
-import { ProductStatus } from '@medusajs/framework/utils'
 import {
   WithAdditionalData,
   createFindParams
@@ -412,7 +411,7 @@ export const UpdateProductVariant = z
  *     description: A unique handle to identify the product.
  *   status:
  *     type: string
- *     enum: [draft, proposed, published, rejected]
+ *     enum: [draft, proposed]
  *     description: The status of the product.
  *     default: draft
  *   external_id:
@@ -504,7 +503,7 @@ export const CreateProduct = z
     images: z.array(z.object({ url: z.string() })).optional(),
     thumbnail: z.string().optional(),
     handle: z.string().optional(),
-    status: z.nativeEnum(ProductStatus).optional().default(ProductStatus.DRAFT),
+    status: z.enum(['draft', 'proposed']).optional().default('draft'),
     external_id: z.string().optional(),
     type_id: z.string().optional(),
     collection_id: z.string().optional(),
@@ -721,12 +720,12 @@ export const VendorUpdateProduct = WithAdditionalData(UpdateProduct)
  * properties:
  *   status:
  *     type: string
- *     enum: [draft, proposed, published, rejected]
+ *     enum: [draft, proposed, published]
  *     description: The status of the product.
  */
 export type VendorUpdateProductStatusType = z.infer<
   typeof VendorUpdateProductStatus
 >
 export const VendorUpdateProductStatus = z.object({
-  status: z.nativeEnum(ProductStatus)
+  status: z.enum(['draft', 'proposed', 'published'])
 })

--- a/apps/backend/src/api/vendor/products/validators.ts
+++ b/apps/backend/src/api/vendor/products/validators.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod'
 
+import { AdditionalData } from '@medusajs/framework/types'
 import { ProductStatus } from '@medusajs/framework/utils'
-import { createFindParams, WithAdditionalData } from '@medusajs/medusa/api/utils/validators'
+import {
+  WithAdditionalData,
+  createFindParams
+} from '@medusajs/medusa/api/utils/validators'
 
 import { IdAssociation } from '../../../shared/infra/http/utils'
-import { AdditionalData } from '@medusajs/framework/types'
 
 export type VendorGetProductParamsType = z.infer<typeof VendorGetProductParams>
 export const VendorGetProductParams = createFindParams({
@@ -489,7 +492,8 @@ export const UpdateProductVariant = z
  *         id:
  *           type: string
  */
-export type VendorCreateProductType = z.infer<typeof CreateProduct> & AdditionalData
+export type VendorCreateProductType = z.infer<typeof CreateProduct> &
+  AdditionalData
 export const CreateProduct = z
   .object({
     title: z.string(),
@@ -528,11 +532,11 @@ export const CreateProduct = z
  *   - $ref: "#/components/schemas/CreateProduct"
  *   - type: object
  *     properties:
-  *      additional_data:
-  *        type: object
-  *        description: Additional data to use in products hooks.
-  *        additionalProperties: true
- * 
+ *      additional_data:
+ *        type: object
+ *        description: Additional data to use in products hooks.
+ *        additionalProperties: true
+ *
  */
 export const VendorCreateProduct = WithAdditionalData(CreateProduct)
 
@@ -662,7 +666,8 @@ export const VendorCreateProduct = WithAdditionalData(CreateProduct)
  *         id:
  *           type: string
  */
-export type VendorUpdateProductType = z.infer<typeof UpdateProduct> & AdditionalData
+export type VendorUpdateProductType = z.infer<typeof UpdateProduct> &
+  AdditionalData
 export const UpdateProduct = z
   .object({
     title: z.string().optional(),
@@ -700,11 +705,11 @@ export const UpdateProduct = z
  *   - $ref: "#/components/schemas/UpdateProduct"
  *   - type: object
  *     properties:
-  *      additional_data:
-  *        type: object
-  *        description: Additional data to use in products hooks.
-  *        additionalProperties: true
- * 
+ *      additional_data:
+ *        type: object
+ *        description: Additional data to use in products hooks.
+ *        additionalProperties: true
+ *
  */
 export const VendorUpdateProduct = WithAdditionalData(UpdateProduct)
 

--- a/apps/backend/src/modules/requests/migrations/.snapshot-requests.json
+++ b/apps/backend/src/modules/requests/migrations/.snapshot-requests.json
@@ -69,6 +69,7 @@
           "nullable": false,
           "default": "'pending'",
           "enumItems": [
+            "draft",
             "pending",
             "accepted",
             "rejected"
@@ -115,6 +116,7 @@
           "keyName": "IDX_request_deleted_at",
           "columnNames": [],
           "composite": false,
+          "constraint": false,
           "primary": false,
           "unique": false,
           "expression": "CREATE INDEX IF NOT EXISTS \"IDX_request_deleted_at\" ON \"request\" (deleted_at) WHERE deleted_at IS NULL"
@@ -125,12 +127,15 @@
             "id"
           ],
           "composite": false,
+          "constraint": true,
           "primary": true,
           "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {}
+      "foreignKeys": {},
+      "nativeEnums": {}
     }
-  ]
+  ],
+  "nativeEnums": {}
 }

--- a/apps/backend/src/modules/requests/migrations/Migration20250428150914.ts
+++ b/apps/backend/src/modules/requests/migrations/Migration20250428150914.ts
@@ -1,0 +1,17 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20250428150914 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "request" drop constraint if exists "request_status_check";`);
+
+    this.addSql(`alter table if exists "request" add constraint "request_status_check" check("status" in ('draft', 'pending', 'accepted', 'rejected'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "request" drop constraint if exists "request_status_check";`);
+
+    this.addSql(`alter table if exists "request" add constraint "request_status_check" check("status" in ('pending', 'accepted', 'rejected'));`);
+  }
+
+}

--- a/apps/backend/src/modules/requests/models/request.ts
+++ b/apps/backend/src/modules/requests/models/request.ts
@@ -7,5 +7,7 @@ export const Request = model.define('request', {
   submitter_id: model.text(),
   reviewer_id: model.text().nullable(),
   reviewer_note: model.text().nullable(),
-  status: model.enum(['pending', 'accepted', 'rejected']).default('pending')
+  status: model
+    .enum(['draft', 'pending', 'accepted', 'rejected'])
+    .default('pending')
 })

--- a/apps/backend/src/modules/requests/types/mutations.ts
+++ b/apps/backend/src/modules/requests/types/mutations.ts
@@ -11,8 +11,8 @@ export type CreateRequestDTO = {
 
 export type UpdateRequestDTO = {
   id: string
-  reviewer_id: string
-  reviewer_note: string
+  reviewer_id?: string
+  reviewer_note?: string
   status: RequestStatus
 }
 

--- a/apps/backend/src/modules/requests/types/mutations.ts
+++ b/apps/backend/src/modules/requests/types/mutations.ts
@@ -1,4 +1,4 @@
-export type RequestStatus = 'pending' | 'accepted' | 'rejected'
+export type RequestStatus = 'pending' | 'accepted' | 'rejected' | 'draft'
 
 export type CreateRequestDTO = {
   type: string

--- a/apps/backend/src/subscribers/product-updated.ts
+++ b/apps/backend/src/subscribers/product-updated.ts
@@ -29,8 +29,11 @@ export default async function productUpdatedHandler({
     }
   })
 
+  if (!foundRequest) {
+    return
+  }
+
   if (
-    foundRequest &&
     foundRequest.status === 'pending' &&
     ['published', 'rejected'].includes(product.status)
   ) {
@@ -41,6 +44,16 @@ export default async function productUpdatedHandler({
         reviewer_id: 'system',
         reviewer_note: 'auto',
         status: product.status === 'published' ? 'accepted' : 'rejected'
+      }
+    })
+  }
+
+  if (foundRequest.status === 'draft' && product.status === 'proposed') {
+    await updateRequestWorkflow.run({
+      container,
+      input: {
+        id: foundRequest.id,
+        status: 'pending'
       }
     })
   }

--- a/apps/backend/src/subscribers/product-updated.ts
+++ b/apps/backend/src/subscribers/product-updated.ts
@@ -48,7 +48,7 @@ export default async function productUpdatedHandler({
     })
   }
 
-  if (foundRequest.status === 'draft' && product.status === 'proposed') {
+  if (product.status === 'proposed') {
     await updateRequestWorkflow.run({
       container,
       input: {

--- a/apps/backend/src/workflows/hooks/request-created.ts
+++ b/apps/backend/src/workflows/hooks/request-created.ts
@@ -20,6 +20,7 @@ createProductRequestWorkflow.hooks.productRequestCreated(
     const request = await service.retrieveRequest(requestId)
 
     if (
+      request.status !== 'draft' &&
       !(await configuration.isRuleEnabled(
         ConfigurationRuleType.REQUIRE_PRODUCT_APPROVAL
       ))

--- a/apps/backend/src/workflows/requests/workflows/create-product-request.ts
+++ b/apps/backend/src/workflows/requests/workflows/create-product-request.ts
@@ -10,7 +10,10 @@ import {
 } from '@medusajs/workflows-sdk'
 
 import { REQUESTS_MODULE } from '../../../modules/requests'
-import { CreateRequestDTO } from '../../../modules/requests/types'
+import {
+  CreateRequestDTO,
+  RequestStatus
+} from '../../../modules/requests/types'
 import { SELLER_MODULE } from '../../../modules/seller'
 import { createRequestStep } from '../steps'
 
@@ -42,9 +45,12 @@ export const createProductRequestWorkflow = createWorkflow(
         ...input.data,
         data: {
           ...productPayload,
-          product_id: product[0].id,
-          status: productPayload.status === 'draft' ? 'draft' : 'pending'
-        }
+          product_id: product[0].id
+        },
+        status:
+          productPayload.status === 'draft'
+            ? ('draft' as RequestStatus)
+            : ('pending' as RequestStatus)
       })
     )
 

--- a/apps/backend/src/workflows/requests/workflows/create-product-request.ts
+++ b/apps/backend/src/workflows/requests/workflows/create-product-request.ts
@@ -42,7 +42,8 @@ export const createProductRequestWorkflow = createWorkflow(
         ...input.data,
         data: {
           ...productPayload,
-          product_id: product[0].id
+          product_id: product[0].id,
+          status: productPayload.status === 'draft' ? 'draft' : 'pending'
         }
       })
     )

--- a/apps/backend/src/workflows/requests/workflows/create-product-request.ts
+++ b/apps/backend/src/workflows/requests/workflows/create-product-request.ts
@@ -23,7 +23,7 @@ export const createProductRequestWorkflow = createWorkflow(
   }) {
     const productPayload = transform(input, (input) => ({
       ...input.data.data,
-      status: 'proposed'
+      status: input.data.data.status === 'draft' ? 'draft' : 'proposed'
     }))
 
     const product = createProductsWorkflow.runAsStep({


### PR DESCRIPTION
Context: We can't get rid of the `request` part of product creation, because we want to maintain functionality for admin to add approval/rejection note. So we have to create request anyway and keep it in inactive state until the product is set as ready to review (proposed). 