### PR TITLE
fix: keep rule key in commission response at all times even if it is …

### DIFF
--- a/packages/modules/commission/src/workflows/commission/steps/list-commission-lines.ts
+++ b/packages/modules/commission/src/workflows/commission/steps/list-commission-lines.ts
@@ -97,7 +97,7 @@ export const listCommissionLinesStep = createStep(
         return {
           ...line,
           order,
-          rule,
+          rule: rule ?? null
         };
       });
 


### PR DESCRIPTION
…null