### PR TITLE
feat: [MM2-1090]: Import requests BE API

### DIFF
--- a/packages/modules/b2c-core/src/workflows/seller/workflows/import-seller-products.ts
+++ b/packages/modules/b2c-core/src/workflows/seller/workflows/import-seller-products.ts
@@ -42,7 +42,7 @@ export const importSellerProductsWorkflow = createWorkflow(
             product_id: p.id,
           },
           submitter_id: input.submitter_id,
-          type: "product",
+          type: "product_import",
           status: "pending" as RequestStatus,
         }));
       }

--- a/packages/modules/requests/src/api/admin/requests/validators.ts
+++ b/packages/modules/requests/src/api/admin/requests/validators.ts
@@ -13,6 +13,7 @@ export const AdminGetRequestsParams = createFindParams({
       'product_collection_update',
       'product_category',
       'product',
+      'product_import',
       'seller',
       'review_remove',
       'product_type',

--- a/packages/modules/requests/src/workflows/requests/utils/select-workflow.ts
+++ b/packages/modules/requests/src/workflows/requests/utils/select-workflow.ts
@@ -1,50 +1,25 @@
 import {
   acceptProductCategoryRequestWorkflow,
-  acceptProductCollectionRequestWorkflow,
   acceptProductCollectionUpdateRequestWorkflow,
   acceptProductRequestWorkflow,
   acceptProductTagRequestWorkflow,
   acceptProductTypeRequestWorkflow,
   acceptReviewRemoveRequestWorkflow,
-  acceptSellerCreationRequestWorkflow
-} from '../workflows'
+  acceptSellerCreationRequestWorkflow,
+  updateRequestWorkflow
+} from "../workflows";
 
-export const getRequestWorkflowByType = (type: string) => {
-  if (type === 'product_collection') {
-    return acceptProductCollectionRequestWorkflow
-  }
+const workflowMap: Record<string, any> = {
+  product: acceptProductRequestWorkflow,
+  product_import: acceptProductRequestWorkflow,
+  product_update: acceptProductRequestWorkflow,
+  product_collection_update: acceptProductCollectionUpdateRequestWorkflow,
+  product_category: acceptProductCategoryRequestWorkflow,
+  product_type: acceptProductTypeRequestWorkflow,
+  product_tag: acceptProductTagRequestWorkflow,
+  seller: acceptSellerCreationRequestWorkflow,
+  review_remove: acceptReviewRemoveRequestWorkflow,
+};
 
-  if (type === 'product_collection_update') {
-    return acceptProductCollectionUpdateRequestWorkflow
-  }
-
-  if (type === 'product_category') {
-    return acceptProductCategoryRequestWorkflow
-  }
-
-  if (type === 'product') {
-    return acceptProductRequestWorkflow
-  }
-
-  if (type === 'product_update') {
-    return acceptProductRequestWorkflow
-  }
-
-  if (type === 'seller') {
-    return acceptSellerCreationRequestWorkflow
-  }
-
-  if (type === 'review_remove') {
-    return acceptReviewRemoveRequestWorkflow
-  }
-
-  if (type === 'product_type') {
-    return acceptProductTypeRequestWorkflow
-  }
-
-  if (type === 'product_tag') {
-    return acceptProductTagRequestWorkflow
-  }
-
-  return null
-}
+export const getRequestWorkflowByType = (type: string) =>
+  workflowMap[type] ?? updateRequestWorkflow;


### PR DESCRIPTION
You can manage import product requests on admin panel using these endpoints:

Get all pending product import requests:
GET /admin/requests?type=product_import&order=-created_at&status=pending

Get single request:
GET /admin/requests/:id

Accept/decline:
POST /admin/requests/:id
body: {
  "status": "accepted" | "rejected",
  "reviewer_note": string
}

