### PR TITLE
fix[mm2-1740]: fix typo in AlgoliaVariantValidator object

### DIFF
--- a/packages/framework/src/types/algolia/algolia-product.ts
+++ b/packages/framework/src/types/algolia/algolia-product.ts
@@ -97,7 +97,7 @@ export const AlgoliaVariantValidator = z.object({
   weight: z.number().nullish(),
   length: z.number().nullish(),
   height: z.number().nullish(),
-  wifth: z.number().nullish(),
+  width: z.number().nullish(),
   variant_rank: z.number().nullish(),
   options: z.array(
     z.object({


### PR DESCRIPTION
Credit for finding this goes to: [@enocben](http://github.com/enocben)