### PR TITLE
fix(types): correct typo 'wifth' to 'width' in Algolia product type

### DIFF
--- a/packages/framework/src/types/algolia/algolia-product.ts
+++ b/packages/framework/src/types/algolia/algolia-product.ts
@@ -97,7 +97,7 @@ export const AlgoliaVariantValidator = z.object({
   weight: z.number().nullish(),
   length: z.number().nullish(),
   height: z.number().nullish(),
-  wifth: z.number().nullish(),
+  width: z.number().nullish(),
   variant_rank: z.number().nullish(),
   options: z.array(
     z.object({


### PR DESCRIPTION
This PR fixes a small typo in the algolia-product.ts file.
The property wifth was incorrectly spelled and is now corrected to width.