### PR TITLE
fix(admin): prevent order detail crash when order_group has 2+ orders

### DIFF
--- a/packages/admin/src/pages/orders/order-detail/components/order-remaining-orders-group-section/order-remaining-orders-group-section.tsx
+++ b/packages/admin/src/pages/orders/order-detail/components/order-remaining-orders-group-section/order-remaining-orders-group-section.tsx
@@ -57,7 +57,8 @@ export const OrderRemainingOrdersGroupSection = () => {
     data: orders as HttpTypes.AdminOrder[],
     columns,
     count: orders.length,
-    enablePagination: false,
+    enablePagination: true,
+    pageSize: Math.max(orders.length, 1),
     getRowId: (row) => row.id,
   })
 


### PR DESCRIPTION
## Summary

Every admin order detail page whose order belongs to an `order_group`
with 2+ orders crashes with a React error — full-page `ErrorBoundary`
fallback. This is the canonical multi-seller marketplace checkout
scenario (one Mercur sub-order per seller, all sharing one
`order_group`), so the bug is on the hot path for every marketplace
using the platform.

Root cause: `OrderRemainingOrdersGroupSection` calls
`useDataTable({ enablePagination: false })`. Mercur's `useDataTable`
deliberately passes `pagination: undefined` into TanStack's
`useReactTable` in that branch, but `_DataTable` still renders its
pagination controls, which call `table.getCanNextPage()` → destructures
the missing pagination slice → `TypeError: Cannot destructure property
'pageIndex' of 'table.getState(...).pagination' as it is undefined.`

Fix: keep pagination enabled with a page size that fits all grouped
orders. UX stays identical (everything on one page, pager hidden because
`pageSize === count`), but the table state contains a valid pagination
slice so `_DataTable` works.

## Changes

- `packages/admin/src/pages/orders/order-detail/components/order-remaining-orders-group-section/order-remaining-orders-group-section.tsx`
  - Swap `enablePagination: false` for `enablePagination: true, pageSize: Math.max(orders.length, 1)`

## Testing

- Reproduced against a fresh `npx @mercurjs/cli@latest create` install:
  1. Seed/create 2 sellers with products
  2. Place a multi-seller order via the store frontend → creates an `order_group` with 2 orders
  3. Open any of the sub-orders in admin → before: full-page crash; after this patch: renders correctly with the "Orders in group" section listing the sibling order
- Verified with `order_group.orders.length` in `{2, 3}` (TechStore + FashionHub + HomeGoods cart)
- Also re-verified the single-order case (no order_group) — the component early-returns `null` as before, unaffected

## Checklist

- [x] This pull request targets `main` (CONTRIBUTING mentions `new`, but there is no `new` branch in the repo — happy to rebase if the base branch should be different).
- [x] I updated documentation, locales if the change requires it. (no doc/locale impact — behaviour preserved)

## Linked issues

Fixes #879