### PR TITLE
[B2C][Vendor panel] Searching, filtering and sorting promotions on Campaign view doesn't work - sorting

### DIFF
--- a/packages/modules/b2c-core/src/api/vendor/campaigns/query-config.ts
+++ b/packages/modules/b2c-core/src/api/vendor/campaigns/query-config.ts
@@ -19,6 +19,6 @@ export const vendorCampaignQueryConfig = {
   },
   retrieve: {
     defaults: vendorCampaignFields,
-    isList: false
+    isList: true
   }
 }


### PR DESCRIPTION
Small fix that passes pagination to the child function. 
The pagination queryconfig was not passing because medusa was filtering it out since it's not a list per say.