### PR TITLE
Use buildHostAddress for seller invite registration_url to fix incorrect domain in invitation links

### DIFF
--- a/apps/backend/src/api/admin/sellers/validators.ts
+++ b/apps/backend/src/api/admin/sellers/validators.ts
@@ -1,3 +1,4 @@
+import { Hosts, buildHostAddress } from '#/shared/infra/http/utils'
 import { z } from 'zod'
 
 import { createFindParams } from '@medusajs/medusa/api/utils/validators'
@@ -57,5 +58,7 @@ export const AdminUpdateSeller = z
 export type AdminInviteSellerType = z.infer<typeof AdminInviteSeller>
 export const AdminInviteSeller = z.object({
   email: z.string().email(),
-  registration_url: z.string().default('http://localhost:5173/register')
+  registration_url: z
+    .string()
+    .default(buildHostAddress(Hosts.VENDOR_PANEL, '/register').toString())
 })


### PR DESCRIPTION
## Summary
This PR updates the default value for the `registration_url` in the seller invitation schema to use the `buildHostAddress` utility. Previously, the invitation link always pointed to localhost, regardless of the deployment environment. With this change, the invitation link will correctly use the vendor panel domain as configured in environment variables or fallback defaults, ensuring that invited sellers receive a valid registration link for the appropriate environment.

## Key changes
Replaced hardcoded localhost registration_url with dynamic buildHostAddress(Hosts.VENDOR_PANEL, '/register').
Ensures invitation links are environment-aware and point to the correct vendor panel domain.

## Alternative considered
A key advantage of this approach is that the backend maintains intrinsic knowledge of where invitation links should direct users, ensuring consistency and environment-awareness across all entry points. Supplying the registration_url directly in the inviteSeller call within the page component was also considered, but this would duplicate URL construction logic and increase the risk of inconsistencies. Centralising the default in the schema feels more robust and maintainable.
