### PR TITLE
fix: Link tax regions to system tax provider

### DIFF
--- a/apps/backend/src/scripts/seed/seed-functions.ts
+++ b/apps/backend/src/scripts/seed/seed-functions.ts
@@ -13,7 +13,8 @@ import {
   createStockLocationsWorkflow,
   createTaxRegionsWorkflow,
   linkSalesChannelsToApiKeyWorkflow,
-  updateStoresWorkflow
+  updateStoresWorkflow,
+  updateTaxRegionsWorkflow
 } from '@medusajs/medusa/core-flows'
 
 import {
@@ -102,10 +103,17 @@ export async function createRegions(container: MedusaContainer) {
     }
   })
 
-  await createTaxRegionsWorkflow(container).run({
+  const { result: taxRegions } = await createTaxRegionsWorkflow(container).run({
     input: countries.map((country_code) => ({
       country_code
     }))
+  })
+
+  await updateTaxRegionsWorkflow(container).run({
+    input: taxRegions.map((taxRegion => ({
+      id: taxRegion.id,
+      provider_id: 'tp_system'
+    })))
   })
 
   return region


### PR DESCRIPTION
The seed script creates tax regions but these are not linked to the system Tax Provider. The most clear issues users see is they can't run the storefront, as when requesting products with `variants.calulated_price`, which internally will call the tax provider calculate tax lines method, the system tries to resolve a provider with id `undefined` (as it is not linked).

This PR adjusts the seeTaxRegions function, to link the created tax regions with the system tax provider.

Fixes #375