### PR TITLE
fix(ci): pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@d59651bd82c48d81756854675ce4fa4d69722200 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
Pin actions/checkout and anthropics/claude-code-action to commit SHAs to satisfy repository policy requiring all actions be pinned.

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `new`.
- [ ] I updated documentation, locales if the change requires it.
- [ ] I added or adjusted tests that cover the change.

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
