### PR TITLE
chore: v2.1.0-canary.0

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/admin",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/cli",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/client",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/core-plugin/package.json
+++ b/packages/core-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/core-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/dashboard-sdk/package.json
+++ b/packages/dashboard-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/dashboard-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/dashboard-shared/package.json
+++ b/packages/dashboard-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/dashboard-shared",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/providers/payout-stripe-connect/package.json
+++ b/packages/providers/payout-stripe-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/payout-stripe-connect",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "description": "Stripe Connect payment provider for Mercur",
   "private": false,
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/types",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/vendor",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",


### PR DESCRIPTION
## Summary
- Bump all 9 published package versions from `2.0.0` to `2.1.0-canary.0`

## Packages updated
- `@mercurjs/cli`
- `@mercurjs/client`
- `@mercurjs/types`
- `@mercurjs/dashboard-sdk`
- `@mercurjs/dashboard-shared`
- `@mercurjs/core-plugin`
- `@mercurjs/vendor`
- `@mercurjs/admin`
- `@mercurjs/payout-stripe-connect`

Tag `v2.1.0-canary.0` has already been pushed. Once merged, the release workflow will publish all packages with `--tag canary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)