### PR TITLE
fix(cli): keep admin invite accept route mapped to Medusa

### DIFF
--- a/packages/cli/src/codegen/constants.ts
+++ b/packages/cli/src/codegen/constants.ts
@@ -303,7 +303,6 @@ export const defaultMercurRoutes = {
     "/admin/payouts/:id": "typeof import(\"@mercurjs/core/api/admin/payouts/[id]/route\")",
     "/admin/orders": "typeof import(\"@mercurjs/core/api/admin/orders/route\")",
     "/admin/products": "typeof import(\"@mercurjs/core/api/admin/products/route\")",
-    "/admin/invites/accept": "typeof import(\"@mercurjs/core/api/admin/invites/accept/route\")",
     "/admin/sellers": "typeof import(\"@mercurjs/core/api/admin/sellers/route\")",
     "/admin/sellers/invite": "typeof import(\"@mercurjs/core/api/admin/sellers/invite/route\")",
     "/admin/sellers/:id": "typeof import(\"@mercurjs/core/api/admin/sellers/[id]/route\")",


### PR DESCRIPTION
## Summary
- removes the Mercur route override for /admin/invites/accept from the CLI codegen route map
- lets the existing Medusa route mapping be used for that endpoint
- fixes generated route types pointing at a non-existent @mercurjs/core-plugin admin invite accept route

Closes #844.

## Verification
- bun run --cwd packages/cli build
- git diff --check

Note: bun run --cwd packages/cli typecheck currently fails on existing upstream errors in src/registry/utils.ts and src/utils/update-files.ts that are unrelated to this route-map change.