### PR TITLE
[B2C][Admin] I get an error when I want to select specific products from the list for "Create Claim" action for order

### DIFF
--- a/packages/modules/b2c-core/src/workflows/hooks/add-order-line-items-pricing-context.ts
+++ b/packages/modules/b2c-core/src/workflows/hooks/add-order-line-items-pricing-context.ts
@@ -1,0 +1,112 @@
+import type {
+  PriceDTO,
+  PriceSetDTO,
+  ProductDTO,
+  ProductVariantDTO,
+  RegionDTO
+} from '@medusajs/framework/types'
+import {
+  ContainerRegistrationKeys,
+  MedusaError
+} from '@medusajs/framework/utils'
+import { StepResponse } from '@medusajs/framework/workflows-sdk'
+import { addOrderLineItemsWorkflow } from '@medusajs/medusa/core-flows'
+
+type VariantWithPricing = Pick<ProductVariantDTO, 'id' | 'title'> & {
+  product?: Pick<ProductDTO, 'title'>
+  price_set?: Pick<PriceSetDTO, 'id'> & {
+    prices?: Pick<PriceDTO, 'currency_code'>[]
+  }
+}
+
+type RegionWithCurrency = Pick<RegionDTO, 'id' | 'currency_code'>
+
+/**
+ * This hook provides the pricing context for adding line items to orders in RMA flows (claims, returns, exchanges).
+ *
+ * In a marketplace scenario, when an admin creates a claim and adds outbound (replacement) items,
+ * the variant prices need to be calculated using the order's region context.
+ *
+ * This hook also validates that all variants have prices in the order's currency.
+ * If any variant is missing a price, it throws a 400 error - this is a vendor responsibility.
+ */
+addOrderLineItemsWorkflow.hooks.setPricingContext(
+  async (
+    { order, variantIds, region, customerData, additional_data },
+    { container }
+  ) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const currencyCode = order?.currency_code || region?.currency_code
+
+    if (variantIds?.length && currencyCode) {
+      const { data: variants } = await query.graph({
+        entity: 'variant',
+        fields: [
+          'id',
+          'title',
+          'product.title',
+          'price_set.prices.currency_code'
+        ],
+        filters: {
+          id: variantIds
+        }
+      })
+
+      const variantsWithoutPrice: string[] = []
+
+      for (const variant of variants as VariantWithPricing[]) {
+        const prices = variant.price_set?.prices || []
+        const currencyCodes = prices.map((p) => p.currency_code)
+
+        if (!currencyCodes.includes(currencyCode)) {
+          const productTitle = variant.product?.title || 'Unknown'
+          const variantTitle = variant.title || variant.id
+          variantsWithoutPrice.push(`${productTitle} - ${variantTitle}`)
+        }
+      }
+
+      if (variantsWithoutPrice.length > 0) {
+        throw new MedusaError(
+          MedusaError.Types.INVALID_DATA,
+          `The following variants do not have a price in ${currencyCode.toUpperCase()}. ` +
+            `Please ask the vendor to add prices for these products: ${variantsWithoutPrice.join(', ')}`
+        )
+      }
+    }
+
+    if (region?.id) {
+      return new StepResponse({
+        region_id: region.id,
+        currency_code: region.currency_code
+      })
+    }
+
+    if (order?.region_id) {
+      const { data: regions } = await query.graph({
+        entity: 'region',
+        fields: ['id', 'currency_code'],
+        filters: {
+          id: order.region_id
+        }
+      })
+
+      const orderRegion = (regions as RegionWithCurrency[])[0]
+
+      if (orderRegion) {
+        return new StepResponse({
+          region_id: orderRegion.id,
+          currency_code: orderRegion.currency_code
+        })
+      }
+    }
+
+    if (order?.currency_code) {
+      return new StepResponse({
+        currency_code: order.currency_code
+      })
+    }
+
+    return new StepResponse({})
+  }
+)


### PR DESCRIPTION
Added a backend error handler when the admin wants to add a claim for order for items that do not have price set for the same currency as the order.
<img width="377" height="126" alt="image" src="https://github.com/user-attachments/assets/a8a1a3d4-ec0e-48bf-9274-471cd6a499b1" />

example case:
<img width="718" height="162" alt="image" src="https://github.com/user-attachments/assets/de9b2d0c-e4f9-4a73-9fed-9f320a920f4f" />
<img width="857" height="395" alt="image" src="https://github.com/user-attachments/assets/39cfe786-f6f8-4b81-8dc2-5581aead3c58" />
<img width="659" height="149" alt="image" src="https://github.com/user-attachments/assets/1d3ed752-987a-41f2-b29d-3731d9788882" />
