### PR TITLE
feat: support admin products and global shipping options in mixed carts

### DIFF
--- a/packages/modules/b2c-core/src/workflows/cart/steps/filter-seller-shipping-options.ts
+++ b/packages/modules/b2c-core/src/workflows/cart/steps/filter-seller-shipping-options.ts
@@ -63,16 +63,48 @@ export const filterSellerShippingOptionsStep = createStep(
       (so) => so.shipping_option_id
     )
 
+    // Get all seller IDs that have shipping options linked
+    const allSellerIdsWithShippingOptions = new Set(
+      sellerShippingOptions.map((so) => so.seller_id)
+    )
+
+    // Check if cart has products without sellers (admin products)
+    const allProductSellerIds = new Set(sellersInCart.map((s) => s.seller_id))
+    const hasAdminProducts = cart.items.some(
+      (item) => !sellersInCart.some((sp) => sp.product_id === item.product_id)
+    )
+
+    // Get global shipping options (not linked to any seller) if cart has admin products
+    let globalShippingOptions: string[] = []
+    if (hasAdminProducts) {
+      // Get all shipping option IDs that are linked to sellers
+      const sellerLinkedOptionIds = new Set(
+        sellerShippingOptions.map((so) => so.shipping_option_id)
+      )
+
+      // Global options are those not linked to any seller
+      globalShippingOptions = input.shipping_options
+        .filter((option) => !sellerLinkedOptionIds.has(option.id))
+        .map((option) => option.id)
+    }
+
+    // Combine seller-specific and global shipping options
+    const allApplicableOptionIds = [
+      ...applicableShippingOptions,
+      ...globalShippingOptions
+    ]
+
     const optionsAvailable = input.shipping_options
-      .filter((option) => applicableShippingOptions.includes(option.id))
+      .filter((option) => allApplicableOptionIds.includes(option.id))
       .map((option) => {
         const relation = sellerShippingOptions.find(
           (o) => o.shipping_option_id === option.id
         )
         return {
           ...option,
-          seller_name: relation.seller.name,
-          seller_id: relation.seller.id
+          seller_name: relation?.seller?.name ?? null,
+          seller_id: relation?.seller?.id ?? null,
+          is_global: !relation
         }
       })
     return new StepResponse(optionsAvailable)

--- a/packages/modules/b2c-core/src/workflows/cart/steps/validate-cart-shipping-options.ts
+++ b/packages/modules/b2c-core/src/workflows/cart/steps/validate-cart-shipping-options.ts
@@ -53,12 +53,40 @@ export const validateCartShippingOptionsStep = createStep(
 
     const sellers = new Set(sellerProducts.map((sp) => sp.seller_id))
 
-    for (const sellerShippingOption of sellerShippingOptions) {
-      if (!sellers.has(sellerShippingOption.seller_id)) {
-        throw new MedusaError(
-          MedusaError.Types.INVALID_DATA,
-          `Shipping option with id: ${sellerShippingOption.shipping_option_id} is not available for any of the cart items`
+    // Check if cart has products without sellers (admin products)
+    const hasAdminProducts = cart.items.some(
+      (item) => !sellerProducts.some((sp) => sp.product_id === item.product_id)
+    )
+
+    // Get all shipping option IDs that are linked to sellers
+    const sellerLinkedOptionIds = new Set(
+      sellerShippingOptions.map((so) => so.shipping_option_id)
+    )
+
+    // Validate each shipping option
+    for (const optionId of input.option_ids) {
+      const isLinkedToSeller = sellerLinkedOptionIds.has(optionId)
+
+      if (isLinkedToSeller) {
+        // This is a seller-specific shipping option
+        const sellerShippingOption = sellerShippingOptions.find(
+          (so) => so.shipping_option_id === optionId
         )
+        if (sellerShippingOption && !sellers.has(sellerShippingOption.seller_id)) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `Shipping option with id: ${optionId} is not available for any of the cart items`
+          )
+        }
+      } else {
+        // This is a global/admin shipping option (not linked to any seller)
+        // Only allow if cart has admin products
+        if (!hasAdminProducts) {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `Global shipping option with id: ${optionId} cannot be used when all products belong to sellers`
+          )
+        }
       }
     }
 

--- a/packages/modules/b2c-core/src/workflows/cart/workflows/split-and-complete-cart.ts
+++ b/packages/modules/b2c-core/src/workflows/cart/workflows/split-and-complete-cart.ts
@@ -127,8 +127,11 @@ export const splitAndCompleteCartWorkflow = createWorkflow(
           >();
           const variantsMap = new Map<string, any>();
 
+          // Special key for admin products (products without seller)
+          const ADMIN_SELLER_KEY = '__admin__';
+
           cart.items.forEach((item) => {
-            const sellerId = productSellerMap.get(item.variant.product_id)!;
+            const sellerId = productSellerMap.get(item.variant.product_id) ?? ADMIN_SELLER_KEY;
             const lineItems = sellerLineItemsMap.get(sellerId) || [];
             lineItems.push(item);
             sellerLineItemsMap.set(sellerId, lineItems);
@@ -139,7 +142,7 @@ export const splitAndCompleteCartWorkflow = createWorkflow(
           cart.shipping_methods.forEach((method) => {
             const sellerId = shippingOptionSellerMap.get(
               method.shipping_option_id
-            )!;
+            ) ?? ADMIN_SELLER_KEY;
             sellerShippingMethodsMap.set(sellerId, method);
           });
 
@@ -313,14 +316,19 @@ export const splitAndCompleteCartWorkflow = createWorkflow(
           cart,
         },
         ({ createdOrders, sellers, orderSet, cart }) => {
-          const sellerOrderLinks = createdOrders.map((order, index) => ({
-            [SELLER_MODULE]: {
-              seller_id: sellers[index],
-            },
-            [Modules.ORDER]: {
-              order_id: order.id,
-            },
-          }));
+          const ADMIN_SELLER_KEY = '__admin__';
+          
+          // Only create seller links for orders that have a real seller (not admin orders)
+          const sellerOrderLinks = createdOrders
+            .filter((_, index) => sellers[index] !== ADMIN_SELLER_KEY)
+            .map((order, index) => ({
+              [SELLER_MODULE]: {
+                seller_id: sellers[index],
+              },
+              [Modules.ORDER]: {
+                order_id: order.id,
+              },
+            }));
 
           const orderSetOrderLinks = createdOrders.map((order) => ({
             [MARKETPLACE_MODULE]: {


### PR DESCRIPTION
Enables mixed carts containing both seller products and admin products, with proper handling of global shipping options.

## Changes
- **filter-seller-shipping-options.ts**: Returns global shipping options when cart contains admin products, adds `is_global` field
- **validate-cart-shipping-options.ts**: Validates global shipping options for admin products
- **split-and-complete-cart.ts**: Creates separate admin orders for products without sellers using `__admin__` key

## Behavior
| Cart | Shipping Options | Orders |
|------|-----------------|--------|
| Seller only | Seller options | 1 order per seller |
| Admin only | Global options | 1 admin order |
| Mixed | Seller + Global options | 1 order per seller + 1 admin order |
