### PR TITLE
fix(dashboard-sdk): escape resolved path for Windows compatibility

### DIFF
--- a/packages/dashboard-sdk/src/virtual-modules.ts
+++ b/packages/dashboard-sdk/src/virtual-modules.ts
@@ -66,7 +66,7 @@ function loadComponentsModule(mercurConfig: BuiltMercurConfig, cwd: string): str
 
     Object.entries(components).forEach(([name, componentPath]) => {
         const resolvedPath = path.resolve(cwd, 'src', componentPath)
-        imports.push(`import _${name} from "${resolvedPath}"`)
+        imports.push(`import _${name} from ${JSON.stringify(resolvedPath)}`)
         exports.push(`${name}: _${name}`)
     })
 


### PR DESCRIPTION
## Summary

`@mercurjs/dashboard-sdk`'s `loadComponentsModule` builds an `import` statement by string-interpolating `path.resolve(...)`'s output directly into a JS double-quoted literal. On Windows the resolved path contains `\` characters, which Vite/esbuild then parse as JS string escape sequences (`\v`, `\f`, `\t`, `\U`, …) — corrupting the import string and breaking the vendor/admin build with:

```
Failed to resolve import "C:UserswtosDesktopstoa-marketplaceappsendorsrccomponentsopbar-actions"
```

(original path was `C:\Users\fwtos\Desktop\stoa-marketplace\apps\vendor\src\components\topbar-actions`; substrings `\U`, `\D`, `\v`, `\t` got consumed as escapes).

Linux/macOS unaffected because their paths are already POSIX.

## Changes

- `packages/dashboard-sdk/src/virtual-modules.ts` — wrap `resolvedPath` with `JSON.stringify` so it produces a properly escaped JS string literal regardless of platform separators.

## Testing

- Verified locally on Windows 11 + bun 1.3.11 against a project from the `basic` template: pre-fix, `bun run build` from `apps/vendor` fails on Windows; post-fix it succeeds and the produced module text is valid JS.
- Linux/macOS behavior unchanged (the `JSON.stringify` of a POSIX absolute path is identical to the previous double-quoted output).

## Checklist

- [ ] This pull request targets `new`. — Targets `main` because there is no `new` branch on this repo and recent merged PRs all target `main`. Happy to retarget if I missed something.
- [x] I updated documentation, locales if the change requires it. — n/a (one-line bug fix in a generated import statement).
- [ ] I added or adjusted tests that cover the change. — `packages/dashboard-sdk` has no existing test setup for `virtual-modules`; I didn't add a new harness for a one-line fix. Happy to add one if you'd like a particular shape (a snapshot of the generated module text on a synthetic Windows-style path would be straightforward).

## Linked issues

Fixes #911
