### PR TITLE
Fix http-client queryparams parsing

### DIFF
--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "swagger-typescript-api": "^13.0.23"
+    "swagger-typescript-api": "^13.0.23",
+    "qs": "^6.14.0"
   }
 }

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -24599,7 +24599,7 @@ export interface CreateProduct {
    * The status of the product.
    * @default "draft"
    */
-  status?: "draft" | "proposed";
+  status?: "draft" | "proposed" | "published" | "rejected";
   /** The external ID of the product. */
   external_id?: string;
   /** The ID of the product type. */
@@ -25217,35 +25217,6 @@ export interface VendorBaseRuleOperatorOptions {
   label?: string;
 }
 
-export interface VendorBatchInventoryItemLevels {
-  /** Levels to create */
-  create?: VendorBatchInventoryLocationLevel[];
-  /** Levels to update */
-  update?: VendorBatchInventoryLocationLevel[];
-  /** Levels to delete */
-  delete?: string[];
-}
-
-export interface VendorBatchInventoryItemLocationsLevel {
-  /** Levels to create */
-  create?: VendorCreateInventoryLevel[];
-  /** Levels to update */
-  update?: VendorBatchInventoryLocationLevel[];
-  /** Levels to delete */
-  delete?: string[];
-}
-
-export interface VendorBatchInventoryLocationLevel {
-  /** The inventory item id. */
-  inventory_item_id?: string;
-  /** The quantity of the InventoryItem in StockLocation. */
-  stocked_quantity?: number;
-  /** The stock location id. */
-  location_id?: string;
-  /** The quantity incoming_quantity. */
-  incoming_quantity?: number;
-}
-
 export interface VendorBatchPromotionRule {
   /** Rules to create. */
   create?: VendorCreatePromotionRule[];
@@ -25533,19 +25504,6 @@ export interface VendorCreatePromotionRule {
 export interface VendorCreateRequest {
   /** The resource to be created by request */
   request: ProductCollectionRequest | ProductCategoryRequest | ReviewRemoveRequest | ProductTypeRequest;
-}
-
-export interface VendorCreateReservation {
-  /** The description of the reservation. */
-  description?: string;
-  /** The location id of the reservation. */
-  location_id?: string;
-  /** The inventory item id of the reservation. */
-  inventory_item_id?: string;
-  /** The line item id of the reservation. */
-  line_item_id?: string;
-  /** The number of items in the reservation. */
-  quantity?: number;
 }
 
 export interface VendorCreateSeller {
@@ -27837,53 +27795,6 @@ export interface VendorReceiveReturnItems {
 }
 
 /**
- * Region
- * Region object
- */
-export interface VendorRegion {
-  /** The unique identifier of the item. */
-  id?: string;
-  /**
-   * The date with timezone at which the resource was created.
-   * @format date-time
-   */
-  created_at?: string;
-  /**
-   * The date with timezone at which the resource was last updated.
-   * @format date-time
-   */
-  updated_at?: string;
-  /** The name of the region. */
-  name?: string;
-  /** The currency of the region. */
-  currency_code?: string;
-  /** Whether taxes are applied automatically during checkout. */
-  automatic_taxes?: boolean;
-  /** The type of the promotion. */
-  type?: string;
-  countries?: VendorRegionCountry[];
-}
-
-/**
- * Region country
- * Region country object
- */
-export interface VendorRegionCountry {
-  /** The unique identifier of the item. */
-  id?: string;
-  /** Name of the country */
-  name?: string;
-  /** Display name of the country */
-  display_name?: string;
-  /** ISO_2 code */
-  iso_2?: string;
-  /** ISO_3 code */
-  iso_3?: string;
-  /** Numcode */
-  num_code?: string;
-}
-
-/**
  * Request
  * A request object
  */
@@ -28696,7 +28607,7 @@ export type VendorUpdateProduct = UpdateProduct & {
 
 export interface VendorUpdateProductStatus {
   /** The status of the product. */
-  status?: "draft" | "proposed" | "published";
+  status?: "draft" | "proposed" | "published" | "rejected";
 }
 
 export interface VendorUpdatePromotion {
@@ -28712,11 +28623,6 @@ export interface VendorUpdatePromotion {
   /** The status of the promotion. */
   status?: "draft" | "active" | "inactive";
   application_method?: VendorUpdateApplicationMethod;
-}
-
-export interface VendorUpdateRequestData {
-  /** The resource to be updated */
-  request: ProductCollectionRequest | ProductCategoryRequest | ReviewRemoveRequest | ProductTypeRequest;
 }
 
 export interface VendorUpdateReservation {
@@ -28827,6 +28733,8 @@ export interface VendorUpdateStockLocation {
   metadata?: object | null;
 }
 
+import qs from "qs";
+
 export type QueryParamsType = Record<string | number, any>;
 export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
 
@@ -28910,10 +28818,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
     const query = rawQuery || {};
-    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
-    return keys
-      .map((key) => (Array.isArray(query[key]) ? this.addArrayQueryParam(query, key) : this.addQueryParam(query, key)))
-      .join("&");
+    return qs.stringify(query);
   }
 
   protected addQueryParams(rawQuery?: QueryParamsType): string {
@@ -59076,25 +58981,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Batch updates InventoryItem levels
-     *
-     * @tags Product
-     * @name VendorBatchInventoryItemLevels
-     * @summary Update inventory item levels
-     * @request POST:/vendor/inventory-items/location-levels/batch
-     * @secure
-     */
-    vendorBatchInventoryItemLevels: (data: VendorBatchInventoryItemLevels, params: RequestParams = {}) =>
-      this.request<void, any>({
-        path: `/vendor/inventory-items/location-levels/batch`,
-        method: "POST",
-        body: data,
-        secure: true,
-        type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
      * @description Retrieves InventoryItem of specified id
      *
      * @tags Product
@@ -59159,29 +59045,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     vendorCreateInventoryLevel: (id: string, data: VendorCreateInventoryLevel, params: RequestParams = {}) =>
       this.request<void, any>({
         path: `/vendor/inventory-items/${id}/location-levels`,
-        method: "POST",
-        body: data,
-        secure: true,
-        type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
-     * @description Batch updates InventoryItem levels
-     *
-     * @tags Product
-     * @name VendorBatchInventoryItemLocationsLevels
-     * @summary Update inventory item levels
-     * @request POST:/vendor/inventory-items/{id}/location-levels/batch
-     * @secure
-     */
-    vendorBatchInventoryItemLocationsLevels: (
-      id: string,
-      data: VendorBatchInventoryItemLocationsLevel,
-      params: RequestParams = {},
-    ) =>
-      this.request<void, any>({
-        path: `/vendor/inventory-items/${id}/location-levels/batch`,
         method: "POST",
         body: data,
         secure: true,
@@ -60076,78 +59939,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         any
       >({
         path: `/vendor/product-categories/${id}`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Retrieves a list of product collections.
-     *
-     * @tags Product
-     * @name VendorListProductCollections
-     * @summary List product collections
-     * @request GET:/vendor/product-collections
-     * @secure
-     */
-    vendorListProductCollections: (
-      query?: {
-        /** The comma-separated fields to include in the response */
-        fields?: string;
-        /** The number of items to skip before starting to collect the result set. */
-        offset?: number;
-        /** The number of items to return. */
-        limit?: number;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          product_collections?: VendorProductCollection[];
-          /** The total number of items available */
-          count?: number;
-          /** The number of items skipped before these items */
-          offset?: number;
-          /** The number of items per page */
-          limit?: number;
-        },
-        any
-      >({
-        path: `/vendor/product-collections`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Retrieves product collection by id.
-     *
-     * @tags Product
-     * @name VendorGetProductCollectionById
-     * @summary Get product collection
-     * @request GET:/vendor/product-collections/{id}
-     * @secure
-     */
-    vendorGetProductCollectionById: (
-      id: string,
-      query?: {
-        /** The comma-separated fields to include in the response */
-        fields?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          /** A product collection object with its properties */
-          product_collection?: VendorProductCollection;
-        },
-        any
-      >({
-        path: `/vendor/product-collections/${id}`,
         method: "GET",
         query: query,
         secure: true,
@@ -61097,78 +60888,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Retrieves a list of regions.
-     *
-     * @tags Region
-     * @name VendorListRegions
-     * @summary List regions
-     * @request GET:/vendor/regions
-     * @secure
-     */
-    vendorListRegions: (
-      query?: {
-        /** The comma-separated fields to include in the response */
-        fields?: string;
-        /** The number of items to skip before starting to collect the result set. */
-        offset?: number;
-        /** The number of items to return. */
-        limit?: number;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          regions?: VendorRegion[];
-          /** The total number of items available */
-          count?: number;
-          /** The number of items skipped before these items */
-          offset?: number;
-          /** The number of items per page */
-          limit?: number;
-        },
-        any
-      >({
-        path: `/vendor/regions`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Retrieves region by id.
-     *
-     * @tags Region
-     * @name VendorGetRegionById
-     * @summary Get region
-     * @request GET:/vendor/regions/{id}
-     * @secure
-     */
-    vendorGetRegionById: (
-      id: string,
-      query?: {
-        /** The comma-separated fields to include in the response */
-        fields?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          /** Region object */
-          region?: VendorRegion;
-        },
-        any
-      >({
-        path: `/vendor/regions/${id}`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
      * @description Retrieves submited requests list
      *
      * @tags Requests
@@ -61263,41 +60982,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Updates specified request payload.
-     *
-     * @tags Requests
-     * @name VendorUpdateRequestData
-     * @summary Update request data
-     * @request POST:/vendor/requests/{id}
-     * @secure
-     */
-    vendorUpdateRequestData: (
-      id: string,
-      data: VendorUpdateRequestData,
-      query?: {
-        /** The comma-separated fields to include in the response */
-        fields?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          /** A request object */
-          request?: VendorRequest;
-        },
-        any
-      >({
-        path: `/vendor/requests/${id}`,
-        method: "POST",
-        query: query,
-        body: data,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
      * @description Retrieves a list of reservations for the authenticated vendor.
      *
      * @tags Reservations
@@ -61333,40 +61017,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "GET",
         query: query,
         secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Creates new reservation
-     *
-     * @tags Reservations
-     * @name VendorCreateReservation
-     * @summary Create reservation
-     * @request POST:/vendor/reservations
-     * @secure
-     */
-    vendorCreateReservation: (
-      data: VendorCreateReservation,
-      query?: {
-        /** Comma-separated fields to include in the response. */
-        fields?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<
-        {
-          /** The reservation's details. */
-          reservation?: VendorReservation;
-        },
-        any
-      >({
-        path: `/vendor/reservations`,
-        method: "POST",
-        query: query,
-        body: data,
-        secure: true,
-        type: ContentType.Json,
         format: "json",
         ...params,
       }),

--- a/patches/swagger-typescript-api+13.0.23.patch
+++ b/patches/swagger-typescript-api+13.0.23.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/swagger-typescript-api/templates/base/http-clients/fetch-http-client.ejs b/node_modules/swagger-typescript-api/templates/base/http-clients/fetch-http-client.ejs
+index a1db383..33dfb66 100644
+--- a/node_modules/swagger-typescript-api/templates/base/http-clients/fetch-http-client.ejs
++++ b/node_modules/swagger-typescript-api/templates/base/http-clients/fetch-http-client.ejs
+@@ -2,6 +2,8 @@
+ const { apiConfig, generateResponses, config } = it;
+ %>
+ 
++import qs from "qs";
++
+ export type QueryParamsType = Record<string | number, any>;
+ export type ResponseFormat = keyof Omit<Body, "body" | "bodyUsed">;
+ 
+@@ -86,14 +88,7 @@ export class HttpClient<SecurityDataType = unknown> {
+ 
+     protected toQueryString(rawQuery?: QueryParamsType): string {
+         const query = rawQuery || {};
+-        const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+-        return keys
+-                .map((key) =>
+-                    Array.isArray(query[key])
+-                    ? this.addArrayQueryParam(query, key)
+-                    : this.addQueryParam(query, key),
+-                )
+-                .join("&");
++        return qs.stringify(query);
+     }
+ 
+     protected addQueryParams(rawQuery?: QueryParamsType): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11486,7 +11486,7 @@ qs@6.13.0:
   dependencies:
     side-channel "^1.0.6"
 
-qs@^6.11.0, qs@^6.11.2, qs@^6.12.0, qs@^6.12.1:
+qs@^6.11.0, qs@^6.11.2, qs@^6.12.0, qs@^6.12.1, qs@^6.14.0:
   version "6.14.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
   integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
@@ -12566,16 +12566,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12639,14 +12630,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13508,7 +13492,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13521,15 +13505,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
- Uses patch-package to modify swagger-typescript-api fetch-http-client template
- Add qs as dependency, to use it inside swagger-typescript-api
- Change toQueryString methods inside fetch-http-client, to use qs.stringify and correctly parse nested objects

Note: I use patch-package, since i found a lot of open issues in swagger-typescript-api about templates approach to customize the generated client not working as well as epxeriencing it myself after trying many times. Patch package works and after the change, i am able to pass nested objects and have them parsed correctly.

Fixes #186 