### PR TITLE
fix(core-plugin, dashboard-sdk): strip base path in dashboard proxy a…

### DIFF
--- a/packages/core-plugin/src/utils/dashboard/dashboard-base.ts
+++ b/packages/core-plugin/src/utils/dashboard/dashboard-base.ts
@@ -96,6 +96,7 @@ export abstract class DashboardBase {
 
         const proxyMiddleware = createProxyMiddleware({
             target: this.getViteDevServerUrl(),
+            pathRewrite: { [`^${route}`]: "" },
         })
 
         const staticServer = express.Router()
@@ -123,6 +124,7 @@ export abstract class DashboardBase {
                 }
 
                 case "static": {
+                    req.url = req.url.slice(route.length) || "/"
                     staticServer(req, res, next)
                     return
                 }

--- a/packages/dashboard-sdk/src/plugin.ts
+++ b/packages/dashboard-sdk/src/plugin.ts
@@ -176,7 +176,7 @@ export function mercurDashboardPlugin(pluginConfig: MercurConfig): Vite.Plugin {
                         "react-i18next",
                         "@medusajs/ui",
                         "@medusajs/dashboard",
-                        "@medusajs/js-sdk",
+                        "@mercurjs/client",
                         "@tanstack/react-query",
                     ],
                 },


### PR DESCRIPTION
https://github.com/mercurjs/mercur/issues/828 

## Summary

  - Fix blank page when accessing admin/vendor dashboards through API proxy in monorepo setups
  - Add `pathRewrite` to strip base path prefix (`/dashboard`, `/seller`) before forwarding to Vite dev server
  - Strip prefix for static file serving mode as well
  - Replace `@medusajs/js-sdk` with `@mercurjs/client` in `optimizeDeps.include` to fix CJS/ESM `qs` named export error

  ## Root cause

  **Proxy issue**: `DashboardBase` proxied requests to Vite without stripping the base path. `localhost:9000/dashboard/@vite/client` was
  forwarded as `/dashboard/@vite/client` to Vite on port 7000, which returned 404.

  **SDK issue**: `@medusajs/js-sdk` in `optimizeDeps.include` pulls in `qs` (CJS-only). In Bun workspaces Vite can serve the dependency
  unbundled, causing ESM named export errors. Mercur v2 uses `@mercurjs/client` — the old reference was stale.

  ## What changed

  - `packages/core-plugin/src/utils/dashboard/dashboard-base.ts`: added `pathRewrite` to proxy config, strip prefix from `req.url` before
  static serving
  - `packages/dashboard-sdk/src/plugin.ts`: `@medusajs/js-sdk` → `@mercurjs/client` in `optimizeDeps.include`

  ## Who is affected

  Monorepo setups where admin/vendor run as separate Vite dev servers proxied through the API. Single-app projects from `mercurjs create` are
   unaffected.

  ## Test plan

  - [x] `localhost:9000/dashboard` loads admin panel via proxy
  - [x] `localhost:9000/seller` loads vendor panel via proxy
  - [x] Built dashboard served correctly (static mode)
  - [x] Non-dashboard API routes unaffected