### PR TITLE
fix: resolve AwilixResolutionError in cart promotions workflow

### DIFF
--- a/packages/modules/b2c-core/src/api/store/carts/[id]/promotions/route.ts
+++ b/packages/modules/b2c-core/src/api/store/carts/[id]/promotions/route.ts
@@ -1,51 +1,63 @@
-import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
-import { ContainerRegistrationKeys, MedusaError, PromotionActions } from "@medusajs/framework/utils"
-import { StoreAddCartPromotionsType } from "@medusajs/medusa/api/store/carts/validators"
-import { updateCartPromotionsWorkflow } from "@medusajs/medusa/core-flows"
-import { fetchSellerByAuthActorId } from "@mercurjs/framework"
-import { validateSellerPromotions } from "../../../../../modules/seller"
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework";
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+  PromotionActions,
+} from "@medusajs/framework/utils";
+import { StoreAddCartPromotionsType } from "@medusajs/medusa/api/store/carts/validators";
+import { updateCartPromotionsWorkflowId } from "@medusajs/medusa/core-flows";
+import { fetchSellerByAuthActorId } from "@mercurjs/framework";
+import { validateSellerPromotions } from "../../../../../modules/seller";
 
 export const POST = async (
-    req: AuthenticatedMedusaRequest<StoreAddCartPromotionsType>,
-    res: MedusaResponse
-  ) => {
-    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  req: AuthenticatedMedusaRequest<StoreAddCartPromotionsType>,
+  res: MedusaResponse,
+) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
 
-    const seller = await fetchSellerByAuthActorId(
-      req.auth_context?.actor_id,
-      req.scope
-    )
+  const seller = await fetchSellerByAuthActorId(
+    req.auth_context?.actor_id,
+    req.scope,
+  );
 
-    const validatePromotions = await validateSellerPromotions(
-      req.validatedBody.promo_codes,
-      req.scope,
-      seller.id
-    )
+  const validatePromotions = await validateSellerPromotions(
+    req.validatedBody.promo_codes,
+    req.scope,
+    seller.id,
+  );
 
-    if (!validatePromotions.valid) {
-      throw new MedusaError(MedusaError.Types.INVALID_DATA, 'Some of the promotion codes are invalid')
-    }
-
-    await updateCartPromotionsWorkflow.run({
-      input: {
-        cart_id: req.params.id,
-        promo_codes: req.validatedBody.promo_codes,
-        action:
-            req.validatedBody.promo_codes.length > 0
-                ? PromotionActions.ADD
-                : PromotionActions.REPLACE,
-        },
-    })
-  
-    const {
-      data: [cart]
-    } = await query.graph({
-      entity: 'cart',
-      filters: {
-        id: req.params.id
-      },
-      fields: req.queryConfig.fields
-    })
-  
-    res.json({ cart })
+  if (!validatePromotions.valid) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Some of the promotion codes are invalid",
+    );
   }
+
+  const workflowEngine = req.scope.resolve(Modules.WORKFLOW_ENGINE);
+  await workflowEngine.run(updateCartPromotionsWorkflowId, {
+    input: {
+      cart_id: req.params.id,
+      promo_codes: req.validatedBody.promo_codes,
+      action:
+        req.validatedBody.promo_codes.length > 0
+          ? PromotionActions.ADD
+          : PromotionActions.REPLACE,
+    },
+  });
+
+  const {
+    data: [cart],
+  } = await query.graph({
+    entity: "cart",
+    filters: {
+      id: req.params.id,
+    },
+    fields: req.queryConfig.fields,
+  });
+
+  res.json({ cart });
+};


### PR DESCRIPTION
## Problem

The store cart promotions route throws `AwilixResolutionError: Could not resolve 'query'` when adding promotion codes to a cart.

## Root Cause

The workflow was called directly without passing the container scope:
```typescript
await updateCartPromotionsWorkflow.run({ input: {...} })
```

This creates an isolated container without access to registered services.

## Solution

Use the Workflow Engine pattern to properly pass the container scope:
```typescript
const workflowEngine = req.scope.resolve(Modules.WORKFLOW_ENGINE)
await workflowEngine.run(updateCartPromotionsWorkflowId, { input: {...} })
```

## Changes

**File:** `packages/modules/b2c-core/src/api/store/carts/[id]/promotions/route.ts`

- Import `Modules` from `@medusajs/framework/utils`
- Import `updateCartPromotionsWorkflowId` instead of workflow object
- Resolve `WORKFLOW_ENGINE` from request scope and execute workflow through it

## Testing

- ✅ Promotion codes successfully added to cart
- ✅ No `AwilixResolutionError` thrown
- ✅ Seller validation works correctly
- ✅ Cart returned with promotions applied

## Versions

- Medusa: 2.11.3
- MercurJS: 1.4.5