### PR TITLE
fix: remove db migration from Dockerfile build step

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -51,6 +51,4 @@ COPY --from=installer /app .
 
 WORKDIR /app/apps/backend
 
-RUN yarn db:migrate
-
 CMD ["yarn", "start"]


### PR DESCRIPTION
tl;dr: Database migrations should run at deployment time, not build time, to avoid race conditions and build failures.

--- 

## Remove database migration from Dockerfile build step

### Problem
The Dockerfile was running `yarn db:migrate` during the image build process (line 54), which is an anti-pattern that can cause several issues:

- **Build failures** when database is not available during image build
- **Race conditions** in multi-instance deployments where multiple containers try to migrate simultaneously
- **Environment coupling** making the image less portable across different environments
- **Deployment complexity** mixing build-time and runtime concerns

### Solution
Removed the `RUN yarn db:migrate` command from the Dockerfile. Database migrations should be handled at deployment time, not build time.

### Deployment Impact for Mercur users
This change requires updating the deployment pipeline to run migrations separately:

```bash
# Recommended deployment sequence:
1. Build Docker image
2. Deploy infrastructure (SST/Terraform/Pulumi/etc)
3. Run database migrations: yarn db:migrate
4. Start application containers
```

### Benefits
- ✅ **Safer deployments** - no migration race conditions
- ✅ **Portable images** - same image works across all environments  
- ✅ **Reliable builds** - builds don't depend on database availability
- ✅ **Better separation of concerns** - build vs runtime operations
- ✅ **Easier rollbacks** - migrations can be managed independently
- ✅  Dockerfile builds successfully without database connection
- ✅  Image can be deployed and migrations run separately
- ✅  No functional changes to the application itself
