### PR TITLE
fix(seller-reviews): move withDeleted out of filters to prevent query error

### DIFF
--- a/apps/backend/src/api/vendor/sellers/me/reviews/route.ts
+++ b/apps/backend/src/api/vendor/sellers/me/reviews/route.ts
@@ -45,7 +45,8 @@ export const GET = async (
   const { data: reviews, metadata } = await query.graph({
     entity: sellerReview.entryPoint,
     fields: req.queryConfig.fields.map((field) => `review.${field}`),
-    filters: { ...req.filterableFields, withDeleted: true },
+    filters: req.filterableFields,
+    withDeleted: true,
     pagination: req.queryConfig.pagination
   })
 


### PR DESCRIPTION
# Fix: `withDeleted` Query Option

## What Changed
Moved `withDeleted: true` out of the `filters` object and passed it as a top-level option in the seller reviews query.

## Why
Including `withDeleted` in `filters` caused an error because it is not a model property. It should be a separate query option.

**Error**
```
Trying to query by not existing property LinkModel.withDeleted
```

## Effect
- Fixes the error when fetching seller reviews
- Ensures soft-deleted records are included as intended 
