### PR TITLE
fix[mm2-2603]: remove seller-feed notification creation from resend n…

### DIFF
--- a/packages/modules/resend/src/subscribers/notification-seller-new-order.ts
+++ b/packages/modules/resend/src/subscribers/notification-seller-new-order.ts
@@ -51,15 +51,6 @@ export default async function sellerNewOrderHandler({
       const customer_name = `${order.customer?.first_name || ""} ${order.customer?.last_name || ""}`;
       await notificationService.createNotifications([
         {
-          to: order.seller?.id,
-          channel: "seller_feed",
-          template: "seller_new_order_notification",
-          data: {
-            order_id: order.id,
-            customer_name,
-          },
-        },
-        {
           to: sellerEmail,
           channel: "email",
           template: ResendNotificationTemplates.SELLER_NEW_ORDER,


### PR DESCRIPTION
…ew orde created subscriber

Case:
resend package was creating a duplicate notficiation for seller-feed channel upon new order creation. This logic is already implemented in b2c-core package.