### PR TITLE
feat(vendor): redesign store settings page with time-off table, empty states, and store request banner

### DIFF
--- a/packages/core-plugin/src/api/admin/sellers/query-config.ts
+++ b/packages/core-plugin/src/api/admin/sellers/query-config.ts
@@ -14,6 +14,7 @@ export const adminSellerFields = [
   "is_premium",
   "closed_from",
   "closed_to",
+  "closure_note",
   "*address",
   "*payment_details",
   "*professional_details",

--- a/packages/core-plugin/src/api/admin/sellers/validators.ts
+++ b/packages/core-plugin/src/api/admin/sellers/validators.ts
@@ -44,6 +44,7 @@ export const AdminCreateSeller = z.object({
   is_premium: z.boolean().optional(),
   closed_from: z.coerce.date().nullable().optional(),
   closed_to: z.coerce.date().nullable().optional(),
+  closure_note: z.string().nullable().optional(),
   metadata: z.record(z.unknown()).nullable().optional(),
   member: z.object({
     email: z.string().email(),
@@ -65,6 +66,7 @@ export const AdminUpdateSeller = z.object({
   is_premium: z.boolean().optional(),
   closed_from: z.coerce.date().nullable().optional(),
   closed_to: z.coerce.date().nullable().optional(),
+  closure_note: z.string().nullable().optional(),
   metadata: z.record(z.unknown()).nullable().optional(),
 })
 

--- a/packages/core-plugin/src/api/vendor/sellers/query-config.ts
+++ b/packages/core-plugin/src/api/vendor/sellers/query-config.ts
@@ -29,6 +29,7 @@ export const retrieveVendorSellerQueryConfig = {
     "is_premium",
     "closed_from",
     "closed_to",
+    "closure_note",
     "*address",
     "*payment_details",
     "*professional_details",

--- a/packages/core-plugin/src/api/vendor/sellers/validators.ts
+++ b/packages/core-plugin/src/api/vendor/sellers/validators.ts
@@ -68,6 +68,7 @@ export const VendorUpdateSeller = z.object({
   website_url: z.string().nullable().optional(),
   closed_from: z.coerce.date().nullable().optional(),
   closed_to: z.coerce.date().nullable().optional(),
+  closure_note: z.string().nullable().optional(),
   metadata: z.record(z.unknown()).nullable().optional(),
 })
 

--- a/packages/core-plugin/src/modules/seller/migrations/Migration20260410120000.ts
+++ b/packages/core-plugin/src/modules/seller/migrations/Migration20260410120000.ts
@@ -1,0 +1,15 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260410120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "seller" add column if not exists "closure_note" text null;`);
+    this.addSql(`alter table if exists "professional_details" alter column "corporate_name" type text, alter column "corporate_name" drop not null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "seller" drop column if exists "closure_note";`);
+    this.addSql(`alter table if exists "professional_details" alter column "corporate_name" type text, alter column "corporate_name" set not null;`);
+  }
+
+}

--- a/packages/core-plugin/src/modules/seller/models/seller.ts
+++ b/packages/core-plugin/src/modules/seller/models/seller.ts
@@ -24,6 +24,7 @@ const Seller = model
     is_premium: model.boolean().default(false),
     closed_from: model.dateTime().nullable(),
     closed_to: model.dateTime().nullable(),
+    closure_note: model.text().nullable(),
     professional_details: model.hasOne(() => ProfessionalDetails, {
       mappedBy: "seller",
     }),

--- a/packages/types/src/seller/common.ts
+++ b/packages/types/src/seller/common.ts
@@ -191,6 +191,7 @@ export interface SellerDTO {
   is_premium: boolean
   closed_from: Date | null
   closed_to: Date | null
+  closure_note: string | null
   professional_details: ProfessionalDetailsDTO | null
   address: SellerAddressDTO | null
   payment_details: PaymentDetailsDTO | null

--- a/packages/vendor/src/components/layout/shell/shell.tsx
+++ b/packages/vendor/src/components/layout/shell/shell.tsx
@@ -270,7 +270,7 @@ const MobileSidebarContainer = ({ children }: PropsWithChildren) => {
 const isTopLevelRoute = (pathname: string) => {
   const clean = pathname.replace(/\/$/, "")
   const segments = clean.split("/").filter(Boolean)
-  return segments.length === 1 || clean === "/settings/store"
+  return segments.length === 1
 }
 
 const StoreSetupWidget = () => {

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -2697,14 +2697,14 @@
     },
     "status": {
       "active": "Active",
-      "pendingApproval": "Pending approval",
+      "pendingApproval": "Pending",
       "suspended": "Suspended",
       "terminated": "Terminated"
     },
     "alert": {
       "pendingApproval": {
-        "title": "Your store is under review",
-        "description": "Your application is being reviewed by our team. You will be notified once your store is approved."
+        "title": "Store request",
+        "description": "Store request has been submitted successfully. Once the Admin reviews it, you'll receive a notification in your panel."
       },
       "suspended": {
         "title": "Your store has been suspended",
@@ -2746,6 +2746,10 @@
     },
     "address": {
       "header": "Address",
+      "empty": {
+        "title": "No address",
+        "message": "There are no records to show"
+      },
       "edit": {
         "header": "Edit Address",
         "description": "Update the address for your store.",
@@ -2754,6 +2758,10 @@
     },
     "paymentDetails": {
       "header": "Payment Details",
+      "empty": {
+        "title": "No payment details",
+        "message": "There are no records to show"
+      },
       "edit": {
         "header": "Edit Payment Details",
         "description": "Update the payment details for your store.",
@@ -2771,6 +2779,10 @@
     },
     "professionalDetails": {
       "header": "Company Details",
+      "empty": {
+        "title": "No company details",
+        "message": "There are no records to show"
+      },
       "edit": {
         "header": "Edit Professional Details",
         "description": "Update the professional details for your store.",
@@ -2782,18 +2794,34 @@
         "taxId": "Tax ID"
       }
     },
-    "scheduledClosure": {
-      "header": "Scheduled Closure",
-      "edit": {
-        "header": "Schedule Store Closure",
-        "description": "Configure the scheduled closure dates for your store.",
-        "successToast": "Scheduled closure updated"
+    "timeOff": {
+      "header": "Time off",
+      "columns": {
+        "firstDay": "First day",
+        "lastDay": "Last day",
+        "note": "Note"
+      },
+      "empty": {
+        "title": "No time off yet",
+        "message": "This store doesn't have scheduled time off",
+        "action": "Create"
+      },
+      "create": {
+        "header": "Create Time Off",
+        "description": "Schedule a time off period for your store.",
+        "successToast": "Time off saved"
       },
       "fields": {
-        "closedFrom": "Close from",
-        "closedTo": "Close until",
-        "closedToHint": "If empty, the store will remain closed indefinitely."
-      }
+        "firstDay": "First day",
+        "lastDay": "Last day",
+        "lastDayHint": "Leave empty to keep the store closed indefinitely",
+        "note": "Note"
+      },
+      "deleteConfirm": {
+        "title": "Delete time off",
+        "description": "Are you sure you want to remove this time off period?"
+      },
+      "deleteSuccess": "Time off removed"
     },
     "subscription": {
       "header": "Subscription",
@@ -2804,6 +2832,9 @@
       "freePeriod": "Free period",
       "requiresOrders": "Requires orders",
       "month": "month"
+    },
+    "edit": {
+      "websiteHint": "Must include protocol (e.g. https://)"
     },
     "toast": {
       "update": "Store successfully updated",

--- a/packages/vendor/src/pages/settings/store/_components/store-address-section.tsx
+++ b/packages/vendor/src/pages/settings/store/_components/store-address-section.tsx
@@ -45,29 +45,40 @@ export const StoreAddressSection = ({ seller }: StoreAddressSectionProps) => {
           ]}
         />
       </div>
-      <div className="flex flex-col gap-2 px-2 pb-2">
-        <div className="px-4 pb-2">
-          <div className="flex items-center gap-4">
-            <IconAvatar size="large" variant="squared">
-              <BuildingStorefront />
-            </IconAvatar>
-            <div className="flex flex-1 flex-col">
-              <Text size="small" leading="compact" weight="plus">
-                {[address?.first_name, address?.last_name]
-                  .filter(Boolean)
-                  .join(" ") || "-"}
-              </Text>
-              <Text
-                size="small"
-                leading="compact"
-                className="text-ui-fg-subtle"
-              >
-                {formattedAddress || "-"}
-              </Text>
+      {formattedAddress ? (
+        <div className="flex flex-col gap-2 px-2 pb-2">
+          <div className="px-4 pb-2">
+            <div className="flex items-center gap-4">
+              <IconAvatar size="large" variant="squared">
+                <BuildingStorefront />
+              </IconAvatar>
+              <div className="flex flex-1 flex-col">
+                <Text size="small" leading="compact" weight="plus">
+                  {[address?.first_name, address?.last_name]
+                    .filter(Boolean)
+                    .join(" ") || address?.company || formattedAddress}
+                </Text>
+                <Text
+                  size="small"
+                  leading="compact"
+                  className="text-ui-fg-subtle"
+                >
+                  {formattedAddress}
+                </Text>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      ) : (
+        <div className="flex flex-col items-center gap-y-1 pb-6 pt-2">
+          <Text size="small" leading="compact" weight="plus">
+            {t("store.address.empty.title")}
+          </Text>
+          <Text size="small" className="text-ui-fg-muted">
+            {t("store.address.empty.message")}
+          </Text>
+        </div>
+      )}
     </Container>
   );
 };

--- a/packages/vendor/src/pages/settings/store/_components/store-general-section.tsx
+++ b/packages/vendor/src/pages/settings/store/_components/store-general-section.tsx
@@ -1,5 +1,4 @@
 import { Children, ReactNode } from "react";
-import { Photo } from "@medusajs/icons";
 import { Badge, Container, Text } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
@@ -33,9 +32,18 @@ export const StoreGeneralSection = ({
                 className="h-full w-full object-cover"
               />
             ) : (
-              <div className="flex h-full w-full items-center justify-center">
-                <Photo className="text-ui-fg-muted" />
-              </div>
+              <div
+                className="h-full w-full"
+                style={{
+                  background: `repeating-linear-gradient(
+                    -45deg,
+                    transparent,
+                    transparent 10px,
+                    rgba(255,255,255,0.5) 10px,
+                    rgba(255,255,255,0.5) 20px
+                  )`,
+                }}
+              />
             )}
           </div>
           <StoreDetailHeader seller={seller} />

--- a/packages/vendor/src/pages/settings/store/_components/store-payment-details-section.tsx
+++ b/packages/vendor/src/pages/settings/store/_components/store-payment-details-section.tsx
@@ -45,27 +45,38 @@ export const StorePaymentDetailsSection = ({
           ]}
         />
       </div>
-      <div className="flex flex-col gap-2 px-2 pb-2">
-        <div className="px-4 pb-2">
-          <div className="flex items-center gap-4">
-            <IconAvatar size="large" variant="squared">
-              <CreditCard />
-            </IconAvatar>
-            <div className="flex flex-1 flex-col">
-              <Text size="small" leading="compact" weight="plus">
-                {details?.holder_name || "-"}
-              </Text>
-              <Text
-                size="small"
-                leading="compact"
-                className="text-ui-fg-subtle"
-              >
-                {subtitle || "-"}
-              </Text>
+      {details ? (
+        <div className="flex flex-col gap-2 px-2 pb-2">
+          <div className="px-4 pb-2">
+            <div className="flex items-center gap-4">
+              <IconAvatar size="large" variant="squared">
+                <CreditCard />
+              </IconAvatar>
+              <div className="flex flex-1 flex-col">
+                <Text size="small" leading="compact" weight="plus">
+                  {details.holder_name || "-"}
+                </Text>
+                <Text
+                  size="small"
+                  leading="compact"
+                  className="text-ui-fg-subtle"
+                >
+                  {subtitle || "-"}
+                </Text>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      ) : (
+        <div className="flex flex-col items-center gap-y-1 pb-6 pt-2">
+          <Text size="small" leading="compact" weight="plus">
+            {t("store.paymentDetails.empty.title")}
+          </Text>
+          <Text size="small" className="text-ui-fg-muted">
+            {t("store.paymentDetails.empty.message")}
+          </Text>
+        </div>
+      )}
     </Container>
   );
 };

--- a/packages/vendor/src/pages/settings/store/_components/store-professional-details-section.tsx
+++ b/packages/vendor/src/pages/settings/store/_components/store-professional-details-section.tsx
@@ -16,6 +16,8 @@ export const StoreProfessionalDetailsSection = ({
   const { t } = useTranslation();
   const details = seller.professional_details;
 
+  const hasDetails = details?.corporate_name || details?.registration_number || details?.tax_id;
+
   return (
     <Container className="p-0">
       <div className="flex items-center justify-between px-6 py-4">
@@ -36,29 +38,40 @@ export const StoreProfessionalDetailsSection = ({
           ]}
         />
       </div>
-      <div className="flex flex-col gap-2 px-2 pb-2">
-        <div className="px-4 pb-2">
-          <div className="flex items-center gap-4">
-            <IconAvatar size="large" variant="squared">
-              <Buildings />
-            </IconAvatar>
-            <div className="flex flex-1 flex-col">
-              <Text size="small" leading="compact" weight="plus">
-                {details?.corporate_name || "-"}
-              </Text>
-              <Text
-                size="small"
-                leading="compact"
-                className="text-ui-fg-subtle"
-              >
-                {[details?.registration_number, details?.tax_id]
-                  .filter(Boolean)
-                  .join(" · ") || "-"}
-              </Text>
+      {hasDetails ? (
+        <div className="flex flex-col gap-2 px-2 pb-2">
+          <div className="px-4 pb-2">
+            <div className="flex items-center gap-4">
+              <IconAvatar size="large" variant="squared">
+                <Buildings />
+              </IconAvatar>
+              <div className="flex flex-1 flex-col">
+                <Text size="small" leading="compact" weight="plus">
+                  {details?.corporate_name || "-"}
+                </Text>
+                <Text
+                  size="small"
+                  leading="compact"
+                  className="text-ui-fg-subtle"
+                >
+                  {[details?.registration_number, details?.tax_id]
+                    .filter(Boolean)
+                    .join(" · ") || "-"}
+                </Text>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      ) : (
+        <div className="flex flex-col items-center gap-y-1 pb-6 pt-2">
+          <Text size="small" leading="compact" weight="plus">
+            {t("store.professionalDetails.empty.title")}
+          </Text>
+          <Text size="small" className="text-ui-fg-muted">
+            {t("store.professionalDetails.empty.message")}
+          </Text>
+        </div>
+      )}
     </Container>
   );
 };

--- a/packages/vendor/src/pages/settings/store/_components/store-time-off-section.tsx
+++ b/packages/vendor/src/pages/settings/store/_components/store-time-off-section.tsx
@@ -1,0 +1,164 @@
+import { CalendarMini, EllipsisHorizontal, PencilSquare, Trash } from "@medusajs/icons";
+import {
+  Container,
+  DropdownMenu,
+  Heading,
+  IconButton,
+  Text,
+  toast,
+  usePrompt,
+} from "@medusajs/ui";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+
+import { DataTable } from "@components/data-table/data-table";
+import { NoRecords } from "@components/common/empty-table-content";
+import { useDate } from "../../../../hooks/use-date";
+import { useUpdateSeller } from "@hooks/api";
+import { HttpTypes } from "@mercurjs/types";
+
+type TimeOffEntry = {
+  id: string;
+  closed_from: Date;
+  closed_to: Date | null;
+  note: string | null;
+};
+
+type StoreTimeOffSectionProps = {
+  seller: HttpTypes.StoreSellerResponse["seller"];
+};
+
+export const StoreTimeOffSection = ({ seller }: StoreTimeOffSectionProps) => {
+  const { t } = useTranslation();
+  const { getFullDate } = useDate();
+  const prompt = usePrompt();
+  const { mutateAsync: updateSeller } = useUpdateSeller(seller.id);
+
+  const data: TimeOffEntry[] = useMemo(() => {
+    if (!seller.closed_from) return [];
+    return [
+      {
+        id: "closure",
+        closed_from: new Date(seller.closed_from),
+        closed_to: seller.closed_to ? new Date(seller.closed_to) : null,
+        note: seller.closure_note ?? null,
+      },
+    ];
+  }, [seller.closed_from, seller.closed_to, seller.closure_note]);
+
+  const handleDelete = async () => {
+    const confirmed = await prompt({
+      title: t("store.timeOff.deleteConfirm.title"),
+      description: t("store.timeOff.deleteConfirm.description"),
+      confirmText: t("actions.delete"),
+      cancelText: t("actions.cancel"),
+    });
+
+    if (!confirmed) return;
+
+    await updateSeller(
+      { closed_from: null, closed_to: null, closure_note: null },
+      {
+        onSuccess: () => {
+          toast.success(t("store.timeOff.deleteSuccess"));
+        },
+        onError: (error: Error) => {
+          toast.error(error.message);
+        },
+      }
+    );
+  };
+
+  const columns = useMemo(
+    () => [
+      {
+        id: "closed_from",
+        header: t("store.timeOff.columns.firstDay"),
+        accessorFn: (row: TimeOffEntry) =>
+          getFullDate({ date: row.closed_from }),
+      },
+      {
+        id: "closed_to",
+        header: t("store.timeOff.columns.lastDay"),
+        accessorFn: (row: TimeOffEntry) =>
+          row.closed_to ? getFullDate({ date: row.closed_to }) : "-",
+      },
+      {
+        id: "note",
+        header: t("store.timeOff.columns.note"),
+        accessorFn: (row: TimeOffEntry) => row.note || "-",
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: () => (
+          <div className="flex justify-end">
+            <DropdownMenu>
+              <DropdownMenu.Trigger asChild>
+                <IconButton variant="transparent" size="small">
+                  <EllipsisHorizontal />
+                </IconButton>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                <DropdownMenu.Item asChild>
+                  <Link to="store-closure">
+                    <PencilSquare className="mr-2" />
+                    {t("actions.edit")}
+                  </Link>
+                </DropdownMenu.Item>
+                <DropdownMenu.Separator />
+                <DropdownMenu.Item onClick={handleDelete}>
+                  <Trash className="mr-2" />
+                  {t("actions.delete")}
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          </div>
+        ),
+        meta: {
+          className: "w-[1%]",
+        },
+      },
+    ],
+    [t, getFullDate, handleDelete]
+  );
+
+  if (data.length === 0) {
+    return (
+      <Container className="flex flex-col overflow-hidden p-0">
+        <div className="flex items-center justify-between px-6 py-4">
+          <Heading level="h2">{t("store.timeOff.header")}</Heading>
+        </div>
+        <NoRecords
+          icon={<CalendarMini className="text-ui-fg-subtle" />}
+          title={t("store.timeOff.empty.title")}
+          message={t("store.timeOff.empty.message")}
+          action={{
+            to: "store-closure",
+            label: t("store.timeOff.empty.action"),
+          }}
+          className="h-[300px]"
+        />
+      </Container>
+    );
+  }
+
+  return (
+    <Container className="flex flex-col overflow-hidden p-0">
+      <DataTable
+        data={data}
+        columns={columns}
+        getRowId={(row) => row.id}
+        rowCount={data.length}
+        heading={t("store.timeOff.header")}
+        enableSearch={false}
+        enablePagination={false}
+        action={{
+          to: "store-closure",
+          label: t("actions.create"),
+        }}
+      />
+    </Container>
+  );
+};

--- a/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
+++ b/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
@@ -237,7 +237,7 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
                 <Form.Item>
                   <Form.Label optional>{t("fields.website")}</Form.Label>
                   <Form.Control>
-                    <Input {...field} />
+                    <Input placeholder="https://example.com" {...field} />
                   </Form.Control>
                   <Form.ErrorMessage />
                 </Form.Item>

--- a/packages/vendor/src/pages/settings/store/store-closure/index.tsx
+++ b/packages/vendor/src/pages/settings/store/store-closure/index.tsx
@@ -21,11 +21,11 @@ export const Component = () => {
       <RouteDrawer.Header>
         <RouteDrawer.Title asChild>
           <Heading>
-            {t("store.scheduledClosure.edit.header")}
+            {t("store.timeOff.create.header")}
           </Heading>
         </RouteDrawer.Title>
         <RouteDrawer.Description className="sr-only">
-          {t("store.scheduledClosure.edit.description")}
+          {t("store.timeOff.create.description")}
         </RouteDrawer.Description>
       </RouteDrawer.Header>
       {!isPending && seller && <StoreClosureForm seller={seller} />}

--- a/packages/vendor/src/pages/settings/store/store-closure/store-closure-form.tsx
+++ b/packages/vendor/src/pages/settings/store/store-closure/store-closure-form.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, DatePicker, toast } from "@medusajs/ui";
+import { Button, DatePicker, Textarea, toast } from "@medusajs/ui";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
@@ -14,15 +14,11 @@ type StoreClosureFormProps = {
   seller: HttpTypes.StoreSellerResponse["seller"];
 };
 
-const StoreClosureSchema = z
-  .object({
-    closed_from: z.date({ required_error: "Close from date is required" }),
-    closed_to: z.date().nullable(),
-  })
-  .refine((data) => data.closed_from >= new Date(new Date().toDateString()), {
-    message: "Close from date cannot be in the past",
-    path: ["closed_from"],
-  });
+const StoreClosureSchema = z.object({
+  closed_from: z.date({ required_error: "Please enter a first day" }),
+  closed_to: z.date().nullable(),
+  closure_note: z.string().nullable(),
+});
 
 export const StoreClosureForm = ({ seller }: StoreClosureFormProps) => {
   const { t } = useTranslation();
@@ -34,6 +30,7 @@ export const StoreClosureForm = ({ seller }: StoreClosureFormProps) => {
         ? new Date(seller.closed_from)
         : null,
       closed_to: seller.closed_to ? new Date(seller.closed_to) : null,
+      closure_note: seller.closure_note ?? "",
     },
     resolver: zodResolver(StoreClosureSchema),
   });
@@ -45,12 +42,11 @@ export const StoreClosureForm = ({ seller }: StoreClosureFormProps) => {
       {
         closed_from: data.closed_from || null,
         closed_to: data.closed_to || null,
+        closure_note: data.closure_note || null,
       },
       {
         onSuccess: () => {
-          toast.success(
-            t("store.scheduledClosure.edit.successToast"),
-          );
+          toast.success(t("store.timeOff.create.successToast"));
           handleSuccess();
         },
         onError: (error: Error) => {
@@ -72,12 +68,11 @@ export const StoreClosureForm = ({ seller }: StoreClosureFormProps) => {
                 return (
                   <Form.Item>
                     <Form.Label>
-                      {t("store.scheduledClosure.fields.closedFrom")}
+                      {t("store.timeOff.fields.firstDay")}
                     </Form.Label>
                     <Form.Control>
                       <DatePicker
                         granularity="minute"
-                        hourCycle={12}
                         shouldCloseOnSelect={false}
                         {...field}
                       />
@@ -95,16 +90,37 @@ export const StoreClosureForm = ({ seller }: StoreClosureFormProps) => {
                 return (
                   <Form.Item>
                     <Form.Label optional>
-                      {t("store.scheduledClosure.fields.closedTo")}
+                      {t("store.timeOff.fields.lastDay")}
                     </Form.Label>
-                    <Form.Hint>
-                      {t("store.scheduledClosure.fields.closedToHint")}
-                    </Form.Hint>
                     <Form.Control>
                       <DatePicker
                         granularity="minute"
                         shouldCloseOnSelect={false}
                         {...field}
+                      />
+                    </Form.Control>
+                    <Form.Hint>
+                      {t("store.timeOff.fields.lastDayHint")}
+                    </Form.Hint>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                );
+              }}
+            />
+
+            <Form.Field
+              control={form.control}
+              name="closure_note"
+              render={({ field }) => {
+                return (
+                  <Form.Item>
+                    <Form.Label optional>
+                      {t("store.timeOff.fields.note")}
+                    </Form.Label>
+                    <Form.Control>
+                      <Textarea
+                        {...field}
+                        value={field.value ?? ""}
                       />
                     </Form.Control>
                     <Form.ErrorMessage />

--- a/packages/vendor/src/pages/settings/store/store-detail-page.tsx
+++ b/packages/vendor/src/pages/settings/store/store-detail-page.tsx
@@ -1,6 +1,8 @@
-import { Children, ReactNode } from "react";
-import { Alert, Text } from "@medusajs/ui";
+import React, { Children, ReactNode } from "react";
+import { InformationCircleSolid } from "@medusajs/icons";
+import { Alert, Button, Container, Heading, Text } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
+import components from "virtual:mercur/components";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
@@ -8,7 +10,7 @@ import { useMe, useSubscription } from "@/hooks/api";
 import { SellerStatus } from "@mercurjs/types";
 
 import { StoreAddressSection } from "./_components/store-address-section";
-import { StoreConfigurationSection } from "./_components/store-configuration-section";
+import { StoreTimeOffSection } from "./_components/store-time-off-section";
 import { StoreGeneralSection } from "./_components/store-general-section";
 import { StoreSubscriptionSection } from "./_components/store-subscription-section";
 import { StorePaymentDetailsSection } from "./_components/store-payment-details-section";
@@ -39,14 +41,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
     throw error;
   }
 
+  const isPendingApproval = seller.status === SellerStatus.PENDING_APPROVAL;
+
   const statusAlert = (() => {
     switch (seller.status) {
-      case SellerStatus.PENDING_APPROVAL:
-        return {
-          variant: "warning" as const,
-          title: t("store.alert.pendingApproval.title"),
-          description: t("store.alert.pendingApproval.description"),
-        };
       case SellerStatus.SUSPENDED:
         return {
           variant: "error" as const,
@@ -66,29 +64,31 @@ const Root = ({ children }: { children?: ReactNode }) => {
     }
   })();
 
-  if (Children.count(children) > 0) {
-    return (
-      <div className="flex flex-col gap-y-3">
-        {statusAlert && (
-          <Alert variant={statusAlert.variant} dismissible className="p-5">
-            <div className="text-ui-fg-subtle txt-small pb-2 font-medium leading-[20px]">
-              {statusAlert.title}
-            </div>
-            <Text className="text-ui-fg-subtle txt-small leading-normal">
-              {statusAlert.description}
+  const StoreSetup = components.StoreSetup as
+    | React.ComponentType<{ seller: any }>
+    | undefined;
+
+  const StatusBanner = () => (
+    <>
+      {isPendingApproval && (
+        <Container className="p-0">
+          <div className="flex items-center gap-x-3 px-6 py-4 border-b border-ui-border-base">
+            <InformationCircleSolid className="text-ui-fg-interactive" />
+            <Heading level="h2">{t("store.alert.pendingApproval.title")}</Heading>
+          </div>
+          <div className="px-6 py-4">
+            <Text size="small" className="text-ui-fg-subtle">
+              {t("store.alert.pendingApproval.description")}
             </Text>
-          </Alert>
-        )}
-
-        <TwoColumnPage data={seller} hasOutlet>
-          {children}
-        </TwoColumnPage>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-y-3">
+          </div>
+          <div className="flex justify-end px-6 py-4 border-t border-ui-border-base bg-ui-bg-subtle rounded-b-lg">
+            <Button variant="secondary" size="small">
+              {t("actions.cancel")}
+            </Button>
+          </div>
+        </Container>
+      )}
+      {StoreSetup && <StoreSetup seller={seller} />}
       {statusAlert && (
         <Alert variant={statusAlert.variant} dismissible className="p-5">
           <div className="text-ui-fg-subtle txt-small pb-2 font-medium leading-[20px]">
@@ -99,22 +99,34 @@ const Root = ({ children }: { children?: ReactNode }) => {
           </Text>
         </Alert>
       )}
+    </>
+  );
+
+  if (Children.count(children) > 0) {
+    return (
       <TwoColumnPage data={seller} hasOutlet>
-        <TwoColumnPage.Main>
-          <StoreGeneralSection seller={seller} />
-        </TwoColumnPage.Main>
-        <TwoColumnPage.Sidebar>
-          <StoreConfigurationSection seller={seller} />
-          <StoreAddressSection seller={seller} />
-          <StoreProfessionalDetailsSection seller={seller} />
-          <StorePaymentDetailsSection seller={seller} />
-          <StoreSubscriptionSection
-            subscription_plan={subscription_plan}
-            subscription_override={subscription_override}
-          />
-        </TwoColumnPage.Sidebar>
+        {children}
       </TwoColumnPage>
-    </div>
+    );
+  }
+
+  return (
+    <TwoColumnPage data={seller} hasOutlet>
+      <TwoColumnPage.Main>
+        <StatusBanner />
+        <StoreGeneralSection seller={seller} />
+        <StoreTimeOffSection seller={seller} />
+      </TwoColumnPage.Main>
+      <TwoColumnPage.Sidebar>
+        <StoreAddressSection seller={seller} />
+        <StoreProfessionalDetailsSection seller={seller} />
+        <StorePaymentDetailsSection seller={seller} />
+        <StoreSubscriptionSection
+          subscription_plan={subscription_plan}
+          subscription_override={subscription_override}
+        />
+      </TwoColumnPage.Sidebar>
+    </TwoColumnPage>
   );
 };
 
@@ -124,7 +136,7 @@ export const StoreDetailPage = Object.assign(Root, {
   MainGeneralSection: StoreGeneralSection,
   MainPaymentDetailsSection: StorePaymentDetailsSection,
   MainProfessionalDetailsSection: StoreProfessionalDetailsSection,
-  SidebarConfigurationSection: StoreConfigurationSection,
+  MainTimeOffSection: StoreTimeOffSection,
   SidebarAddressSection: StoreAddressSection,
   SidebarSubscriptionSection: StoreSubscriptionSection,
   Header: StoreDetailHeader,


### PR DESCRIPTION
  ## Summary                                                                                                                            
  - Replace "Scheduled Closure" sidebar section with "Time Off" data table in main column (empty state, create/edit drawer, delete      
  action)                                                                                                                               
  - Add `closure_note` field to Seller model with migration (also fixes `corporate_name` NOT NULL constraint bug)                       
  - Add empty states for Address, Company Details, and Payment Details sections                                                         
  - Redesign PENDING_APPROVAL banner as "Store request" card with info icon and Cancel button                                           
  - Move Store request + Complete store profile into left column instead of full-width                                                  
  - Add diagonal stripe pattern for missing banner image                                                                                
  - Add website URL format hint in edit form                                                                                            
  - Update i18n keys (Time Off, empty states, status labels)                                                                            
                                                                                                                                        
  ## Test plan                                                                                                                          
  - [ ] Run migration, verify `closure_note` column added and `corporate_name` allows null                                              
  - [ ] Create/edit/delete time off entry on `/settings/store`                                                                          
  - [ ] Verify empty states show for Address, Company Details, Payment Details when data is missing                                     
  - [ ] Verify "Store request" banner appears for PENDING_APPROVAL sellers in left column                                               
  - [ ] Verify "Complete store profile" checklist appears in left column                                                                
  - [ ] Clear professional details fields and save — should succeed (was 400 before migration)                                          
  - [ ] Check banner placeholder shows diagonal stripes when no banner image                                                            
  - [ ] Verify website URL hint shows "Must include protocol"      