### PR TITLE
fix: resolve AwilixResolutionError in cart promotions workflow

### DIFF
--- a/packages/modules/b2c-core/src/api/store/carts/[id]/promotions/route.ts
+++ b/packages/modules/b2c-core/src/api/store/carts/[id]/promotions/route.ts
@@ -1,7 +1,7 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
-import { ContainerRegistrationKeys, MedusaError, PromotionActions } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules, PromotionActions } from "@medusajs/framework/utils"
 import { StoreAddCartPromotionsType } from "@medusajs/medusa/api/store/carts/validators"
-import { updateCartPromotionsWorkflow } from "@medusajs/medusa/core-flows"
+import { updateCartPromotionsWorkflowId } from "@medusajs/medusa/core-flows"
 import { fetchSellerByAuthActorId } from "@mercurjs/framework"
 import { validateSellerPromotions } from "../../../../../modules/seller"
 
@@ -26,7 +26,8 @@ export const POST = async (
       throw new MedusaError(MedusaError.Types.INVALID_DATA, 'Some of the promotion codes are invalid')
     }
 
-    await updateCartPromotionsWorkflow.run({
+    const workflowEngine = req.scope.resolve(Modules.WORKFLOW_ENGINE)
+    await workflowEngine.run(updateCartPromotionsWorkflowId, {
       input: {
         cart_id: req.params.id,
         promo_codes: req.validatedBody.promo_codes,


### PR DESCRIPTION
## Problem https://github.com/mercurjs/mercur/issues/589

The store cart promotions route (`/api/store/carts/[id]/promotions`) was throwing an `AwilixResolutionError: Could not resolve 'query'` error when attempting to add promotion codes to a cart.

### Root Cause

The workflow was being called directly without passing the container scope:

```typescript
await updateCartPromotionsWorkflow.run({
    input: { ... }
});
```

This caused the workflow to create an isolated container without access to the `query` service, resulting in errors when the workflow's internal `useQueryGraphStep` tried to resolve `ContainerRegistrationKeys.QUERY`.

## Solution

Updated the route to use the Workflow Engine pattern (consistent with core Medusa implementation):

```typescript
const workflowEngine = req.scope.resolve(Modules.WORKFLOW_ENGINE);
await workflowEngine.run(updateCartPromotionsWorkflowId, {
    input: { ... }
});
```

This ensures the workflow has access to all registered services in the container, including the `query` service.

## Changes

**File:** `packages/modules/b2c-core/src/api/store/carts/[id]/promotions/route.ts`

- Changed workflow execution from direct call to Workflow Engine pattern
- Import `updateCartPromotionsWorkflowId` instead of workflow object
- Import `Modules` from `@medusajs/framework/utils`
- Resolve `WORKFLOW_ENGINE` from request scope
- Maintains all existing seller validation logic

## Testing

- ✅ Successfully adds promotion codes to cart
- ✅ No `AwilixResolutionError` thrown
- ✅ Seller-specific promotion validation works correctly
- ✅ Cart is returned with promotions applied

## Alignment with Core Medusa

This change aligns the MercurJS implementation with the core Medusa cart promotions route pattern found in `@medusajs/medusa/dist/api/store/carts/[id]/promotions/route.js`.

## Versions

- Medusa: 2.11.3
- MercurJS: 1.4.5

## Checklist

- [x] Fix tested and confirmed working in production environment
- [x] Code follows existing patterns in the codebase
- [x] No breaking changes to API contract
- [x] Maintains backward compatibility