### PR TITLE
feat(seller): Add seller.created event

### DIFF
--- a/packages/framework/src/types/seller/events.ts
+++ b/packages/framework/src/types/seller/events.ts
@@ -1,3 +1,4 @@
 export enum SellerEvents {
-  STORE_STATUS_CHANGED = 'seller.store_status_changed'
+  STORE_STATUS_CHANGED = 'seller.store_status_changed',
+  CREATED = 'seller.created'
 }

--- a/packages/modules/b2c-core/src/workflows/seller/workflows/create-seller.ts
+++ b/packages/modules/b2c-core/src/workflows/seller/workflows/create-seller.ts
@@ -1,12 +1,12 @@
 import { transform } from "@medusajs/framework/workflows-sdk";
-import { setAuthAppMetadataStep } from "@medusajs/medusa/core-flows";
+import { emitEventStep, setAuthAppMetadataStep } from "@medusajs/medusa/core-flows";
 import {
   WorkflowResponse,
   createHook,
   createWorkflow,
 } from "@medusajs/workflows-sdk";
 
-import { CreateMemberDTO, CreateSellerDTO } from "@mercurjs/framework";
+import { CreateMemberDTO, CreateSellerDTO, SellerEvents } from "@mercurjs/framework";
 
 import {
   createMemberStep,
@@ -47,6 +47,12 @@ export const createSellerWorkflow = createWorkflow(
     const sellerCreatedHook = createHook("sellerCreated", {
       sellerId: seller.id,
     });
+
+    emitEventStep({
+      eventName: SellerEvents.CREATED,
+      data: { id: seller.id },
+    });
+
     return new WorkflowResponse(seller, { hooks: [sellerCreatedHook] });
   }
 );


### PR DESCRIPTION
**Summary**
Introduces a new seller.created event that is emitted immediately after a seller is successfully created in the createSellerWorkflow.

- Added `CREATED` event to `SellerEvents` enum
- Emitted `seller.created` event in `createSellerWorkflow` upon successful seller creation
- Addressed timing issue where `requests.seller.accepted` fires before seller persistence


**Problem Solved**
Currently, the `requests.seller.accepted` event is triggered when a seller request is approved. However, this event fires before the actual seller entity is created in the database (it triggers the workflow that creates the seller). This sequence makes it impossible to perform downstream actions that require the seller entity to exist (e.g., assigning specific attributes, syncing with external systems that need the seller ID, or creating related resources) within consumers of `requests.seller.accepted`.

**Changes**
- packages/framework/src/types/seller/events.ts
: Added CREATED = 'seller.created' to the SellerEvents enum.
- packages/modules/b2c-core/src/workflows/seller/workflows/create-seller.ts
: Updated createSellerWorkflow to emit the seller.created event using emitEventStep immediately after the seller and member are created and persisted.