### PR TITLE
Fix null check in notification-buyer-new-order.ts

### DIFF
--- a/packages/modules/resend/src/subscribers/notification-buyer-new-order.ts
+++ b/packages/modules/resend/src/subscribers/notification-buyer-new-order.ts
@@ -44,7 +44,7 @@ export default async function orderCreatedHandler({
 
       const orderUrl = buildHostAddress(
         Hosts.STOREFRONT,
-        `/user/orders/${order.order_set.id ?? order.id}`
+        `/user/orders/${order.order_set?.id ?? order.id}`
       ).toString();
 
       await notificationService.createNotifications({


### PR DESCRIPTION
Fixes a potential runtime error when order_set is undefined.

File affected:
- notification-buyer-new-order.ts