### PR TITLE
fix(core-plugin): solve building errors

### DIFF
--- a/packages/core-plugin/src/modules/seller/service.ts
+++ b/packages/core-plugin/src/modules/seller/service.ts
@@ -217,6 +217,13 @@ class SellerModuleService extends MedusaService({
     token: string,
     @MedusaContext() sharedContext: Context = {},
   ): Promise<MemberInviteDTO> {
+    if (!this.options_.jwt_secret) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "JWT secret is not configured"
+      )
+    }
+
     let decoded: JwtPayload
     try {
       decoded = jwt.verify(token, this.options_.jwt_secret, {


### PR DESCRIPTION
## Summary

I was unable to build caused of a wrong typing.

## Changes

- Check if jwt_secret is defined before calling verify.

## Testing

List the tests or commands you ran to validate the change.
`bun turbo run build --filter=@mercurjs/core-plugin`

## Checklist

- [ ] This pull request targets `new`.
- [ ] I updated documentation, locales if the change requires it.
- [ ] I added or adjusted tests that cover the change.

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
