### PR TITLE
feat(MM2-2493): enhance product variants API to support pricing context with region, currency, customer, and customer group IDs

### DIFF
--- a/packages/modules/b2c-core/src/api/admin/custom/product-variants/route.ts
+++ b/packages/modules/b2c-core/src/api/admin/custom/product-variants/route.ts
@@ -115,6 +115,12 @@ import {
  *       type: string
  *     required: false
  *     description: Customer group ID used as pricing context. Enables group-specific price list matching.
+ *   - name: country_code
+ *     in: query
+ *     schema:
+ *       type: string
+ *     required: false
+ *     description: Country code used as pricing context (e.g. "pl"). Required to calculate tax-inclusive prices (calculated_amount_with_tax).
  * responses:
  *   "200":
  *     description: OK
@@ -158,16 +164,17 @@ export const GET = async (
     );
   }
 
-  const { region_id, currency_code, customer_id, customer_group_id, ...filterableFields } =
+  const { region_id, currency_code, customer_id, customer_group_id, country_code, ...filterableFields } =
     req.filterableFields as AdminGetProductVariantsParamsType;
 
   const pricingContext =
-    region_id || currency_code || customer_id || customer_group_id
+    region_id || currency_code || customer_id || customer_group_id || country_code
       ? {
           ...(region_id && { region_id }),
           ...(currency_code && { currency_code }),
           ...(customer_id && { customer_id }),
           ...(customer_group_id && { customer_group_id }),
+          ...(country_code && { country_code }),
         }
       : undefined;
 
@@ -219,6 +226,7 @@ export const GET = async (
         calculated_price: QueryContext(pricingContext),
       },
     });
+
     const pricingMap = new Map(
       (priced as unknown as PricedVariant[]).map((v) => [v.id, v.calculated_price ?? null])
     );

--- a/packages/modules/b2c-core/src/api/admin/custom/product-variants/validators.ts
+++ b/packages/modules/b2c-core/src/api/admin/custom/product-variants/validators.ts
@@ -31,6 +31,7 @@ const GetProductVariantsParamsFields = z.object({
   currency_code: z.string().optional(),
   customer_id: z.string().optional(),
   customer_group_id: z.string().optional(),
+  country_code: z.string().optional(),
 });
 
 export type AdminGetProductVariantsParamsType = z.infer<


### PR DESCRIPTION
Extended the `/admin/custom/product-variants` endpoint with pricing context support.

The endpoint now accepts optional `region_id,` `currency_code`, `customer_id`, `customer_group_id` `country_code` parameters. When `fields=+calculated_price` is provided along with at least currency_code, the endpoint will return calculated_price for each variant.