### PR TITLE
fix: add missing env secret for stripe webhook

### DIFF
--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -54,7 +54,8 @@ module.exports = defineConfig({
               '@mercurjs/payment-stripe-connect/providers/stripe-connect',
             id: 'stripe-connect',
             options: {
-              apiKey: process.env.STRIPE_SECRET_API_KEY
+              apiKey: process.env.STRIPE_SECRET_API_KEY,
+              webhookSecret: process.env.STRIPE_CONNECTED_ACCOUNTS_WEBHOOK_SECRET
             }
           }
         ]


### PR DESCRIPTION
add missing env secret for stripe webhook.

<img width="1242" height="469" alt="Screenshot 2025-10-29 at 14 01 34" src="https://github.com/user-attachments/assets/00f7e0af-e3a9-4a20-89bc-40d78d1a519b" />

