### PR TITLE
chore: change dockerfile to be able to control wheater or not syncing…

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -50,4 +50,8 @@ WORKDIR /app/apps/backend
 EXPOSE 9000
 
 # Run migrations, optionally seed demo data (controlled by SEED_DEMO_DATA env), and start server
-CMD ["sh", "-c", "yarn db:migrate && if [ \"$SEED_DEMO_DATA\" = \"true\" ]; then yarn seed || true; fi && yarn start"]
+# MIGRATE_LINKS options: "safe" (default), "skip", "all"
+# - safe: auto-creates new links, skips deletions (recommended for most users)
+# - skip: ignores all link operations
+# - all: auto-executes all link operations including deletions (use with caution)
+CMD ["sh", "-c", "case \"$MIGRATE_LINKS\" in skip) LINK_FLAG='--skip-links';; all) LINK_FLAG='--execute-all-links';; *) LINK_FLAG='--execute-safe-links';; esac && yarn db:migrate $LINK_FLAG && if [ \"$SEED_DEMO_DATA\" = \"true\" ]; then yarn seed || true; fi && yarn start"]


### PR DESCRIPTION
… links should happen when running migrations

It seems that deployments might hand up when Medusa is running migrations that might delete some link tables. This is due to a fact that Medusa prompts user a question in terminal how would they like to proceed. This new command introduces additional env variable that will set the behaviour of syncing links so users do not need to interact with the terminal.