### PR TITLE
feat(admin,vendor): i18n coverage and onboarding extensibility

### DIFF
--- a/packages/admin/src/components/layout/main-layout/main-layout.tsx
+++ b/packages/admin/src/components/layout/main-layout/main-layout.tsx
@@ -346,7 +346,7 @@ const useCoreRoutes = (): Omit<INavItem, "pathname">[] => {
     },
     {
       icon: <CreditCardRefresh />,
-      label: "Payouts",
+      label: t("payouts.domain"),
       to: "/payouts",
     },
   ];

--- a/packages/admin/src/components/layout/settings-layout/settings-layout.tsx
+++ b/packages/admin/src/components/layout/settings-layout/settings-layout.tsx
@@ -86,7 +86,7 @@ const useSettingRoutes = (): INavItem[] => {
         to: "/settings/locations",
       },
       {
-        label: "Commission Rates",
+        label: t("commissionRates.domain"),
         to: "/settings/commission-rates",
       },
       ...extensionNavItems,

--- a/packages/admin/src/get-route-map.tsx
+++ b/packages/admin/src/get-route-map.tsx
@@ -1179,7 +1179,7 @@ export function getRouteMap({
                 errorElement: <ErrorBoundary />,
                 element: <Outlet />,
                 handle: {
-                  breadcrumb: () => "Commission Rates",
+                  breadcrumb: () => t("commissionRates.domain"),
                 },
                 children: [
                   {

--- a/packages/admin/src/hooks/table/columns/use-seller-table-columns.tsx
+++ b/packages/admin/src/hooks/table/columns/use-seller-table-columns.tsx
@@ -15,7 +15,7 @@ export const useSellersTableColumns = () => {
     () => [
       columnHelper.display({
         id: "name",
-        header: t("stores.fields.name"),
+        header: t("stores.fields.seller"),
         cell: ({ row }) => row.original.name,
       }),
       columnHelper.display({

--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -1524,6 +1524,9 @@
         "domain": {
           "type": "string"
         },
+        "associatedStore": {
+          "type": "string"
+        },
         "additionalAttributes": {
           "type": "string"
         },
@@ -2727,6 +2730,7 @@
       },
       "required": [
         "domain",
+        "associatedStore",
         "additionalAttributes",
         "list",
         "edit",
@@ -5199,6 +5203,15 @@
                 },
                 "requiresAction": {
                   "type": "string"
+                },
+                "awaitingPickup": {
+                  "type": "string"
+                },
+                "awaitingShipping": {
+                  "type": "string"
+                },
+                "awaitingDelivery": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -5212,7 +5225,10 @@
                 "partiallyReturned",
                 "returned",
                 "canceled",
-                "requiresAction"
+                "requiresAction",
+                "awaitingPickup",
+                "awaitingShipping",
+                "awaitingDelivery"
               ],
               "additionalProperties": false
             },
@@ -5245,6 +5261,9 @@
               "additionalProperties": false
             },
             "trackingLabel": {
+              "type": "string"
+            },
+            "labelLink": {
               "type": "string"
             },
             "shippingFromLabel": {
@@ -5281,6 +5300,7 @@
             "status",
             "toast",
             "trackingLabel",
+            "labelLink",
             "shippingFromLabel",
             "itemsLabel"
           ],
@@ -5661,9 +5681,33 @@
             },
             "returnableQuantity": {
               "type": "string"
+            },
+            "groupId": {
+              "type": "string"
+            },
+            "orderIds": {
+              "type": "string"
+            },
+            "vendor": {
+              "type": "string"
+            },
+            "vendorsCount_one": {
+              "type": "string"
+            },
+            "vendorsCount_other": {
+              "type": "string"
             }
           },
-          "required": ["displayId", "refundableAmount", "returnableQuantity"],
+          "required": [
+            "displayId",
+            "refundableAmount",
+            "returnableQuantity",
+            "groupId",
+            "orderIds",
+            "vendor",
+            "vendorsCount_one",
+            "vendorsCount_other"
+          ],
           "additionalProperties": false
         }
       },
@@ -5697,6 +5741,48 @@
         "activity",
         "fields"
       ],
+      "additionalProperties": false
+    },
+    "payouts": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "string"
+        },
+        "list": {
+          "type": "object",
+          "properties": {
+            "empty": {
+              "type": "string"
+            }
+          },
+          "required": ["empty"],
+          "additionalProperties": false
+        },
+        "status": {
+          "type": "object",
+          "properties": {
+            "paid": {
+              "type": "string"
+            },
+            "processing": {
+              "type": "string"
+            },
+            "pending": {
+              "type": "string"
+            },
+            "failed": {
+              "type": "string"
+            },
+            "canceled": {
+              "type": "string"
+            }
+          },
+          "required": ["paid", "processing", "pending", "failed", "canceled"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["domain", "list", "status"],
       "additionalProperties": false
     },
     "draftOrders": {
@@ -12265,6 +12351,131 @@
       },
       "required": ["domain"],
       "additionalProperties": false
+    },
+    "commissionRates": {
+      "type": "object",
+      "properties": {
+        "domain": { "type": "string" },
+        "description": { "type": "string" },
+        "create": {
+          "type": "object",
+          "properties": {
+            "header": { "type": "string" },
+            "description": { "type": "string" },
+            "successToast": { "type": "string" }
+          },
+          "required": ["header", "description", "successToast"],
+          "additionalProperties": false
+        },
+        "edit": {
+          "type": "object",
+          "properties": {
+            "header": { "type": "string" },
+            "successToast": { "type": "string" }
+          },
+          "required": ["header", "successToast"],
+          "additionalProperties": false
+        },
+        "delete": {
+          "type": "object",
+          "properties": {
+            "description": { "type": "string" },
+            "successToast": { "type": "string" }
+          },
+          "required": ["description", "successToast"],
+          "additionalProperties": false
+        },
+        "rules": {
+          "type": "object",
+          "properties": {
+            "empty": { "type": "string" }
+          },
+          "required": ["empty"],
+          "additionalProperties": false
+        },
+        "fields": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "code": { "type": "string" },
+            "type": {
+              "type": "object",
+              "properties": {
+                "label": { "type": "string" },
+                "percentage": { "type": "string" },
+                "fixed": { "type": "string" }
+              },
+              "required": ["label", "percentage", "fixed"],
+              "additionalProperties": false
+            },
+            "target": {
+              "type": "object",
+              "properties": {
+                "label": { "type": "string" },
+                "item": { "type": "string" },
+                "shipping": { "type": "string" }
+              },
+              "required": ["label", "item", "shipping"],
+              "additionalProperties": false
+            },
+            "currencyCode": { "type": "string" },
+            "currencyPlaceholder": { "type": "string" },
+            "rate": { "type": "string" },
+            "minAmount": { "type": "string" },
+            "priority": { "type": "string" },
+            "enabled": { "type": "string" },
+            "enabledHint": { "type": "string" },
+            "includeTax": { "type": "string" },
+            "includeTaxHint": { "type": "string" }
+          },
+          "required": [
+            "name",
+            "code",
+            "type",
+            "target",
+            "currencyCode",
+            "currencyPlaceholder",
+            "rate",
+            "minAmount",
+            "priority",
+            "enabled",
+            "enabledHint",
+            "includeTax",
+            "includeTaxHint"
+          ],
+          "additionalProperties": false
+        },
+        "status": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "string" },
+            "disabled": { "type": "string" }
+          },
+          "required": ["enabled", "disabled"],
+          "additionalProperties": false
+        },
+        "toggle": {
+          "type": "object",
+          "properties": {
+            "enabledToast": { "type": "string" },
+            "disabledToast": { "type": "string" }
+          },
+          "required": ["enabledToast", "disabledToast"],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "domain",
+        "description",
+        "create",
+        "edit",
+        "delete",
+        "rules",
+        "fields",
+        "status",
+        "toggle"
+      ],
+      "additionalProperties": false
     }
   },
   "required": [
@@ -12291,6 +12502,7 @@
     "customers",
     "customerGroups",
     "orders",
+    "payouts",
     "draftOrders",
     "stockLocations",
     "shippingProfile",
@@ -12330,7 +12542,8 @@
     "configuration",
     "algolia",
     "commission",
-    "commissionLines"
+    "commissionLines",
+    "commissionRates"
   ],
   "additionalProperties": false
 }

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -406,6 +406,7 @@
   },
   "products": {
     "domain": "Products",
+    "associatedStore": "Associated Store",
     "additionalAttributes": "Additional Attributes",
     "list": {
       "noRecordsMessage": "Create your first product to start selling."
@@ -1395,7 +1396,10 @@
         "partiallyReturned": "Partially returned",
         "returned": "Returned",
         "canceled": "Canceled",
-        "requiresAction": "Requires action"
+        "requiresAction": "Requires action",
+        "awaitingPickup": "Awaiting pickup",
+        "awaitingShipping": "Awaiting shipping",
+        "awaitingDelivery": "Awaiting delivery"
       },
       "toast": {
         "created": "Fulfillment created successfully",
@@ -1405,6 +1409,7 @@
         "fulfillmentPickedUp": "Fulfillment marked as picked up successfully"
       },
       "trackingLabel": "Tracking",
+      "labelLink": "Label",
       "shippingFromLabel": "Shipping from",
       "itemsLabel": "Items"
     },
@@ -1506,7 +1511,25 @@
     "fields": {
       "displayId": "Display ID",
       "refundableAmount": "Refundable amount",
-      "returnableQuantity": "Returnable quantity"
+      "returnableQuantity": "Returnable quantity",
+      "groupId": "Group ID",
+      "orderIds": "Order IDs",
+      "vendor": "Vendor",
+      "vendorsCount_one": "{{count}} vendor",
+      "vendorsCount_other": "{{count}} vendors"
+    }
+  },
+  "payouts": {
+    "domain": "Payouts",
+    "list": {
+      "empty": "No payouts found"
+    },
+    "status": {
+      "paid": "Paid",
+      "processing": "Processing",
+      "pending": "Pending",
+      "failed": "Failed",
+      "canceled": "Canceled"
     }
   },
   "draftOrders": {
@@ -3272,8 +3295,6 @@
     "providers": "Providers",
     "availability": "Availability",
     "inventory": "Inventory",
-    "optional": "Optional",
-    "note": "Note",
     "automaticTaxes": "Automatic Taxes",
     "taxInclusivePricing": "Tax inclusive pricing",
     "currency": "Currency",
@@ -3433,6 +3454,7 @@
       "city": "City",
       "province": "Province",
       "country_code": "Country Code",
+      "seller": "Seller",
       "premium": "Featured"
     },
     "status": {
@@ -3565,5 +3587,56 @@
   },
   "commissionLines": {
     "domain": "Commission Lines"
+  },
+  "commissionRates": {
+    "domain": "Commission Rates",
+    "description": "Manage commission rates and rules for your marketplace.",
+    "create": {
+      "header": "Create Commission Rate",
+      "description": "Configure a new commission rate for your marketplace.",
+      "successToast": "Commission rate created successfully"
+    },
+    "edit": {
+      "header": "Edit Commission Rate",
+      "successToast": "Commission rate updated successfully"
+    },
+    "delete": {
+      "description": "Are you sure you want to delete the commission rate \"{{name}}\"?",
+      "successToast": "Commission rate deleted successfully"
+    },
+    "rules": {
+      "empty": "No rules configured"
+    },
+    "fields": {
+      "name": "Name",
+      "code": "Code",
+      "type": {
+        "label": "Type",
+        "percentage": "Percentage",
+        "fixed": "Fixed"
+      },
+      "target": {
+        "label": "Target",
+        "item": "Item",
+        "shipping": "Shipping"
+      },
+      "currencyCode": "Currency Code",
+      "currencyPlaceholder": "Select currency",
+      "rate": "Rate",
+      "minAmount": "Minimum Amount",
+      "priority": "Priority",
+      "enabled": "Enabled",
+      "enabledHint": "Enable or disable this commission rate.",
+      "includeTax": "Include Tax",
+      "includeTaxHint": "Include tax in the commission calculation."
+    },
+    "status": {
+      "enabled": "Enabled",
+      "disabled": "Disabled"
+    },
+    "toggle": {
+      "enabledToast": "Commission rate enabled successfully",
+      "disabledToast": "Commission rate disabled successfully"
+    }
   }
 }

--- a/packages/admin/src/i18n/translations/pl.json
+++ b/packages/admin/src/i18n/translations/pl.json
@@ -260,7 +260,9 @@
       },
       "main": {
         "store": "Sklep",
-        "storeSettings": "Ustawienia sklepu"
+        "marketplace": "Marketplace",
+        "storeSettings": "Ustawienia sklepu",
+        "marketplaceSettings": "Ustawienia marketplace"
       },
       "settings": {
         "header": "Ustawienia",
@@ -407,6 +409,7 @@
   },
   "products": {
     "domain": "Produkty",
+    "associatedStore": "Powiązany sklep",
     "additionalAttributes": "Dodatkowe atrybuty",
     "list": {
       "noRecordsMessage": "Utwórz swój pierwszy produkt, aby rozpocząć sprzedaż."
@@ -766,6 +769,57 @@
         "successToast_many": "Produktów zostało pomyślnie usuniętych z kolekcji.",
         "successToast_other": "Produktów zostało pomyślnie usuniętych z kolekcji."
       }
+    }
+  },
+  "commissionRates": {
+    "domain": "Stawki prowizji",
+    "description": "Zarządzaj stawkami prowizji i regułami dla swojego marketplace.",
+    "create": {
+      "header": "Utwórz stawkę prowizji",
+      "description": "Skonfiguruj nową stawkę prowizji dla swojego marketplace.",
+      "successToast": "Stawka prowizji utworzona pomyślnie"
+    },
+    "edit": {
+      "header": "Edytuj stawkę prowizji",
+      "successToast": "Stawka prowizji zaktualizowana pomyślnie"
+    },
+    "delete": {
+      "description": "Czy na pewno chcesz usunąć stawkę prowizji \"{{name}}\"?",
+      "successToast": "Stawka prowizji usunięta pomyślnie"
+    },
+    "rules": {
+      "empty": "Brak skonfigurowanych reguł"
+    },
+    "fields": {
+      "name": "Nazwa",
+      "code": "Kod",
+      "type": {
+        "label": "Typ",
+        "percentage": "Procentowy",
+        "fixed": "Stały"
+      },
+      "target": {
+        "label": "Cel",
+        "item": "Pozycja",
+        "shipping": "Wysyłka"
+      },
+      "currencyCode": "Kod waluty",
+      "currencyPlaceholder": "Wybierz walutę",
+      "rate": "Stawka",
+      "minAmount": "Kwota minimalna",
+      "priority": "Priorytet",
+      "enabled": "Włączone",
+      "enabledHint": "Włącz lub wyłącz tę stawkę prowizji.",
+      "includeTax": "Uwzględnij podatek",
+      "includeTaxHint": "Uwzględnij podatek w obliczeniach prowizji."
+    },
+    "status": {
+      "enabled": "Włączone",
+      "disabled": "Wyłączone"
+    },
+    "toggle": {
+      "enabledToast": "Stawka prowizji włączona pomyślnie",
+      "disabledToast": "Stawka prowizji wyłączona pomyślnie"
     }
   },
   "categories": {
@@ -1409,7 +1463,10 @@
         "partiallyReturned": "Częściowo zwrócone",
         "returned": "Zwrócone",
         "canceled": "Anulowane",
-        "requiresAction": "Wymaga działania"
+        "requiresAction": "Wymaga działania",
+        "awaitingPickup": "Oczekuje na odbiór",
+        "awaitingShipping": "Oczekuje na wysyłkę",
+        "awaitingDelivery": "Oczekuje na dostawę"
       },
       "toast": {
         "created": "Realizacja została pomyślnie utworzona",
@@ -1419,6 +1476,7 @@
         "fulfillmentPickedUp": "Realizacja została pomyślnie oznaczona jako odebrana"
       },
       "trackingLabel": "Śledzenie przesyłki",
+      "labelLink": "Etykieta",
       "shippingFromLabel": "Wysyłka z",
       "itemsLabel": "Produkty"
     },
@@ -1526,7 +1584,25 @@
     "fields": {
       "displayId": "Indeks zamówienia",
       "refundableAmount": "Kwota do zwrotu",
-      "returnableQuantity": "Ilość do zwrotu"
+      "returnableQuantity": "Ilość do zwrotu",
+      "groupId": "ID grupy",
+      "orderIds": "ID zamówień",
+      "vendor": "Sprzedawca",
+      "vendorsCount_one": "{{count}} sprzedawca",
+      "vendorsCount_other": "{{count}} sprzedawców"
+    }
+  },
+  "payouts": {
+    "domain": "Wypłaty",
+    "list": {
+      "empty": "Nie znaleziono wypłat"
+    },
+    "status": {
+      "paid": "Opłacone",
+      "processing": "Przetwarzane",
+      "pending": "Oczekujące",
+      "failed": "Nieudane",
+      "canceled": "Anulowane"
     }
   },
   "draftOrders": {
@@ -2479,7 +2555,12 @@
     "roles": {
       "admin": "Administrator",
       "developer": "Wywoływacz",
-      "member": "Członek"
+      "member": "Członek",
+      "administration": "Administracja sklepem",
+      "inventoryManagement": "Zarządzanie magazynem",
+      "orderManagement": "Zarządzanie zamówieniami",
+      "accounting": "Księgowość",
+      "support": "Wsparcie"
     },
     "list": {
       "empty": {
@@ -2493,7 +2574,11 @@
     },
     "deleteUserWarning": "Zamierzasz usunąć użytkownika {{name}}. Tej akcji nie można cofnąć.",
     "deleteUserSuccess": "Użytkownik {{name}} został pomyślnie usunięty",
-    "invite": "Zaproszenia"
+    "invite": "Zaproszenia",
+    "status": {
+      "active": "Aktywny",
+      "pending": "Oczekujący"
+    }
   },
   "store": {
     "domain": "Sklep",
@@ -2523,6 +2608,103 @@
       "currenciesUpdated": "Waluty zostały pomyślnie zaktualizowane",
       "currenciesRemoved": "Pomyślnie usunięto waluty ze sklepu",
       "updatedTaxInclusivitySuccessfully": "Ceny zawierające podatek zostały pomyślnie zaktualizowane"
+    },
+    "logo": "Logo",
+    "banner": "Baner",
+    "address": {
+      "header": "Adres",
+      "defaultName": "Siedziba główna",
+      "nameLabel": "Nazwa",
+      "apartmentLabel": "Mieszkanie, lokal itp.",
+      "empty": {
+        "title": "Brak adresu",
+        "message": "Brak rekordów do wyświetlenia"
+      },
+      "edit": {
+        "header": "Edytuj adres",
+        "description": "Zaktualizuj adres tego sklepu.",
+        "successToast": "Adres zaktualizowany"
+      },
+      "validation": {
+        "nameRequired": "Wprowadź nazwę",
+        "countryRequired": "Wybierz kraj"
+      }
+    },
+    "paymentDetails": {
+      "header": "Dane płatności",
+      "empty": {
+        "title": "Brak danych płatności",
+        "message": "Brak rekordów do wyświetlenia"
+      },
+      "edit": {
+        "header": "Edytuj dane płatności",
+        "description": "Zaktualizuj dane płatności tego sklepu.",
+        "successToast": "Dane płatności zaktualizowane"
+      },
+      "fields": {
+        "countryCode": "Kraj",
+        "holderName": "Nazwa konta",
+        "bankName": "Nazwa banku",
+        "iban": "IBAN",
+        "bic": "SWIFT / BIC",
+        "swiftBic": "SWIFT / BIC",
+        "routingNumber": "Numer rozliczeniowy",
+        "achRoutingNumber": "Numer rozliczeniowy ACH",
+        "accountNumber": "Numer konta"
+      },
+      "validation": {
+        "countryRequired": "Wybierz kraj",
+        "accountNameRequired": "Wprowadź nazwę konta"
+      }
+    },
+    "professionalDetails": {
+      "header": "Dane firmy",
+      "empty": {
+        "title": "Brak danych firmy",
+        "message": "Brak rekordów do wyświetlenia"
+      },
+      "edit": {
+        "header": "Edytuj dane firmy",
+        "description": "Zaktualizuj dane firmy tego sklepu.",
+        "successToast": "Dane firmy zaktualizowane"
+      },
+      "fields": {
+        "corporateName": "Firma",
+        "registrationNumber": "Numer rejestracyjny",
+        "taxId": "NIP"
+      }
+    },
+    "timeOff": {
+      "header": "Dni wolne",
+      "empty": {
+        "title": "Brak dni wolnych",
+        "message": "Ten sklep nie ma zaplanowanych dni wolnych",
+        "action": "Utwórz"
+      }
+    },
+    "scheduledClosure": {
+      "header": "Zaplanowane zamknięcie",
+      "edit": {
+        "header": "Zaplanuj zamknięcie sklepu",
+        "description": "Skonfiguruj daty zaplanowanego zamknięcia tego sklepu.",
+        "successToast": "Zaplanowane zamknięcie zaktualizowane"
+      },
+      "fields": {
+        "closedFrom": "Zamknięte od",
+        "closedTo": "Zamknięte do",
+        "closedToHint": "Jeśli puste, sklep pozostanie zamknięty bezterminowo."
+      }
+    },
+    "subscription": {
+      "header": "Plan subskrypcji",
+      "month": "miesiąc"
+    }
+  },
+  "marketplace": {
+    "domain": "Marketplace",
+    "manageMarketplaceDetails": "Zarządzaj szczegółami swojego marketplace",
+    "edit": {
+      "header": "Edytuj marketplace"
     }
   },
   "regions": {
@@ -3171,7 +3353,10 @@
     "startDate": "Data rozpoczęcia",
     "endDate": "Data końcowa",
     "draft": "Projekt",
-    "values": "Wartości"
+    "values": "Wartości",
+    "premium": "Wyróżniony sklep",
+    "selectPlaceholder": "Wybierz",
+    "website": "Strona internetowa"
   },
   "dateTime": {
     "years_one": "Rok",
@@ -3202,5 +3387,276 @@
     "seconds_few": "Sekundy",
     "seconds_many": "Sekund",
     "seconds_other": "Sekund"
+  },
+  "stores": {
+    "domain": "Sklepy",
+    "handleTooltip": "Uchwyt jest używany jako fragment URL sklepu. Pozostaw puste, aby wygenerować automatycznie z nazwy.",
+    "fields": {
+      "name": "Nazwa",
+      "handle": "Uchwyt",
+      "email": "E-mail",
+      "phone": "Telefon",
+      "logo": "Logo",
+      "cover_image": "Obraz tytułowy",
+      "address": "Adres",
+      "address_1": "Linia adresu 1",
+      "address_2": "Linia adresu 2",
+      "postal_code": "Kod pocztowy",
+      "city": "Miasto",
+      "province": "Województwo",
+      "country_code": "Kod kraju",
+      "seller": "Sprzedawca",
+      "premium": "Wyróżniony"
+    },
+    "status": {
+      "open": "Aktywny",
+      "pending_approval": "Oczekujący",
+      "pendingApproval": "Oczekujący",
+      "suspended": "Nieaktywny",
+      "terminated": "Zakończony"
+    },
+    "premium": {
+      "yes": "Tak",
+      "no": "Nie",
+      "description": "Jeśli zaznaczone, sklep zostanie wyróżniony specjalną odznaką do użytku wewnętrznego lub w celach promocyjnych."
+    },
+    "invite": {
+      "button": "Zaproś",
+      "header": "Zaproś sklep",
+      "hint": "Zaproś nowy sklep do swojego marketplace",
+      "successToast": "Zaproszenie wysłane do {{email}}",
+      "errorToast": "Nie udało się wysłać zaproszenia"
+    },
+    "members": {
+      "mainAdmin": "Administrator",
+      "addUser": {
+        "header": "Dodaj użytkownika",
+        "action": "Dodaj",
+        "hint": "Dodaj nowego użytkownika do zarządzania tym sklepem. Możesz wybrać istniejącego użytkownika lub zaprosić nowego.",
+        "addedToast": "Użytkownik został pomyślnie dodany.",
+        "invitedToast": "Użytkownik został pomyślnie zaproszony.",
+        "validation": {
+          "roleRequired": "Wybierz rolę"
+        }
+      },
+      "invite": {
+        "resendSuccess": "Zaproszenie wysłane ponownie do {{email}}",
+        "deleteSuccess": "Zaproszenie dla {{email}} usunięte",
+        "linkCopied": "Link zaproszenia skopiowany do schowka",
+        "copyFailed": "Nie udało się skopiować linku zaproszenia",
+        "noVendorUrl": "URL sprzedawcy nie jest skonfigurowany w backendzie (MERCUR_VENDOR_URL)"
+      }
+    },
+    "edit": {
+      "header": "Edytuj sklep",
+      "mediaHeading": "Multimedia",
+      "mediaTipLabel": "Wskazówka:",
+      "mediaTipBody": "Te multimedia będą widoczne w sklepie internetowym.",
+      "uploadLogoLabel": "Prześlij logo",
+      "uploadLogoHint": "Przeciągnij i upuść logo tutaj lub kliknij, aby przesłać.",
+      "uploadBannerLabel": "Prześlij baner",
+      "uploadBannerHint": "Przeciągnij i upuść baner tutaj lub kliknij, aby przesłać.",
+      "successToast": "Sklep {{name}} został pomyślnie zaktualizowany."
+    },
+    "create": {
+      "tabs": {
+        "details": "Szczegóły",
+        "users": "Administrator"
+      },
+      "header": "Szczegóły",
+      "usersHeader": "Administrator",
+      "usersHint": "Przypisz administratora do zarządzania tym sklepem. Wybierz istniejącego użytkownika lub zaproś nowego.",
+      "usersHintSecondary": "Po utworzeniu sklepu wybrany użytkownik otrzyma zaproszenie do dołączenia.",
+      "ownerEmail": "E-mail właściciela",
+      "ownerEmailHint": "Właścicielowi zostanie przyznana rola administracji sklepu.",
+      "successToast": "Sklep utworzony pomyślnie",
+      "validation": {
+        "nameRequired": "Wprowadź nazwę",
+        "emailRequired": "Wprowadź adres e-mail",
+        "emailInvalid": "Wprowadź prawidłowy adres e-mail",
+        "currencyRequired": "Wybierz walutę"
+      }
+    },
+    "request": {
+      "title": "Wniosek o sklep",
+      "description": "{{requester}} złożył wniosek o sklep. Sprawdź szczegóły, wprowadź niezbędne zmiany i zdecyduj, czy potwierdzić i opublikować sklep, czy odrzucić wniosek.",
+      "confirm": "Potwierdź",
+      "reject": "Odrzuć",
+      "confirmTitle": "Potwierdź wniosek",
+      "confirmDescription": "Zamierzasz potwierdzić ten wniosek o sklep.",
+      "rejectTitle": "Odrzuć wniosek",
+      "rejectDescription": "Zamierzasz odrzucić ten wniosek o sklep.",
+      "noteLabel": "Notatki dla sprzedawcy",
+      "notePlaceholder": "Określ wprowadzone zmiany lub dodatkowe wymagania",
+      "confirmNotePlaceholder": "Określ wprowadzone zmiany lub dodatkowe wymagania",
+      "rejectNotePlaceholder": "Wyjaśnij, dlaczego odrzucasz wniosek lub zaproponuj zmiany",
+      "confirmSuccess": "Wniosek o sklep został pomyślnie potwierdzony.",
+      "rejectSuccess": "Wniosek o sklep został pomyślnie odrzucony."
+    },
+    "actions": {
+      "approve": {
+        "label": "Zatwierdź",
+        "title": "Zatwierdź sklep",
+        "description": "Czy na pewno chcesz zatwierdzić ten sklep?",
+        "success": "Sklep zatwierdzony"
+      },
+      "reject": {
+        "label": "Odrzuć",
+        "title": "Odrzuć sklep",
+        "description": "Czy na pewno chcesz odrzucić ten sklep?",
+        "success": "Sklep odrzucony"
+      },
+      "edit": {
+        "label": "Edytuj"
+      },
+      "delete": {
+        "label": "Usuń",
+        "title": "Usuń sklep",
+        "description": "Czy na pewno chcesz usunąć ten sklep? Tej akcji nie można cofnąć.",
+        "success": "Sklep usunięty",
+        "successToast": "Usunięto {{count}} sklep(ów)",
+        "errorToast": "Nie udało się usunąć sklepu(-ów)"
+      }
+    },
+    "bulkEdit": {
+      "successToast": "Zaktualizowano {{count}} sklep(ów)",
+      "emptyHeading": "Nie wybrano sklepów",
+      "emptyDescription": "Wybierz sklepy z listy, aby je tutaj edytować."
+    },
+    "emptyStates": {
+      "products": {
+        "title": "Brak produktów",
+        "message": "Produkty opublikowane przez ten sklep pojawią się tutaj."
+      },
+      "users": {
+        "title": "Brak użytkowników",
+        "message": "Zaproś pierwszego użytkownika, aby zarządzał tym sklepem."
+      },
+      "orders": {
+        "title": "Brak zamówień",
+        "message": "Zamówienia złożone w tym sklepie pojawią się tutaj."
+      }
+    }
+  },
+  "attributes": {
+    "domain": "Atrybuty produktów",
+    "subtitle": "Zarządzaj atrybutami produktów i ich możliwymi wartościami.",
+    "list": {
+      "title": "Atrybuty produktów",
+      "noRecordsMessage": "Nie utworzono jeszcze żadnych atrybutów produktów."
+    },
+    "create": {
+      "header": "Utwórz atrybut",
+      "subtitle": "Zdefiniuj nowy atrybut produktu.",
+      "tabs": {
+        "details": "Szczegóły",
+        "type": "Typ"
+      },
+      "fillNameWarning": "Wypełnij przynajmniej pole nazwy przed przejściem do konfiguracji typu.",
+      "possibleValuesRequired": "Dla tego typu wymagana jest co najmniej jedna możliwa wartość",
+      "successToast": "Atrybut \"{{name}}\" został pomyślnie utworzony."
+    },
+    "edit": {
+      "header": "Edytuj atrybut",
+      "subtitle": "Zaktualizuj szczegóły atrybutu.",
+      "successToast": "Atrybut \"{{name}}\" został pomyślnie zaktualizowany."
+    },
+    "editPossibleValue": {
+      "header": "Edytuj możliwą wartość",
+      "subtitle": "Zaktualizuj szczegóły możliwej wartości.",
+      "successToast": "Możliwa wartość \"{{value}}\" została pomyślnie zaktualizowana."
+    },
+    "createPossibleValues": {
+      "header": "Utwórz wartości",
+      "subtitle": "Utwórz dodatkowe wartości dla atrybutu \"{{name}}\".",
+      "tabs": {
+        "values": "Wartości",
+        "organizeRanking": "Uporządkuj kolejność"
+      },
+      "addValue": "Dodaj wartość",
+      "enterValue": "Wprowadź wartość",
+      "successToast": "Wartości zostały pomyślnie utworzone."
+    },
+    "deletePossibleValue": {
+      "title": "Usuń wartość",
+      "confirmation": "Masz zamiar usunąć możliwą wartość \"{{value}}\". Tej akcji nie można cofnąć.",
+      "successToast": "Możliwa wartość \"{{value}}\" została pomyślnie usunięta.",
+      "inUseMessage": "Nie można usunąć wartości {{value}}, ponieważ jest obecnie używana przez jednego lub więcej sprzedawców w ich wariantach produktów. Aby ją edytować, poproś sprzedawców o zaktualizowanie ich produktów."
+    },
+    "delete": {
+      "title": "Usuń atrybut",
+      "confirmation": "Masz zamiar usunąć atrybut \"{{name}}\". Tej akcji nie można cofnąć.",
+      "successToast": "Atrybut \"{{name}}\" został pomyślnie usunięty.",
+      "inUseMessage": "Nie można usunąć atrybutu {{name}}, ponieważ jest obecnie używany przez jednego lub więcej sprzedawców w ich wariantach produktów. Aby go usunąć, poproś sprzedawców o zaktualizowanie ich produktów.",
+      "gotIt": "Rozumiem"
+    },
+    "fields": {
+      "name": "Nazwa",
+      "handle": "Identyfikator",
+      "description": "Opis",
+      "type": "Typ",
+      "filterable": "Filtrowalny",
+      "required": "Wymagany",
+      "global": "Globalny",
+      "category": "Kategoria",
+      "categories": "Kategorie produktów",
+      "productAttribute": "Atrybut produktu",
+      "values": "Wartości",
+      "possibleValues": "Możliwe wartości",
+      "value": "Wartość",
+      "rank": "Pozycja",
+      "metadata": "Metadane"
+    },
+    "type": {
+      "select": "Pojedynczy wybór",
+      "multivalue": "Wielokrotny wybór",
+      "unit": "Jednostka",
+      "toggle": "Przełącznik",
+      "text_area": "Pole tekstowe"
+    },
+    "selectCategory": {
+      "title": "Wybierz kategorię",
+      "description": "Wybierz kategorię, do której ma zastosowanie ten atrybut.",
+      "placeholder": "Wybierz kategorię"
+    },
+    "hints": {
+      "global": "Po włączeniu ten atrybut dotyczy wszystkich produktów, niezależnie od kategorii.",
+      "categoryInheritance": "Podkategorie odziedziczą ten atrybut."
+    }
+  },
+  "refundReasons": {
+    "domain": "Powody zwrotów",
+    "subtitle": "Zarządzaj powodami zwrotów.",
+    "calloutHint": "Zarządzaj powodami, aby kategoryzować zwroty.",
+    "editReason": "Edytuj powód zwrotu",
+    "create": {
+      "header": "Dodaj powód zwrotu",
+      "subtitle": "Określ najczęstsze powody zwrotów.",
+      "hint": "Utwórz nowy powód zwrotu, aby kategoryzować zwroty.",
+      "successToast": "Powód zwrotu {{label}} został pomyślnie utworzony."
+    },
+    "edit": {
+      "header": "Edytuj powód zwrotu",
+      "subtitle": "Edytuj wartość powodu zwrotu.",
+      "successToast": "Powód zwrotu {{label}} został pomyślnie zaktualizowany."
+    },
+    "delete": {
+      "confirmation": "Zamierzasz usunąć powód zwrotu \"{{label}}\". Tej akcji nie można cofnąć.",
+      "successToast": "Powód zwrotu został pomyślnie usunięty."
+    },
+    "fields": {
+      "label": {
+        "label": "Etykieta",
+        "placeholder": "Gest dobrej woli"
+      },
+      "code": {
+        "label": "Kod",
+        "placeholder": "gest_dobrej_woli"
+      },
+      "description": {
+        "label": "Opis",
+        "placeholder": "Klient miał złe doświadczenie zakupowe"
+      }
+    }
   }
 }

--- a/packages/admin/src/pages/commission-rates/commission-rate-create/components/create-commission-rate-form/create-commission-rate-form.tsx
+++ b/packages/admin/src/pages/commission-rates/commission-rate-create/components/create-commission-rate-form/create-commission-rate-form.tsx
@@ -150,7 +150,7 @@ export const CreateCommissionRateForm = ({
       },
       {
         onSuccess: ({ commission_rate }) => {
-          toast.success("Commission rate created successfully");
+          toast.success(t("commissionRates.create.successToast"));
           handleSuccess(`../${commission_rate.id}`);
         },
         onError: (e) => {
@@ -309,9 +309,9 @@ export const CreateCommissionRateForm = ({
           >
             <div className="flex w-full max-w-[720px] flex-col gap-y-8">
               <div>
-                <Heading>Create Commission Rate</Heading>
+                <Heading>{t("commissionRates.create.header")}</Heading>
                 <Text size="small" className="text-ui-fg-subtle">
-                  Configure a new commission rate for your marketplace.
+                  {t("commissionRates.create.description")}
                 </Text>
               </div>
               <div className="flex flex-col gap-y-4">
@@ -321,7 +321,7 @@ export const CreateCommissionRateForm = ({
                     name="name"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>Name</Form.Label>
+                        <Form.Label>{t("commissionRates.fields.name")}</Form.Label>
                         <Form.Control>
                           <Input {...field} />
                         </Form.Control>
@@ -334,7 +334,7 @@ export const CreateCommissionRateForm = ({
                     name="code"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>Code</Form.Label>
+                        <Form.Label>{t("commissionRates.fields.code")}</Form.Label>
                         <Form.Control>
                           <Input {...field} />
                         </Form.Control>
@@ -349,7 +349,7 @@ export const CreateCommissionRateForm = ({
                     name="type"
                     render={({ field: { onChange, ref, ...field } }) => (
                       <Form.Item>
-                        <Form.Label>Type</Form.Label>
+                        <Form.Label>{t("commissionRates.fields.type.label")}</Form.Label>
                         <Form.Control>
                           <Select {...field} onValueChange={onChange}>
                             <Select.Trigger ref={ref}>
@@ -357,9 +357,11 @@ export const CreateCommissionRateForm = ({
                             </Select.Trigger>
                             <Select.Content>
                               <Select.Item value="percentage">
-                                Percentage
+                                {t("commissionRates.fields.type.percentage")}
                               </Select.Item>
-                              <Select.Item value="fixed">Fixed</Select.Item>
+                              <Select.Item value="fixed">
+                                {t("commissionRates.fields.type.fixed")}
+                              </Select.Item>
                             </Select.Content>
                           </Select>
                         </Form.Control>
@@ -372,16 +374,18 @@ export const CreateCommissionRateForm = ({
                     name="target"
                     render={({ field: { onChange, ref, ...field } }) => (
                       <Form.Item>
-                        <Form.Label>Target</Form.Label>
+                        <Form.Label>{t("commissionRates.fields.target.label")}</Form.Label>
                         <Form.Control>
                           <Select {...field} onValueChange={onChange}>
                             <Select.Trigger ref={ref}>
                               <Select.Value />
                             </Select.Trigger>
                             <Select.Content>
-                              <Select.Item value="item">Item</Select.Item>
+                              <Select.Item value="item">
+                                {t("commissionRates.fields.target.item")}
+                              </Select.Item>
                               <Select.Item value="shipping">
-                                Shipping
+                                {t("commissionRates.fields.target.shipping")}
                               </Select.Item>
                             </Select.Content>
                           </Select>
@@ -397,11 +401,11 @@ export const CreateCommissionRateForm = ({
                     name="currency_code"
                     render={({ field: { onChange, ref, ...field } }) => (
                       <Form.Item>
-                        <Form.Label>Currency Code</Form.Label>
+                        <Form.Label>{t("commissionRates.fields.currencyCode")}</Form.Label>
                         <Form.Control>
                           <Select {...field} onValueChange={onChange}>
                             <Select.Trigger ref={ref}>
-                              <Select.Value placeholder="Select currency" />
+                              <Select.Value placeholder={t("commissionRates.fields.currencyPlaceholder")} />
                             </Select.Trigger>
                             <Select.Content>
                               {storeCurrencies.map((currency) => (
@@ -424,7 +428,7 @@ export const CreateCommissionRateForm = ({
                     name="value"
                     render={({ field: { value, onChange, ...field } }) => (
                       <Form.Item>
-                        <Form.Label>Rate</Form.Label>
+                        <Form.Label>{t("commissionRates.fields.rate")}</Form.Label>
                         <Form.Control>
                           {watchType === "percentage" ? (
                             <PercentageInput
@@ -463,7 +467,7 @@ export const CreateCommissionRateForm = ({
                     name="min_amount"
                     render={({ field: { value, onChange, ...field } }) => (
                       <Form.Item>
-                        <Form.Label>Minimum Amount</Form.Label>
+                        <Form.Label>{t("commissionRates.fields.minAmount")}</Form.Label>
                         <Form.Control>
                           <CurrencyInput
                             min={0}
@@ -489,7 +493,7 @@ export const CreateCommissionRateForm = ({
                     name="priority"
                     render={({ field }) => (
                       <Form.Item>
-                        <Form.Label>Priority</Form.Label>
+                        <Form.Label>{t("commissionRates.fields.priority")}</Form.Label>
                         <Form.Control>
                           <Input type="number" {...field} />
                         </Form.Control>
@@ -505,7 +509,7 @@ export const CreateCommissionRateForm = ({
                 render={({ field: { value, onChange, ...field } }) => (
                   <Form.Item>
                     <div className="flex items-start justify-between">
-                      <Form.Label>Enabled</Form.Label>
+                      <Form.Label>{t("commissionRates.fields.enabled")}</Form.Label>
                       <Form.Control>
                         <Switch
                           {...field}
@@ -515,7 +519,7 @@ export const CreateCommissionRateForm = ({
                       </Form.Control>
                     </div>
                     <Form.Hint>
-                      Enable or disable this commission rate.
+                      {t("commissionRates.fields.enabledHint")}
                     </Form.Hint>
                     <Form.ErrorMessage />
                   </Form.Item>
@@ -527,7 +531,7 @@ export const CreateCommissionRateForm = ({
                 render={({ field: { value, onChange, ...field } }) => (
                   <Form.Item>
                     <div className="flex items-start justify-between">
-                      <Form.Label>Include Tax</Form.Label>
+                      <Form.Label>{t("commissionRates.fields.includeTax")}</Form.Label>
                       <Form.Control>
                         <Switch
                           {...field}
@@ -537,7 +541,7 @@ export const CreateCommissionRateForm = ({
                       </Form.Control>
                     </div>
                     <Form.Hint>
-                      Include tax in the commission calculation.
+                      {t("commissionRates.fields.includeTaxHint")}
                     </Form.Hint>
                     <Form.ErrorMessage />
                   </Form.Item>

--- a/packages/admin/src/pages/commission-rates/commission-rate-detail/components/commission-rate-general-section/commission-rate-general-section.tsx
+++ b/packages/admin/src/pages/commission-rates/commission-rate-detail/components/commission-rate-general-section/commission-rate-general-section.tsx
@@ -15,6 +15,8 @@ type CommissionRateGeneralSectionProps = {
 export const CommissionRateGeneralSection = ({
   commissionRate,
 }: CommissionRateGeneralSectionProps) => {
+  const { t } = useTranslation()
+
   const formatValue = () => {
     if (commissionRate.type === "percentage") {
       return `${commissionRate.value}%`
@@ -30,13 +32,15 @@ export const CommissionRateGeneralSection = ({
         <Heading>{commissionRate.name}</Heading>
         <div className="flex items-center gap-4">
           <StatusBadge color={commissionRate.is_enabled ? "green" : "grey"}>
-            {commissionRate.is_enabled ? "Enabled" : "Disabled"}
+            {commissionRate.is_enabled
+              ? t("commissionRates.status.enabled")
+              : t("commissionRates.status.disabled")}
           </StatusBadge>
           <CommissionRateActions commissionRate={commissionRate} />
         </div>
       </div>
       <SectionRow
-        title="Code"
+        title={t("commissionRates.fields.code")}
         value={
           <Badge size="2xsmall" className="uppercase">
             {commissionRate.code}
@@ -44,29 +48,38 @@ export const CommissionRateGeneralSection = ({
         }
       />
       <SectionRow
-        title="Type"
+        title={t("commissionRates.fields.type.label")}
         value={
           <Badge
             size="2xsmall"
             color={commissionRate.type === "percentage" ? "blue" : "grey"}
           >
-            {commissionRate.type === "percentage" ? "Percentage" : "Fixed"}
+            {commissionRate.type === "percentage"
+              ? t("commissionRates.fields.type.percentage")
+              : t("commissionRates.fields.type.fixed")}
           </Badge>
         }
       />
-      <SectionRow title="Value" value={formatValue()} />
+      <SectionRow title={t("fields.value")} value={formatValue()} />
       <SectionRow
-        title="Target"
-        value={commissionRate.target === "item" ? "Item" : "Shipping"}
+        title={t("commissionRates.fields.target.label")}
+        value={
+          commissionRate.target === "item"
+            ? t("commissionRates.fields.target.item")
+            : t("commissionRates.fields.target.shipping")
+        }
       />
       <SectionRow
-        title="Include Tax"
-        value={commissionRate.include_tax ? "Yes" : "No"}
+        title={t("commissionRates.fields.includeTax")}
+        value={commissionRate.include_tax ? t("general.yes") : t("general.no")}
       />
-      <SectionRow title="Priority" value={String(commissionRate.priority)} />
+      <SectionRow
+        title={t("commissionRates.fields.priority")}
+        value={String(commissionRate.priority)}
+      />
       {commissionRate.min_amount != null && (
         <SectionRow
-          title="Minimum Amount"
+          title={t("commissionRates.fields.minAmount")}
           value={
             commissionRate.currency_code
               ? `${commissionRate.min_amount} ${commissionRate.currency_code.toUpperCase()}`
@@ -97,8 +110,8 @@ const CommissionRateActions = ({
         onSuccess: () => {
           toast.success(
             newEnabled
-              ? "Commission rate enabled successfully"
-              : "Commission rate disabled successfully"
+              ? t("commissionRates.toggle.enabledToast")
+              : t("commissionRates.toggle.disabledToast")
           )
         },
         onError: (e) => {
@@ -111,7 +124,9 @@ const CommissionRateActions = ({
   const handleDelete = async () => {
     const res = await prompt({
       title: t("general.areYouSure"),
-      description: `Are you sure you want to delete the commission rate "${commissionRate.name}"?`,
+      description: t("commissionRates.delete.description", {
+        name: commissionRate.name,
+      }),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
     })
@@ -122,7 +137,7 @@ const CommissionRateActions = ({
 
     await mutateAsync(undefined, {
       onSuccess: () => {
-        toast.success("Commission rate deleted successfully")
+        toast.success(t("commissionRates.delete.successToast"))
         navigate("/settings/commission-rates", { replace: true })
       },
       onError: (e) => {

--- a/packages/admin/src/pages/commission-rates/commission-rate-detail/components/commission-rate-rules-section/commission-rate-rules-section.tsx
+++ b/packages/admin/src/pages/commission-rates/commission-rate-detail/components/commission-rate-rules-section/commission-rate-rules-section.tsx
@@ -48,7 +48,7 @@ export const CommissionRateRulesSection = ({
       {entries.length === 0 ? (
         <div className="flex items-center justify-center px-6 py-8">
           <Text size="small" className="text-ui-fg-subtle">
-            No rules configured
+            {t("commissionRates.rules.empty")}
           </Text>
         </div>
       ) : (

--- a/packages/admin/src/pages/commission-rates/commission-rate-edit/commission-rate-edit.tsx
+++ b/packages/admin/src/pages/commission-rates/commission-rate-edit/commission-rate-edit.tsx
@@ -1,4 +1,5 @@
 import { Heading } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 
 import { RouteDrawer } from "../../../components/modals"
@@ -6,6 +7,7 @@ import { useCommissionRate } from "../../../hooks/api/commission-rates"
 import { EditCommissionRateForm } from "./components/edit-commission-rate-form"
 
 export const CommissionRateEdit = () => {
+  const { t } = useTranslation()
   const { id } = useParams()
 
   const {
@@ -22,7 +24,7 @@ export const CommissionRateEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>Edit Commission Rate</Heading>
+        <Heading>{t("commissionRates.edit.header")}</Heading>
       </RouteDrawer.Header>
       {!isLoading && commission_rate && (
         <EditCommissionRateForm commissionRate={commission_rate} />

--- a/packages/admin/src/pages/commission-rates/commission-rate-edit/components/edit-commission-rate-form/edit-commission-rate-form.tsx
+++ b/packages/admin/src/pages/commission-rates/commission-rate-edit/components/edit-commission-rate-form/edit-commission-rate-form.tsx
@@ -196,7 +196,7 @@ export const EditCommissionRateForm = ({
         });
       }
 
-      toast.success("Commission rate updated successfully");
+      toast.success(t("commissionRates.edit.successToast"));
       handleSuccess();
     } catch (e: any) {
       toast.error(e.message);
@@ -362,7 +362,7 @@ export const EditCommissionRateForm = ({
               name="name"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>Name</Form.Label>
+                  <Form.Label>{t("commissionRates.fields.name")}</Form.Label>
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>
@@ -375,7 +375,7 @@ export const EditCommissionRateForm = ({
               name="code"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>Code</Form.Label>
+                  <Form.Label>{t("commissionRates.fields.code")}</Form.Label>
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>
@@ -388,15 +388,19 @@ export const EditCommissionRateForm = ({
               name="type"
               render={({ field: { onChange, ref, ...field } }) => (
                 <Form.Item>
-                  <Form.Label>Type</Form.Label>
+                  <Form.Label>{t("commissionRates.fields.type.label")}</Form.Label>
                   <Form.Control>
                     <Select {...field} onValueChange={onChange}>
                       <Select.Trigger ref={ref}>
                         <Select.Value />
                       </Select.Trigger>
                       <Select.Content>
-                        <Select.Item value="percentage">Percentage</Select.Item>
-                        <Select.Item value="fixed">Fixed</Select.Item>
+                        <Select.Item value="percentage">
+                          {t("commissionRates.fields.type.percentage")}
+                        </Select.Item>
+                        <Select.Item value="fixed">
+                          {t("commissionRates.fields.type.fixed")}
+                        </Select.Item>
                       </Select.Content>
                     </Select>
                   </Form.Control>
@@ -409,15 +413,19 @@ export const EditCommissionRateForm = ({
               name="target"
               render={({ field: { onChange, ref, ...field } }) => (
                 <Form.Item>
-                  <Form.Label>Target</Form.Label>
+                  <Form.Label>{t("commissionRates.fields.target.label")}</Form.Label>
                   <Form.Control>
                     <Select {...field} onValueChange={onChange}>
                       <Select.Trigger ref={ref}>
                         <Select.Value />
                       </Select.Trigger>
                       <Select.Content>
-                        <Select.Item value="item">Item</Select.Item>
-                        <Select.Item value="shipping">Shipping</Select.Item>
+                        <Select.Item value="item">
+                          {t("commissionRates.fields.target.item")}
+                        </Select.Item>
+                        <Select.Item value="shipping">
+                          {t("commissionRates.fields.target.shipping")}
+                        </Select.Item>
                       </Select.Content>
                     </Select>
                   </Form.Control>
@@ -430,11 +438,11 @@ export const EditCommissionRateForm = ({
               name="currency_code"
               render={({ field: { onChange, ref, ...field } }) => (
                 <Form.Item>
-                  <Form.Label>Currency Code</Form.Label>
+                  <Form.Label>{t("commissionRates.fields.currencyCode")}</Form.Label>
                   <Form.Control>
                     <Select {...field} onValueChange={onChange}>
                       <Select.Trigger ref={ref}>
-                        <Select.Value placeholder="Select currency" />
+                        <Select.Value placeholder={t("commissionRates.fields.currencyPlaceholder")} />
                       </Select.Trigger>
                       <Select.Content>
                         {storeCurrencies.map((currency) => (
@@ -457,7 +465,7 @@ export const EditCommissionRateForm = ({
               name="value"
               render={({ field: { value, onChange, ...field } }) => (
                 <Form.Item>
-                  <Form.Label>Rate</Form.Label>
+                  <Form.Label>{t("commissionRates.fields.rate")}</Form.Label>
                   <Form.Control>
                     {watchType === "percentage" ? (
                       <PercentageInput
@@ -492,7 +500,7 @@ export const EditCommissionRateForm = ({
               name="min_amount"
               render={({ field: { value, onChange, ...field } }) => (
                 <Form.Item>
-                  <Form.Label>Minimum Amount</Form.Label>
+                  <Form.Label>{t("commissionRates.fields.minAmount")}</Form.Label>
                   <Form.Control>
                     <CurrencyInput
                       min={0}
@@ -516,7 +524,7 @@ export const EditCommissionRateForm = ({
               name="priority"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>Priority</Form.Label>
+                  <Form.Label>{t("commissionRates.fields.priority")}</Form.Label>
                   <Form.Control>
                     <Input type="number" {...field} />
                   </Form.Control>
@@ -530,7 +538,7 @@ export const EditCommissionRateForm = ({
               render={({ field: { value, onChange, ...field } }) => (
                 <Form.Item>
                   <div className="flex items-start justify-between">
-                    <Form.Label>Include Tax</Form.Label>
+                    <Form.Label>{t("commissionRates.fields.includeTax")}</Form.Label>
                     <Form.Control>
                       <Switch
                         {...field}

--- a/packages/admin/src/pages/commission-rates/commission-rate-list/components/commission-rate-list-table/commission-rate-list-table.tsx
+++ b/packages/admin/src/pages/commission-rates/commission-rate-list/components/commission-rate-list-table/commission-rate-list-table.tsx
@@ -64,9 +64,9 @@ export const CommissionRateListTable = () => {
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
         <div>
-          <Heading>Commission Rates</Heading>
+          <Heading>{t("commissionRates.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">
-            Manage commission rates and rules for your marketplace.
+            {t("commissionRates.description")}
           </Text>
         </div>
         <Link to="/settings/commission-rates/create">
@@ -85,7 +85,7 @@ export const CommissionRateListTable = () => {
         pagination
         search
         orderBy={[
-          { key: "name", label: "Name" },
+          { key: "name", label: t("commissionRates.fields.name") },
           { key: "created_at", label: t("fields.createdAt") },
           { key: "updated_at", label: t("fields.updatedAt") },
         ]}
@@ -106,7 +106,9 @@ const CommissionRateActions = ({
   const handleDelete = async () => {
     const res = await prompt({
       title: t("general.areYouSure"),
-      description: `Are you sure you want to delete the commission rate "${commissionRate.name}"?`,
+      description: t("commissionRates.delete.description", {
+        name: commissionRate.name,
+      }),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
     })
@@ -117,7 +119,7 @@ const CommissionRateActions = ({
 
     await mutateAsync(undefined, {
       onSuccess: () => {
-        toast.success("Commission rate deleted successfully")
+        toast.success(t("commissionRates.delete.successToast"))
       },
       onError: (e) => {
         toast.error(e.message)
@@ -154,10 +156,12 @@ const CommissionRateActions = ({
 const columnHelper = createColumnHelper<CommissionRateDTO>()
 
 const useColumns = () => {
+  const { t } = useTranslation()
+
   return useMemo(
     () => [
       columnHelper.accessor("code", {
-        header: "Code",
+        header: t("commissionRates.fields.code"),
         cell: ({ getValue }) => (
           <Badge size="2xsmall" className="uppercase">
             {getValue()}
@@ -165,19 +169,29 @@ const useColumns = () => {
         ),
       }),
       columnHelper.accessor("type", {
-        header: () => <TextHeader text="Type" />,
+        header: () => <TextHeader text={t("commissionRates.fields.type.label")} />,
         cell: ({ getValue }) => {
           const type = getValue()
-          return <TextCell text={type === "percentage" ? "Percentage" : "Fixed"} />
+          return (
+            <TextCell
+              text={
+                type === "percentage"
+                  ? t("commissionRates.fields.type.percentage")
+                  : t("commissionRates.fields.type.fixed")
+              }
+            />
+          )
         },
       }),
       columnHelper.accessor("is_enabled", {
-        header: "Status",
+        header: t("fields.status"),
         cell: ({ getValue }) => {
           const enabled = getValue()
           return (
             <StatusBadge color={enabled ? "green" : "grey"}>
-              {enabled ? "Enabled" : "Disabled"}
+              {enabled
+                ? t("commissionRates.status.enabled")
+                : t("commissionRates.status.disabled")}
             </StatusBadge>
           )
         },
@@ -189,6 +203,6 @@ const useColumns = () => {
         ),
       }),
     ],
-    []
+    [t]
   )
 }

--- a/packages/admin/src/pages/commission-rates/commission-rate-list/components/commission-rate-list-view/commission-rate-list-data-table.tsx
+++ b/packages/admin/src/pages/commission-rates/commission-rate-list/components/commission-rate-list-view/commission-rate-list-data-table.tsx
@@ -66,7 +66,7 @@ export const CommissionRateListDataTable = () => {
       pagination
       search
       orderBy={[
-        { key: "name", label: "Name" },
+        { key: "name", label: t("commissionRates.fields.name") },
         { key: "created_at", label: t("fields.createdAt") },
         { key: "updated_at", label: t("fields.updatedAt") },
       ]}
@@ -86,7 +86,9 @@ const CommissionRateActions = ({
   const handleDelete = async () => {
     const res = await prompt({
       title: t("general.areYouSure"),
-      description: `Are you sure you want to delete the commission rate "${commissionRate.name}"?`,
+      description: t("commissionRates.delete.description", {
+        name: commissionRate.name,
+      }),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
     })
@@ -97,7 +99,7 @@ const CommissionRateActions = ({
 
     await mutateAsync(undefined, {
       onSuccess: () => {
-        toast.success("Commission rate deleted successfully")
+        toast.success(t("commissionRates.delete.successToast"))
       },
       onError: (e) => {
         toast.error(e.message)
@@ -134,10 +136,12 @@ const CommissionRateActions = ({
 const columnHelper = createColumnHelper<CommissionRateDTO>()
 
 const useColumns = () => {
+  const { t } = useTranslation()
+
   return useMemo(
     () => [
       columnHelper.accessor("code", {
-        header: "Code",
+        header: t("commissionRates.fields.code"),
         cell: ({ getValue }) => (
           <Badge size="2xsmall" className="uppercase">
             {getValue()}
@@ -145,19 +149,29 @@ const useColumns = () => {
         ),
       }),
       columnHelper.accessor("type", {
-        header: () => <TextHeader text="Type" />,
+        header: () => <TextHeader text={t("commissionRates.fields.type.label")} />,
         cell: ({ getValue }) => {
           const type = getValue()
-          return <TextCell text={type === "percentage" ? "Percentage" : "Fixed"} />
+          return (
+            <TextCell
+              text={
+                type === "percentage"
+                  ? t("commissionRates.fields.type.percentage")
+                  : t("commissionRates.fields.type.fixed")
+              }
+            />
+          )
         },
       }),
       columnHelper.accessor("is_enabled", {
-        header: "Status",
+        header: t("fields.status"),
         cell: ({ getValue }) => {
           const enabled = getValue()
           return (
             <StatusBadge color={enabled ? "green" : "grey"}>
-              {enabled ? "Enabled" : "Disabled"}
+              {enabled
+                ? t("commissionRates.status.enabled")
+                : t("commissionRates.status.disabled")}
             </StatusBadge>
           )
         },
@@ -169,6 +183,6 @@ const useColumns = () => {
         ),
       }),
     ],
-    []
+    [t]
   )
 }

--- a/packages/admin/src/pages/commission-rates/commission-rate-list/components/commission-rate-list-view/commission-rate-list-header.tsx
+++ b/packages/admin/src/pages/commission-rates/commission-rate-list/components/commission-rate-list-view/commission-rate-list-header.tsx
@@ -4,11 +4,12 @@ import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
 export const CommissionRateListTitle = () => {
+  const { t } = useTranslation()
   return (
     <div>
-      <Heading>Commission Rates</Heading>
+      <Heading>{t("commissionRates.domain")}</Heading>
       <Text className="text-ui-fg-subtle" size="small">
-        Manage commission rates and rules for your marketplace.
+        {t("commissionRates.description")}
       </Text>
     </div>
   )

--- a/packages/admin/src/pages/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/admin/src/pages/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -229,22 +229,22 @@ const Fulfillment = ({
 
   let statusText = fulfillment.requires_shipping
     ? isPickUpFulfillment
-      ? "Awaiting pickup"
-      : "Awaiting shipping"
-    : "Awaiting delivery"
+      ? t("orders.fulfillment.status.awaitingPickup")
+      : t("orders.fulfillment.status.awaitingShipping")
+    : t("orders.fulfillment.status.awaitingDelivery")
   let statusColor: "blue" | "green" | "red" = "blue"
   let statusTimestamp = fulfillment.created_at
 
   if (fulfillment.canceled_at) {
-    statusText = "Canceled"
+    statusText = t("orders.fulfillment.status.canceled")
     statusColor = "red"
     statusTimestamp = fulfillment.canceled_at
   } else if (fulfillment.delivered_at) {
-    statusText = "Delivered"
+    statusText = t("orders.fulfillment.status.delivered")
     statusColor = "green"
     statusTimestamp = fulfillment.delivered_at
   } else if (fulfillment.shipped_at) {
-    statusText = "Shipped"
+    statusText = t("orders.fulfillment.status.shipped")
     statusColor = "green"
     statusTimestamp = fulfillment.shipped_at
   }
@@ -439,7 +439,7 @@ const Fulfillment = ({
                           className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover transition-fg"
                         >
                           <Text size="small" leading="compact" as="span">
-                            Label
+                            {t("orders.fulfillment.labelLink")}
                           </Text>
                         </a>
                       )}

--- a/packages/admin/src/pages/orders/order-list/components/order-list-table/order-list-data-table.tsx
+++ b/packages/admin/src/pages/orders/order-list/components/order-list-table/order-list-data-table.tsx
@@ -48,7 +48,10 @@ export type OrderGroupRow = {
   children: OrderGroupRow[];
 };
 
-function transformOrderGroups(orderGroups: any[]): OrderGroupRow[] {
+function transformOrderGroups(
+  orderGroups: any[],
+  t: (key: string, options?: Record<string, unknown>) => string,
+): OrderGroupRow[] {
   return orderGroups.map((group) => {
     const orders = group.orders ?? [];
 
@@ -88,7 +91,7 @@ function transformOrderGroups(orderGroups: any[]): OrderGroupRow[] {
       id: group.id,
       display_id: `#G${group.display_id}`,
       order_ids: orderIds,
-      vendor: `${group.seller_count} vendors`,
+      vendor: t("orders.fields.vendorsCount", { count: group.seller_count }),
       created_at: new Date(group.created_at),
       updated_at: new Date(group.updated_at),
       customer_name: customerName,
@@ -119,8 +122,8 @@ export const OrderListDataTable = () => {
   );
 
   const rows = useMemo(
-    () => transformOrderGroups(order_groups ?? []),
-    [order_groups],
+    () => transformOrderGroups(order_groups ?? [], t),
+    [order_groups, t],
   );
 
   const filters = useOrderGroupTableFilters();
@@ -155,7 +158,7 @@ export const OrderListDataTable = () => {
       isLoading={isLoading}
       pageSize={PAGE_SIZE}
       orderBy={[
-        { key: "display_id", label: "Display ID" },
+        { key: "display_id", label: t("orders.fields.displayId") },
         { key: "created_at", label: t("fields.createdAt") },
         { key: "updated_at", label: t("fields.updatedAt") },
       ]}
@@ -175,7 +178,7 @@ const useColumns = () => {
   return useMemo(
     () => [
       columnHelper.accessor("display_id", {
-        header: () => <TextHeader text="Group ID" />,
+        header: () => <TextHeader text={t("orders.fields.groupId")} />,
         cell: ({ row, getValue }) => {
           if (row.original._type === "order") {
             return null;
@@ -213,7 +216,7 @@ const useColumns = () => {
         },
       }),
       columnHelper.accessor("order_ids", {
-        header: () => <TextHeader text="Order IDs" />,
+        header: () => <TextHeader text={t("orders.fields.orderIds")} />,
         cell: ({ row, getValue }) => {
           if (row.original._type === "group") {
             return <TextCell text={getValue()} />;
@@ -222,7 +225,7 @@ const useColumns = () => {
         },
       }),
       columnHelper.accessor("vendor", {
-        header: () => <TextHeader text="Vendor" />,
+        header: () => <TextHeader text={t("orders.fields.vendor")} />,
         cell: ({ getValue }) => <TextCell text={getValue()} />,
       }),
       columnHelper.accessor("created_at", {

--- a/packages/admin/src/pages/payouts/payout-detail/components/payout-general-section.tsx
+++ b/packages/admin/src/pages/payouts/payout-detail/components/payout-general-section.tsx
@@ -22,8 +22,9 @@ const payoutStatusColor = (status: string) => {
 export const PayoutGeneralSection = ({ payout }: { payout: PayoutDTO }) => {
   const { t } = useTranslation()
 
-  const statusText =
-    payout.status.charAt(0).toUpperCase() + payout.status.slice(1)
+  const statusText = t(`payouts.status.${payout.status}`, {
+    defaultValue: payout.status.charAt(0).toUpperCase() + payout.status.slice(1),
+  })
 
   return (
     <Container className="divide-y p-0">

--- a/packages/admin/src/pages/payouts/payout-list/payout-list.tsx
+++ b/packages/admin/src/pages/payouts/payout-list/payout-list.tsx
@@ -14,8 +14,10 @@ import { PayoutDTO } from "@mercurjs/types"
 const PAGE_SIZE = 10
 
 export const PayoutListTitle = () => {
+  const { t } = useTranslation()
+
   return (
-    <Heading level="h2">Payouts</Heading>
+    <Heading level="h2">{t("payouts.domain")}</Heading>
   )
 }
 
@@ -86,7 +88,7 @@ export const PayoutListDataTable = () => {
       ]}
       queryObject={raw}
       noRecords={{
-        message: "No payouts found",
+        message: t("payouts.list.empty"),
       }}
     />
   )

--- a/packages/admin/src/pages/products/product-detail/components/product-seller-section/product-seller-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-seller-section/product-seller-section.tsx
@@ -1,6 +1,7 @@
 import { TriangleRightMini } from "@medusajs/icons";
 import { Avatar, Container, Heading } from "@medusajs/ui";
 import { SellerDTO } from "@mercurjs/types";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 
 type ProductSellerSectionProps = {
@@ -8,6 +9,8 @@ type ProductSellerSectionProps = {
 };
 
 export const ProductSellerSection = ({ seller }: ProductSellerSectionProps) => {
+  const { t } = useTranslation();
+
   if (!seller) {
     return null;
   }
@@ -15,7 +18,7 @@ export const ProductSellerSection = ({ seller }: ProductSellerSectionProps) => {
   return (
     <Container className="p-0">
       <div className="flex items-center justify-between px-6 py-4">
-        <Heading level="h2">Associated Store</Heading>
+        <Heading level="h2">{t("products.associatedStore")}</Heading>
       </div>
       <div className="txt-small flex flex-col gap-2 px-2 pb-2">
         <Link

--- a/packages/admin/src/pages/products/product-list/components/product-list-table/product-list-table.tsx
+++ b/packages/admin/src/pages/products/product-list/components/product-list-table/product-list-table.tsx
@@ -269,6 +269,7 @@ const ProductActions = ({ product }: { product: HttpTypes.AdminProduct }) => {
 const columnHelper = createColumnHelper<HttpTypes.AdminProduct>();
 
 const useColumns = () => {
+  const { t } = useTranslation();
   const base = useProductTableColumns();
 
   const columns = useMemo(
@@ -276,7 +277,7 @@ const useColumns = () => {
       ...base,
       columnHelper.display({
         id: "seller",
-        header: "Seller",
+        header: t("store.domain"),
         cell: ({ row }) => {
           const seller = (row.original as any).seller;
           return seller?.name || "-";
@@ -297,7 +298,7 @@ const useColumns = () => {
         },
       }),
     ],
-    [base],
+    [base, t],
   );
 
   return columns;

--- a/packages/admin/src/pages/stores/store-list/components/store-list-table/store-list-data-table.tsx
+++ b/packages/admin/src/pages/stores/store-list/components/store-list-table/store-list-data-table.tsx
@@ -68,7 +68,7 @@ export const StoreListDataTable = () => {
       pagination
       navigateTo={(row) => `/stores/${row.original.id}`}
       orderBy={[
-        { key: "name", label: t("stores.fields.name") },
+        { key: "name", label: t("stores.fields.seller") },
         { key: "email", label: t("stores.fields.email") },
         { key: "created_at", label: t("fields.createdAt") },
       ]}

--- a/packages/core/.mercur/_generated/index.ts
+++ b/packages/core/.mercur/_generated/index.ts
@@ -142,7 +142,7 @@ export type Routes = {
             $id: typeof import("@medusajs/medusa/api/admin/invites/[id]/route") & {
                 resend: typeof import("@medusajs/medusa/api/admin/invites/[id]/resend/route");
             };
-            accept: typeof import("@medusajs/medusa/api/admin/invites/accept/route");
+            accept: typeof import("@mercurjs/core-plugin/api/admin/invites/accept/route");
         };
         locales: typeof import("@medusajs/medusa/api/admin/locales/route") & {
             $code: typeof import("@medusajs/medusa/api/admin/locales/[code]/route");
@@ -427,6 +427,7 @@ export type Routes = {
             $id: typeof import("../../src/api/admin/payouts/[id]/route");
         };
         sellers: typeof import("../../src/api/admin/sellers/route") & {
+            invite: typeof import("@mercurjs/core-plugin/api/admin/sellers/invite/route");
             $id: typeof import("../../src/api/admin/sellers/[id]/route") & {
                 address: typeof import("../../src/api/admin/sellers/[id]/address/route");
                 approve: typeof import("../../src/api/admin/sellers/[id]/approve/route");

--- a/packages/core/src/api/admin/sellers/validators.ts
+++ b/packages/core/src/api/admin/sellers/validators.ts
@@ -3,8 +3,10 @@ import {
   createFindParams,
   createOperatorMap,
   createSelectParams,
+  WithAdditionalData,
 } from "@medusajs/medusa/api/utils/validators"
 import { booleanString } from "@medusajs/medusa/api/utils/common-validators/common"
+import { AdditionalData } from "@medusajs/framework/types"
 import { SellerRole } from "@mercurjs/types"
 
 export type AdminGetSellerParamsType = z.infer<typeof AdminGetSellerParams>
@@ -48,8 +50,8 @@ export const AdminGetSellerProductsParams = createFindParams({
   })
 )
 
-export type AdminCreateSellerType = z.infer<typeof AdminCreateSeller>
-export const AdminCreateSeller = z.object({
+export type AdminCreateSellerType = z.infer<typeof CreateSeller> & AdditionalData
+export const CreateSeller = z.object({
   name: z.string(),
   handle: z.string().optional(),
   email: z.string().email(),
@@ -71,9 +73,10 @@ export const AdminCreateSeller = z.object({
     email: z.string().email(),
   }),
 })
+export const AdminCreateSeller = WithAdditionalData(CreateSeller)
 
-export type AdminUpdateSellerType = z.infer<typeof AdminUpdateSeller>
-export const AdminUpdateSeller = z.object({
+export type AdminUpdateSellerType = z.infer<typeof UpdateSeller> & AdditionalData
+export const UpdateSeller = z.object({
   name: z.string().optional(),
   handle: z.string().optional(),
   email: z.string().email().optional(),
@@ -91,6 +94,7 @@ export const AdminUpdateSeller = z.object({
   closure_note: z.string().nullable().optional(),
   metadata: z.record(z.unknown()).nullable().optional(),
 })
+export const AdminUpdateSeller = WithAdditionalData(UpdateSeller)
 
 export type AdminSuspendSellerType = z.infer<typeof AdminSuspendSeller>
 export const AdminSuspendSeller = z.object({
@@ -116,10 +120,8 @@ export const AdminInviteSellerMember = z.object({
   role_id: z.nativeEnum(SellerRole),
 })
 
-export type AdminUpsertSellerAddressType = z.infer<
-  typeof AdminUpsertSellerAddress
->
-export const AdminUpsertSellerAddress = z.object({
+export type AdminUpsertSellerAddressType = z.infer<typeof UpsertSellerAddress> & AdditionalData
+export const UpsertSellerAddress = z.object({
   name: z.string().nullable().optional(),
   company: z.string().nullable().optional(),
   first_name: z.string().nullable().optional(),
@@ -133,11 +135,10 @@ export const AdminUpsertSellerAddress = z.object({
   phone: z.string().nullable().optional(),
   metadata: z.record(z.unknown()).nullable().optional(),
 })
+export const AdminUpsertSellerAddress = WithAdditionalData(UpsertSellerAddress)
 
-export type AdminUpsertSellerPaymentDetailsType = z.infer<
-  typeof AdminUpsertSellerPaymentDetails
->
-export const AdminUpsertSellerPaymentDetails = z.object({
+export type AdminUpsertSellerPaymentDetailsType = z.infer<typeof UpsertSellerPaymentDetails> & AdditionalData
+export const UpsertSellerPaymentDetails = z.object({
   country_code: z.string().optional(),
   holder_name: z.string().optional(),
   bank_name: z.string().nullable().optional(),
@@ -146,12 +147,12 @@ export const AdminUpsertSellerPaymentDetails = z.object({
   routing_number: z.string().nullable().optional(),
   account_number: z.string().nullable().optional(),
 })
+export const AdminUpsertSellerPaymentDetails = WithAdditionalData(UpsertSellerPaymentDetails)
 
-export type AdminUpsertSellerProfessionalDetailsType = z.infer<
-  typeof AdminUpsertSellerProfessionalDetails
->
-export const AdminUpsertSellerProfessionalDetails = z.object({
+export type AdminUpsertSellerProfessionalDetailsType = z.infer<typeof UpsertSellerProfessionalDetails> & AdditionalData
+export const UpsertSellerProfessionalDetails = z.object({
   corporate_name: z.string().nullable().optional(),
   registration_number: z.string().nullable().optional(),
   tax_id: z.string().nullable().optional(),
 })
+export const AdminUpsertSellerProfessionalDetails = WithAdditionalData(UpsertSellerProfessionalDetails)

--- a/packages/core/src/api/vendor/sellers/validators.ts
+++ b/packages/core/src/api/vendor/sellers/validators.ts
@@ -1,7 +1,9 @@
 import {
   createFindParams,
   createSelectParams,
+  WithAdditionalData,
 } from "@medusajs/medusa/api/utils/validators"
+import { AdditionalData } from "@medusajs/framework/types"
 import { SellerRole } from "@mercurjs/types"
 import { z } from "zod"
 
@@ -14,8 +16,8 @@ export const VendorGetSellersParams = createFindParams({
 export type VendorGetSellerParamsType = z.infer<typeof VendorGetSellerParams>
 export const VendorGetSellerParams = createSelectParams()
 
-export type VendorCreateSellerAccountType = z.infer<typeof VendorCreateSellerAccount>
-export const VendorCreateSellerAccount = z.object({
+export type VendorCreateSellerAccountType = z.infer<typeof CreateSellerAccount> & AdditionalData
+export const CreateSellerAccount = z.object({
   name: z.string(),
   handle: z.string().optional(),
   email: z.string().email(),
@@ -60,9 +62,10 @@ export const VendorCreateSellerAccount = z.object({
     .optional(),
   metadata: z.record(z.unknown()).nullable().optional(),
 })
+export const VendorCreateSellerAccount = WithAdditionalData(CreateSellerAccount)
 
-export type VendorUpdateSellerType = z.infer<typeof VendorUpdateSeller>
-export const VendorUpdateSeller = z.object({
+export type VendorUpdateSellerType = z.infer<typeof UpdateSeller> & AdditionalData
+export const UpdateSeller = z.object({
   name: z.string().optional(),
   handle: z.string().optional(),
   email: z.string().email().optional(),
@@ -76,6 +79,7 @@ export const VendorUpdateSeller = z.object({
   closure_note: z.string().nullable().optional(),
   metadata: z.record(z.unknown()).nullable().optional(),
 })
+export const VendorUpdateSeller = WithAdditionalData(UpdateSeller)
 
 export type VendorInviteMemberType = z.infer<typeof VendorInviteMember>
 export const VendorInviteMember = z.object({
@@ -88,8 +92,8 @@ export const VendorUpdateMemberRole = z.object({
   role_id: z.nativeEnum(SellerRole),
 })
 
-export type VendorUpsertSellerAddressType = z.infer<typeof VendorUpsertSellerAddress>
-export const VendorUpsertSellerAddress = z.object({
+export type VendorUpsertSellerAddressType = z.infer<typeof UpsertSellerAddress> & AdditionalData
+export const UpsertSellerAddress = z.object({
   name: z.string().nullable().optional(),
   company: z.string().nullable().optional(),
   first_name: z.string().nullable().optional(),
@@ -103,9 +107,10 @@ export const VendorUpsertSellerAddress = z.object({
   phone: z.string().nullable().optional(),
   metadata: z.record(z.unknown()).nullable().optional(),
 })
+export const VendorUpsertSellerAddress = WithAdditionalData(UpsertSellerAddress)
 
-export type VendorUpsertSellerPaymentDetailsType = z.infer<typeof VendorUpsertSellerPaymentDetails>
-export const VendorUpsertSellerPaymentDetails = z.object({
+export type VendorUpsertSellerPaymentDetailsType = z.infer<typeof UpsertSellerPaymentDetails> & AdditionalData
+export const UpsertSellerPaymentDetails = z.object({
   country_code: z.string().optional(),
   holder_name: z.string().optional(),
   bank_name: z.string().nullable().optional(),
@@ -114,13 +119,15 @@ export const VendorUpsertSellerPaymentDetails = z.object({
   routing_number: z.string().nullable().optional(),
   account_number: z.string().nullable().optional(),
 })
+export const VendorUpsertSellerPaymentDetails = WithAdditionalData(UpsertSellerPaymentDetails)
 
-export type VendorUpsertSellerProfessionalDetailsType = z.infer<typeof VendorUpsertSellerProfessionalDetails>
-export const VendorUpsertSellerProfessionalDetails = z.object({
+export type VendorUpsertSellerProfessionalDetailsType = z.infer<typeof UpsertSellerProfessionalDetails> & AdditionalData
+export const UpsertSellerProfessionalDetails = z.object({
   corporate_name: z.string().nullable().optional(),
   registration_number: z.string().nullable().optional(),
   tax_id: z.string().nullable().optional(),
 })
+export const VendorUpsertSellerProfessionalDetails = WithAdditionalData(UpsertSellerProfessionalDetails)
 
 export type VendorSelectSellerType = z.infer<typeof VendorSelectSeller>
 export const VendorSelectSeller = z.object({

--- a/packages/dashboard-sdk/src/types.ts
+++ b/packages/dashboard-sdk/src/types.ts
@@ -48,6 +48,25 @@ export interface MercurConfig {
         SettingsSidebar?: string
         TopbarActions?: string
         StoreSetup?: string
+        /**
+         * Component that injects additional fields into the vendor
+         * onboarding wizard's company step.
+         *
+         * The default export should be a React component that calls
+         * `useFormContext()` from react-hook-form and renders extra
+         * `<Form.Field />` entries. Values are forwarded to the
+         * create-seller mutation under the standard Medusa
+         * `additional_data` key.
+         *
+         * @example
+         * ```ts
+         * components: {
+         *   OnboardingCompanyExtraFields:
+         *     'components/onboarding/company-extra-fields',
+         * }
+         * ```
+         */
+        OnboardingCompanyExtraFields?: string
     },
     /** Internationalization settings. */
     i18n?: {

--- a/packages/vendor/src/components/inputs/country-select/country-select.tsx
+++ b/packages/vendor/src/components/inputs/country-select/country-select.tsx
@@ -3,6 +3,7 @@ import {
   ComponentType,
   forwardRef,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -15,14 +16,35 @@ type CountrySelectProps = ComponentPropsWithoutRef<typeof Select> & {
   onChange?: (value: string) => void;
 };
 
+const getDisplayNames = (language: string) => {
+  try {
+    return new Intl.DisplayNames([language], { type: "region" });
+  } catch {
+    return null;
+  }
+};
+
 export const CountrySelect: ComponentType<CountrySelectProps> = forwardRef<
   HTMLButtonElement,
   CountrySelectProps
 >(({ disabled, placeholder, defaultValue, onChange, ...field }, ref) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const innerRef = useRef<HTMLButtonElement>(null);
 
   useImperativeHandle(ref, () => innerRef.current as HTMLButtonElement);
+
+  const localizedCountries = useMemo(() => {
+    const displayNames = getDisplayNames(i18n.language);
+    const collator = new Intl.Collator(i18n.language, { sensitivity: "base" });
+
+    return countries
+      .map((country) => ({
+        ...country,
+        localized_name:
+          displayNames?.of(country.iso_2.toUpperCase()) ?? country.display_name,
+      }))
+      .sort((a, b) => collator.compare(a.localized_name, b.localized_name));
+  }, [i18n.language]);
 
   return (
     <div className="relative">
@@ -39,12 +61,12 @@ export const CountrySelect: ComponentType<CountrySelectProps> = forwardRef<
           />
         </Select.Trigger>
         <Select.Content>
-          {countries.map((country) => (
+          {localizedCountries.map((country) => (
             <Select.Item
               key={country.iso_2}
               value={country.iso_2.toLowerCase()}
             >
-              {country.display_name}
+              {country.localized_name}
             </Select.Item>
           ))}
         </Select.Content>

--- a/packages/vendor/src/components/layout/main-layout/main-layout.tsx
+++ b/packages/vendor/src/components/layout/main-layout/main-layout.tsx
@@ -318,7 +318,7 @@ export const useCoreRoutes = (): Omit<INavItem, "pathname">[] => {
     },
     {
       icon: <CreditCardRefresh />,
-      label: "Payouts",
+      label: t("payouts.domain"),
       to: "/payouts",
     },
   ];

--- a/packages/vendor/src/components/onboarding-wizard/hooks/use-onboarding.ts
+++ b/packages/vendor/src/components/onboarding-wizard/hooks/use-onboarding.ts
@@ -29,7 +29,14 @@ type CompanyData = {
   corporate_name?: string;
   registration_number?: string;
   tax_id?: string;
+  [key: string]: unknown;
 };
+
+const KNOWN_COMPANY_KEYS = new Set([
+  "corporate_name",
+  "registration_number",
+  "tax_id",
+]);
 
 type PaymentData = {
   country_code: string;
@@ -114,6 +121,18 @@ export const useOnboarding = (memberEmail: string) => {
         companyData?.registration_number ||
         companyData?.tax_id;
 
+      const companyExtras = companyData
+        ? Object.fromEntries(
+            Object.entries(companyData).filter(
+              ([key, value]) =>
+                !KNOWN_COMPANY_KEYS.has(key) &&
+                value !== undefined &&
+                value !== "",
+            ),
+          )
+        : {};
+      const hasCompanyExtras = Object.keys(companyExtras).length > 0;
+
       const isUS = paymentData?.country_code === "us";
 
       let registerDraft: { first_name?: string; last_name?: string } = {};
@@ -174,6 +193,7 @@ export const useOnboarding = (memberEmail: string) => {
                 account_number: paymentData.account_number || null,
               }
             : undefined,
+          additional_data: hasCompanyExtras ? companyExtras : undefined,
         });
 
         const newSellerId = result.seller.id;

--- a/packages/vendor/src/components/onboarding-wizard/steps/company-step.tsx
+++ b/packages/vendor/src/components/onboarding-wizard/steps/company-step.tsx
@@ -1,16 +1,20 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Heading, Input } from "@medusajs/ui";
+import { ComponentType } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import components from "virtual:mercur/components";
 import * as z from "zod";
 
 import { Form } from "@components/common/form";
 
-const CompanyStepSchema = z.object({
-  corporate_name: z.string().optional(),
-  registration_number: z.string().optional(),
-  tax_id: z.string().optional(),
-});
+const CompanyStepSchema = z
+  .object({
+    corporate_name: z.string().optional(),
+    registration_number: z.string().optional(),
+    tax_id: z.string().optional(),
+  })
+  .passthrough();
 
 type CompanyStepValues = z.infer<typeof CompanyStepSchema>;
 
@@ -19,6 +23,10 @@ type CompanyStepProps = {
   onSkip: () => void;
   isPending?: boolean;
 };
+
+const ExtraFields = components.OnboardingCompanyExtraFields as
+  | ComponentType
+  | undefined;
 
 export const CompanyStep = ({ onSubmit, onSkip, isPending }: CompanyStepProps) => {
   const { t } = useTranslation();
@@ -90,6 +98,7 @@ export const CompanyStep = ({ onSubmit, onSkip, isPending }: CompanyStepProps) =
                 </Form.Item>
               )}
             />
+            {ExtraFields && <ExtraFields />}
           </div>
           <div className="flex flex-col gap-y-2">
             <Button type="submit" className="w-full" isLoading={isPending}>

--- a/packages/vendor/src/get-route-map.tsx
+++ b/packages/vendor/src/get-route-map.tsx
@@ -252,12 +252,13 @@ export function getRouteMap({
                             lazy: () =>
                               import("./pages/orders/[id]/allocate-items"),
                           },
+                          {
+                            path: ":f_id/create-shipment",
+                            lazy: () =>
+                              import("./pages/orders/[id]/shipment"),
+                          },
                         ],
                       },
-                      // {
-                      //   path: "fulfillments/:f_id/shipment",
-                      //   lazy: () => import("./pages/orders/[id]/shipment"),
-                      // },
                     ],
                   },
                 ],

--- a/packages/vendor/src/hooks/table/columns/use-payout-table-columns.tsx
+++ b/packages/vendor/src/hooks/table/columns/use-payout-table-columns.tsx
@@ -38,7 +38,7 @@ export const usePayoutTableColumns = () => {
       columnHelper.accessor("display_id", {
         header: () => (
           <div className="flex h-full w-full items-center">
-            <span className="truncate">Payout</span>
+            <span className="truncate">{t("payouts.payout")}</span>
           </div>
         ),
         cell: ({ getValue }) => {
@@ -63,7 +63,9 @@ export const usePayoutTableColumns = () => {
           const status = getValue()
           return (
             <StatusBadge color={payoutStatusColor(status)}>
-              {status.charAt(0).toUpperCase() + status.slice(1)}
+              {t(`payouts.status.${status}`, {
+                defaultValue: status.charAt(0).toUpperCase() + status.slice(1),
+              })}
             </StatusBadge>
           )
         },

--- a/packages/vendor/src/hooks/table/filters/use-payout-table-filters.tsx
+++ b/packages/vendor/src/hooks/table/filters/use-payout-table-filters.tsx
@@ -15,11 +15,11 @@ export const usePayoutTableFilters = (): Filter[] => {
       type: "select",
       multiple: true,
       options: [
-        { label: "Pending", value: "pending" },
-        { label: "Processing", value: "processing" },
-        { label: "Paid", value: "paid" },
-        { label: "Failed", value: "failed" },
-        { label: "Canceled", value: "canceled" },
+        { label: t("payouts.status.pending"), value: "pending" },
+        { label: t("payouts.status.processing"), value: "processing" },
+        { label: t("payouts.status.paid"), value: "paid" },
+        { label: t("payouts.status.failed"), value: "failed" },
+        { label: t("payouts.status.canceled"), value: "canceled" },
       ],
     }
 

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -4271,6 +4271,12 @@
             "totalPaidByCustomer": {
               "type": "string"
             },
+            "totalPending": {
+              "type": "string"
+            },
+            "totalRefunded": {
+              "type": "string"
+            },
             "totalStoreCreditRefunds": {
               "type": "string"
             },
@@ -4375,6 +4381,8 @@
             "title",
             "isReadyToBeCaptured",
             "totalPaidByCustomer",
+            "totalPending",
+            "totalRefunded",
             "totalStoreCreditRefunds",
             "capture",
             "capture_short",
@@ -5184,6 +5192,12 @@
             "addTracking": {
               "type": "string"
             },
+            "addTrackingUrl": {
+              "type": "string"
+            },
+            "trackingUrlPlaceholder": {
+              "type": "string"
+            },
             "sendNotification": {
               "type": "string"
             },
@@ -5200,6 +5214,8 @@
             "trackingUrl",
             "labelUrl",
             "addTracking",
+            "addTrackingUrl",
+            "trackingUrlPlaceholder",
             "sendNotification",
             "sendNotificationHint",
             "toastCreated"
@@ -5338,6 +5354,15 @@
                 },
                 "requiresAction": {
                   "type": "string"
+                },
+                "awaitingPickup": {
+                  "type": "string"
+                },
+                "awaitingShipping": {
+                  "type": "string"
+                },
+                "awaitingDelivery": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -5351,7 +5376,10 @@
                 "partiallyReturned",
                 "returned",
                 "canceled",
-                "requiresAction"
+                "requiresAction",
+                "awaitingPickup",
+                "awaitingShipping",
+                "awaitingDelivery"
               ],
               "additionalProperties": false
             },

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -473,6 +473,11 @@
         "inventory": "Inventory kits",
         "attributes": "Attributes"
       },
+      "defaults": {
+        "optionTitle": "Default option",
+        "optionValue": "Default option value",
+        "variantTitle": "Default variant"
+      },
       "errors": {
         "variants": "Please select at least one variant.",
         "options": "Please create at least one option.",
@@ -490,6 +495,7 @@
       },
       "variants": {
         "header": "Variants",
+        "optionsHeader": "Options",
         "subHeadingTitle": "Yes, this is a product with variants",
         "subHeadingDescription": "When unchecked, we will create a default variant for you",
         "optionTitle": {
@@ -576,6 +582,9 @@
       }
     },
     "attributes": "Attributes",
+    "attributesSection": {
+      "removeWarning": "You are about to remove this attribute from the product. This action cannot be undone."
+    },
     "editAttributes": "Edit Attributes",
     "editOptions": "Edit Options",
     "editPrices": "Edit prices",
@@ -1252,6 +1261,8 @@
       "title": "Payments",
       "isReadyToBeCaptured": "Payment <0/> is ready to be captured.",
       "totalPaidByCustomer": "Total paid by customer",
+      "totalPending": "Total pending",
+      "totalRefunded": "Refunded",
       "totalStoreCreditRefunds": "Total store credit refunds",
       "capture": "Capture payment",
       "capture_short": "Capture",
@@ -1492,6 +1503,8 @@
       "trackingUrl": "Tracking URL",
       "labelUrl": "Label URL",
       "addTracking": "Add tracking number",
+      "addTrackingUrl": "Add tracking URL",
+      "trackingUrlPlaceholder": "https://www.dhl.com/shipment/1234567890",
       "sendNotification": "Send notification",
       "sendNotificationHint": "Notify the customer about this shipment.",
       "toastCreated": "Shipment created successfully."
@@ -1537,7 +1550,10 @@
         "partiallyReturned": "Partially returned",
         "returned": "Returned",
         "canceled": "Canceled",
-        "requiresAction": "Requires action"
+        "requiresAction": "Requires action",
+        "awaitingPickup": "Awaiting pickup",
+        "awaitingShipping": "Awaiting shipping",
+        "awaitingDelivery": "Awaiting delivery"
       },
       "toast": {
         "created": "Fulfillment created successfully",
@@ -2581,6 +2597,18 @@
         "placeholder": "Search for customer groups",
         "attribute": "Customer groups"
       }
+    }
+  },
+  "payouts": {
+    "domain": "Payouts",
+    "payout": "Payout",
+    "noRecords": "No payouts found",
+    "status": {
+      "pending": "Pending",
+      "processing": "Processing",
+      "paid": "Paid",
+      "failed": "Failed",
+      "canceled": "Canceled"
     }
   },
   "profile": {

--- a/packages/vendor/src/i18n/translations/pl.json
+++ b/packages/vendor/src/i18n/translations/pl.json
@@ -245,8 +245,8 @@
       "store": {
         "label": "Sklep",
         "storeSettings": "Ustawienia sklepu",
-        "editStore": "Edit Store",
-        "switchStore": "Switch store"
+        "editStore": "Edytuj sklep",
+        "switchStore": "Zmień sklep"
       },
       "actions": {
         "logout": "Wyloguj się"
@@ -425,12 +425,32 @@
         "details": "Szczegóły",
         "organize": "Organizacja",
         "variants": "Warianty",
-        "inventory": "Zestawy magazynowe"
+        "inventory": "Zestawy magazynowe",
+        "attributes": "Atrybuty"
+      },
+      "defaults": {
+        "optionTitle": "Domyślna opcja",
+        "optionValue": "Domyślna wartość opcji",
+        "variantTitle": "Domyślny wariant"
       },
       "errors": {
         "variants": "Wybierz co najmniej jeden wariant.",
         "options": "Utwórz co najmniej jedną opcję.",
-        "uniqueSku": "SKU musi być unikalny."
+        "uniqueSku": "SKU musi być unikalny.",
+        "primaryCategoryRequired": "Kategoria główna jest wymagana",
+        "titleRequired": "Tytuł jest wymagany",
+        "handleInvalidFormat": "Identyfikator może zawierać tylko małe litery, cyfry i myślniki",
+        "handleMustContainLetter": "Identyfikator musi zawierać co najmniej jedną literę"
+      },
+      "attributes": {
+        "description": "Dodaj atrybuty do swojego produktu. Wybierz spośród atrybutów zdefiniowanych przez administratora lub utwórz własne.",
+        "requiredHeading": "Wymagane atrybuty",
+        "requiredDescription": "Te atrybuty są wymagane dla produktów w tej kategorii.",
+        "buttonLabel": "Atrybut",
+        "learnMore": {
+          "label": "Dowiedz się więcej o atrybutach",
+          "content": "Atrybuty pomagają klientom znajdować i filtrować Twoje produkty. Atrybuty zdefiniowane przez administratora pojawiają się w wynikach wyszukiwania."
+        }
       },
       "inventory": {
         "heading": "Zestawy magazynowe",
@@ -440,6 +460,7 @@
       },
       "variants": {
         "header": "Warianty",
+        "optionsHeader": "Opcje",
         "subHeadingTitle": "Tak, to produkt z wariantami",
         "subHeadingDescription": "Jeśli odznaczone, stworzymy dla Ciebie domyślny wariant",
         "optionTitle": {
@@ -508,9 +529,18 @@
       "filtered": {
         "heading": "Brak wariantów",
         "description": "Nie ma wariantów, które pasują do aktualnych kryteriów filtrów."
+      },
+      "editStocksAndPrices": {
+        "header": "Edytuj stany i ceny",
+        "description": "Zarządzaj lokalizacjami zapasów oraz cenami dla wszystkich wariantów",
+        "action": "Edytuj stany i ceny",
+        "successToast": "Stany i ceny zostały pomyślnie zaktualizowane"
       }
     },
     "attributes": "Atrybuty",
+    "attributesSection": {
+      "removeWarning": "Zamierzasz usunąć ten atrybut z produktu. Tej akcji nie można cofnąć."
+    },
     "editAttributes": "Edytuj atrybuty",
     "editOptions": "Edytuj opcje",
     "editPrices": "Edytuj ceny",
@@ -590,6 +620,13 @@
       },
       "categories": {
         "label": "Kategorie"
+      },
+      "primaryCategory": {
+        "label": "Kategoria główna",
+        "tooltip": "Kategoria główna określa, które atrybuty są dostępne dla tego produktu. Atrybuty są tworzone przez administratora podczas konfiguracji platformy."
+      },
+      "secondaryCategories": {
+        "label": "Kategorie dodatkowe"
       },
       "tags": {
         "label": "Tagi"
@@ -691,7 +728,11 @@
         "header": "Utwórz opcję",
         "successToast": "Opcja {{title}} została pomyślnie utworzona."
       },
-      "deleteWarning": "Zamierzasz usunąć opcję produktu: {{title}}. Tej akcji nie można cofnąć."
+      "deleteWarning": "Zamierzasz usunąć opcję produktu: {{title}}. Tej akcji nie można cofnąć.",
+      "variations": {
+        "label": "Warianty",
+        "description": "Atrybuty używane do tworzenia wariantów produktu."
+      }
     },
     "organization": {
       "header": "Organizacja",
@@ -1157,6 +1198,8 @@
       "title": "Płatności",
       "isReadyToBeCaptured": "Płatność <0/> jest gotowa do realizacji.",
       "totalPaidByCustomer": "Łączna kwota zapłacona przez klienta",
+      "totalPending": "Łącznie oczekujące",
+      "totalRefunded": "Zwrócone",
       "totalStoreCreditRefunds": "Całkowite zwroty kredytów sklepowych",
       "capture": "Zrealizuj płatność",
       "capture_short": "Zrealizuj",
@@ -1391,7 +1434,11 @@
     "shipment": {
       "title": "Oznacz realizację jako wysłaną",
       "trackingNumber": "Numer do śledzenia przesyłki",
+      "trackingUrl": "Adres URL śledzenia",
+      "labelUrl": "Adres URL etykiety",
       "addTracking": "Dodaj numer do śledzenia przesyłki",
+      "addTrackingUrl": "Dodaj adres URL śledzenia",
+      "trackingUrlPlaceholder": "https://www.dhl.com/shipment/1234567890",
       "sendNotification": "Wyślij powiadomienie",
       "sendNotificationHint": "Powiadom klienta o tej wysyłce.",
       "toastCreated": "Wysyłka została pomyślnie utworzona."
@@ -1437,7 +1484,10 @@
         "partiallyReturned": "Częściowo zwrócone",
         "returned": "Zwrócone",
         "canceled": "Anulowane",
-        "requiresAction": "Wymaga działania"
+        "requiresAction": "Wymaga działania",
+        "awaitingPickup": "Oczekuje na odbiór",
+        "awaitingShipping": "Oczekuje na wysyłkę",
+        "awaitingDelivery": "Oczekuje na dostawę"
       },
       "toast": {
         "created": "Realizacja została pomyślnie utworzona",
@@ -2464,10 +2514,24 @@
       }
     }
   },
+  "payouts": {
+    "domain": "Wypłaty",
+    "payout": "Wypłata",
+    "noRecords": "Nie znaleziono wypłat",
+    "status": {
+      "pending": "Oczekuje",
+      "processing": "W trakcie przetwarzania",
+      "paid": "Wypłacono",
+      "failed": "Nieudana",
+      "canceled": "Anulowana"
+    }
+  },
   "profile": {
     "domain": "Profil",
     "manageYourProfileDetails": "Zarządzaj danymi swojego profilu.",
     "fields": {
+      "firstName": "Imię",
+      "lastName": "Nazwisko",
       "languageLabel": "Język",
       "usageInsightsLabel": "Informacje o użytkowaniu"
     },
@@ -2487,6 +2551,7 @@
     "inviteUser": "Zaproś użytkownika",
     "inviteUserHint": "Zaproś nowego użytkownika do swojego sklepu.",
     "sendInvite": "Wyślij zaproszenie",
+    "selectRole": "Wybierz rolę",
     "pendingInvites": "Oczekujące zaproszenia",
     "deleteInviteWarning": "Zamierzasz usunąć zaproszenie dla użytkownika {{email}}. Tej akcji nie można cofnąć.",
     "resendInvite": "Wyślij zaproszenie ponownie",
@@ -2495,14 +2560,25 @@
     "validFromUntil": "Obowiązuje od <0>{{from}}</0> - <1>{{until}}</1>",
     "acceptedOnDate": "Zaakceptowano w dniu {{date}}",
     "inviteStatus": {
-      "accepted": "Przyjęty",
-      "pending": "Aż do",
-      "expired": "Wygasły"
+      "accepted": "Zaakceptowane",
+      "pending": "Oczekuje",
+      "expired": "Wygasłe"
     },
     "roles": {
       "admin": "Administrator",
-      "developer": "Wywoływacz",
-      "member": "Członek"
+      "developer": "Programista",
+      "member": "Członek",
+      "administration": "Administracja",
+      "inventoryManagement": "Zarządzanie magazynem",
+      "orderManagement": "Zarządzanie zamówieniami",
+      "accounting": "Księgowość",
+      "support": "Wsparcie"
+    },
+    "inviteForm": {
+      "validation": {
+        "emailInvalid": "Wprowadź prawidłowy adres e-mail",
+        "roleRequired": "Wybierz rolę"
+      }
     },
     "list": {
       "empty": {
@@ -2522,6 +2598,39 @@
     "domain": "Sklep",
     "manageYourStoresDetails": "Zarządzaj szczegółami swojego sklepu",
     "editStore": "Edytuj sklep",
+    "handleTooltip": "Identyfikator staje się fragmentem URL Twojego sklepu. Pozostaw puste, aby wygenerować automatycznie z nazwy.",
+    "logo": "Logo",
+    "banner": "Baner",
+    "mediaHeading": "Media",
+    "mediaTip": {
+      "label": "Wskazówka:",
+      "message": "Te media będą widoczne w witrynie sklepu."
+    },
+    "validation": {
+      "nameRequired": "Wprowadź nazwę",
+      "nameTooLong": "Nazwa może mieć maksymalnie 100 znaków",
+      "emailInvalid": "Wprowadź prawidłowy adres e-mail"
+    },
+    "status": {
+      "active": "Aktywny",
+      "pendingApproval": "Oczekuje",
+      "suspended": "Nieaktywny",
+      "terminated": "Zakończony"
+    },
+    "alert": {
+      "pendingApproval": {
+        "title": "Wniosek o sklep",
+        "description": "Wniosek o sklep został pomyślnie wysłany. Po sprawdzeniu przez administratora otrzymasz powiadomienie w panelu."
+      },
+      "suspended": {
+        "title": "Twój sklep został zawieszony",
+        "description": "Twój sklep został zawieszony przez administratora platformy. Skontaktuj się z pomocą techniczną, aby uzyskać więcej informacji."
+      },
+      "terminated": {
+        "title": "Twój sklep został zamknięty",
+        "description": "Twój sklep został trwale zamknięty przez administratora platformy. Skontaktuj się z pomocą techniczną, aby uzyskać więcej informacji."
+      }
+    },
     "defaultCurrency": "Domyślna waluta",
     "defaultRegion": "Domyślny region",
     "defaultSalesChannel": "Domyślny kanał sprzedaży",
@@ -2539,7 +2648,110 @@
     "removeCurrencyWarning_other": "Zamierzasz usunąć {{count}} walut ze swojego sklepu. Upewnij się, że usunąłeś wszystkie ceny w wybranych walutach.",
     "currencyAlreadyAdded": "Waluta została już dodana do Twojego sklepu.",
     "edit": {
-      "header": "Edytuj sklep"
+      "header": "Edytuj sklep",
+      "websiteHint": "Musi zawierać protokół (np. https://)"
+    },
+    "address": {
+      "header": "Adres",
+      "defaultName": "Siedziba",
+      "nameLabel": "Nazwa",
+      "namePlaceholder": "Siedziba",
+      "empty": {
+        "title": "Brak adresu",
+        "message": "Brak rekordów do wyświetlenia"
+      },
+      "edit": {
+        "header": "Edytuj adres",
+        "description": "Zaktualizuj adres swojego sklepu.",
+        "successToast": "Adres został zaktualizowany"
+      },
+      "validation": {
+        "nameRequired": "Wprowadź nazwę",
+        "countryRequired": "Wybierz kraj"
+      }
+    },
+    "paymentDetails": {
+      "header": "Dane płatności",
+      "empty": {
+        "title": "Brak danych płatności",
+        "message": "Brak rekordów do wyświetlenia"
+      },
+      "edit": {
+        "header": "Edytuj dane płatności",
+        "description": "Zaktualizuj dane płatności swojego sklepu.",
+        "successToast": "Dane płatności zostały zaktualizowane"
+      },
+      "fields": {
+        "countryCode": "Kraj",
+        "holderName": "Nazwa właściciela konta",
+        "bankName": "Nazwa banku",
+        "iban": "IBAN",
+        "bic": "SWIFT / BIC",
+        "swiftBic": "SWIFT / BIC",
+        "routingNumber": "Numer routingu",
+        "achRoutingNumber": "Numer routingu ACH",
+        "accountNumber": "Numer konta"
+      },
+      "validation": {
+        "countryRequired": "Wybierz kraj",
+        "accountNameRequired": "Wprowadź nazwę właściciela konta"
+      }
+    },
+    "professionalDetails": {
+      "header": "Dane firmy",
+      "empty": {
+        "title": "Brak danych firmy",
+        "message": "Brak rekordów do wyświetlenia"
+      },
+      "edit": {
+        "header": "Edytuj dane firmy",
+        "description": "Zaktualizuj dane firmy swojego sklepu.",
+        "successToast": "Dane firmy zostały zaktualizowane"
+      },
+      "fields": {
+        "corporateName": "Pełna nazwa firmy",
+        "registrationNumber": "Numer rejestracyjny",
+        "taxId": "NIP"
+      }
+    },
+    "timeOff": {
+      "header": "Przerwa",
+      "columns": {
+        "firstDay": "Pierwszy dzień",
+        "lastDay": "Ostatni dzień",
+        "note": "Notatka"
+      },
+      "validation": {
+        "firstDayRequired": "Wybierz pierwszy dzień"
+      },
+      "empty": {
+        "title": "Brak zaplanowanej przerwy",
+        "message": "Ten sklep nie ma zaplanowanej przerwy",
+        "action": "Utwórz"
+      },
+      "create": {
+        "header": "Utwórz przerwę",
+        "description": "Zaplanuj okres przerwy dla swojego sklepu.",
+        "successToast": "Przerwa została zapisana"
+      },
+      "fields": {
+        "firstDay": "Pierwszy dzień",
+        "lastDay": "Ostatni dzień",
+        "lastDayHint": "Pozostaw puste, aby zamknąć sklep na czas nieokreślony",
+        "note": "Notatka"
+      },
+      "deleteConfirm": {
+        "title": "Usuń przerwę",
+        "description": "Czy na pewno chcesz usunąć ten okres przerwy?"
+      },
+      "deleteSuccess": "Przerwa została usunięta"
+    },
+    "subscription": {
+      "header": "Subskrypcja",
+      "month": "miesiąc"
+    },
+    "scheduledClosure": {
+      "header": "Zaplanowana przerwa"
     },
     "toast": {
       "update": "Sklep pomyślnie zaktualizowany",
@@ -2839,10 +3051,148 @@
       }
     }
   },
+  "storeSelect": {
+    "title": "Wybierz sklep",
+    "subtitle": "Wybierz sklep, aby kontynuować.",
+    "pendingApproval": "Oczekuje",
+    "addNewStore": "Dodaj nowy sklep",
+    "status": {
+      "open": "Aktywny",
+      "pendingApproval": "Oczekuje",
+      "suspended": "Nieaktywny",
+      "terminated": "Zakończony"
+    }
+  },
   "login": {
     "forgotPassword": "Zapomniałeś hasła? - <0>Resetuj</0>",
     "title": "Witamy w {{name}}",
     "hint": "Zaloguj się, aby uzyskać dostęp do obszaru konta"
+  },
+  "register": {
+    "title": "Dołącz do Mercur!",
+    "hint": "Wprowadź swoje dane i utwórz hasło, aby skonfigurować konto sprzedawcy w {{name}}.",
+    "companyName": "Nazwa firmy",
+    "confirmPassword": "Potwierdź hasło",
+    "signUp": "Zarejestruj się",
+    "alreadySeller": "Masz już konto? <0>Zaloguj się</0>",
+    "passwordMismatch": "Hasła nie są zgodne",
+    "emailTaken": "Podany adres e-mail jest już zajęty",
+    "error": "Coś poszło nie tak. Spróbuj ponownie.",
+    "validation": {
+      "nameRequired": "Nazwa musi mieć co najmniej 2 znaki",
+      "firstNameRequired": "Wprowadź swoje imię",
+      "lastNameRequired": "Wprowadź swoje nazwisko",
+      "emailInvalid": "Wprowadź prawidłowy adres e-mail",
+      "passwordMinLength": "Hasło musi mieć co najmniej 8 znaków",
+      "passwordComplexity": "Hasło musi zawierać jedną małą literę, jedną wielką literę oraz jedną cyfrę lub symbol",
+      "confirmPasswordRequired": "Potwierdź swoje hasło"
+    },
+    "firstName": "Imię",
+    "lastName": "Nazwisko",
+    "passwordHint": "Twoje hasło musi zawierać co najmniej 8 znaków, jedną małą literę, jedną wielką literę oraz jedną cyfrę lub symbol",
+    "successTitle": "Dziękujemy za rejestrację!",
+    "successHint": "Może być konieczne oczekiwanie na autoryzację administratora przed zalogowaniem. Wkrótce otrzymasz e-mail z potwierdzeniem.",
+    "backToLogin": "Powrót do logowania"
+  },
+  "onboarding": {
+    "step": "Krok {{current}} / {{total}}",
+    "organizationSetup": {
+      "title": "Skonfiguruj swoją organizację",
+      "subtitle": "Podaj nazwę swojej organizacji",
+      "organizationName": "Nazwa organizacji",
+      "organizationNamePlaceholder": "Moja organizacja"
+    },
+    "storeSetup": {
+      "title": "Skonfiguruj swój sklep",
+      "subtitle": "Podaj szczegóły swojego sklepu",
+      "storeName": "Nazwa sklepu",
+      "storeNamePlaceholder": "Mój sklep",
+      "storeEmail": "E-mail sklepu",
+      "storeEmailHint": "Publiczny adres kontaktowy Twojego sklepu",
+      "selectCurrency": "Wybierz walutę",
+      "currencyHint": "Nie można zmienić po utworzeniu sklepu",
+      "descriptionPlaceholder": "Opis Twojego sklepu"
+    },
+    "detailsSetup": {
+      "title": "Uzupełnij swój profil",
+      "subtitle": "Dodaj swój adres i dane firmy",
+      "addressTitle": "Adres",
+      "addressSubtitle": "Adres Twojej firmy",
+      "professionalTitle": "Dane firmy",
+      "professionalSubtitle": "Informacje o sprzedawcy biznesowym",
+      "isProfessional": "Sprzedawca biznesowy",
+      "isProfessionalDescription": "Zarejestruj się jako podmiot gospodarczy",
+      "corporateName": "Firma",
+      "registrationNumber": "Numer rejestracyjny",
+      "taxId": "NIP",
+      "completeSetup": "Zakończ konfigurację"
+    },
+    "submitted": {
+      "title": "Wniosek został wysłany!",
+      "description": "Twoje konto sprzedawcy zostało utworzone i oczekuje na zatwierdzenie. Powiadomimy Cię pod adresem {{email}}, gdy Twój sklep zostanie zweryfikowany.",
+      "hint": "W międzyczasie możesz wybrać swój sklep i dokończyć konfigurację.",
+      "action": "Przejdź do panelu"
+    },
+    "wizard": {
+      "stepOf": "Krok {{current}} z {{total}}",
+      "steps": {
+        "store": "Szczegóły sklepu",
+        "address": "Adres",
+        "company": "Dane firmy",
+        "payment": "Dane płatności"
+      },
+      "store": {
+        "title": "Wprowadź dane swojego sklepu",
+        "name": "Nazwa",
+        "email": "E-mail",
+        "handle": "Identyfikator",
+        "handleTooltip": "Identyfikator staje się fragmentem URL Twojego sklepu. Pozostaw puste, aby wygenerować automatycznie z nazwy.",
+        "handlePlaceholder": "moj-sklep",
+        "currency": "Waluta",
+        "selectCurrency": "Wybierz",
+        "currencyHint": "Nie można zmienić po utworzeniu sklepu"
+      },
+      "skip": "Pomiń",
+      "address": {
+        "title": "Wprowadź swój adres",
+        "name": "Nazwa",
+        "namePlaceholder": "Siedziba",
+        "address": "Adres",
+        "address2": "Mieszkanie, apartament itp.",
+        "postalCode": "Kod pocztowy",
+        "city": "Miasto",
+        "country": "Kraj",
+        "state": "Województwo"
+      },
+      "company": {
+        "title": "Wprowadź dane swojej firmy",
+        "subtitle": "Informacje o sprzedawcy biznesowym",
+        "corporateName": "Firma",
+        "registrationNumber": "Numer rejestracyjny",
+        "taxId": "NIP"
+      },
+      "payment": {
+        "title": "Wprowadź dane płatności",
+        "subtitle": "W jaki sposób chcesz otrzymywać wypłaty",
+        "accountName": "Nazwa właściciela konta",
+        "accountNumber": "Numer konta",
+        "achRoutingNumber": "Numer routingu ACH",
+        "iban": "IBAN",
+        "swiftBic": "SWIFT / BIC"
+      },
+      "validation": {
+        "nameRequired": "Wprowadź nazwę",
+        "emailInvalid": "Wprowadź adres e-mail",
+        "currencyRequired": "Wybierz walutę",
+        "countryRequired": "Wybierz kraj",
+        "accountNameRequired": "Wprowadź nazwę właściciela konta"
+      },
+      "preview": {
+        "title": "Witamy w Mercur",
+        "description": "Twój kompleksowy panel sprzedawcy do zarządzania sklepem, produktami, zamówieniami i wypłatami.",
+        "placeholder": "Podgląd aplikacji"
+      }
+    }
   },
   "invite": {
     "title": "Witamy w Mercur",

--- a/packages/vendor/src/pages/login/login.tsx
+++ b/packages/vendor/src/pages/login/login.tsx
@@ -33,7 +33,7 @@ const LoginHeader = () => {
 
   return (
     <div className="mb-6 flex flex-col">
-      <Heading>{t("login.title")}</Heading>
+      <Heading>{t("login.title", { name: config.name ?? "Mercur" })}</Heading>
       <Text size="small" className="text-ui-fg-subtle">
         {t("login.hint")}
       </Text>

--- a/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -191,7 +191,7 @@ const UnfulfilledItemDisplay = ({
         <Link
           to={`/orders/${order.id}/fulfillment?requires_shipping=${requiresShipping}`}
         >
-          <Button>Fulfill items</Button>
+          <Button>{t("orders.fulfillment.fulfillItems")}</Button>
         </Link>
       </div>
     </Container>
@@ -227,22 +227,22 @@ const Fulfillment = ({
 
   let statusText = fulfillment.requires_shipping
     ? isPickUpFulfillment
-      ? "Awaiting pickup"
-      : "Awaiting shipping"
-    : "Awaiting delivery"
+      ? t("orders.fulfillment.status.awaitingPickup")
+      : t("orders.fulfillment.status.awaitingShipping")
+    : t("orders.fulfillment.status.awaitingDelivery")
   let statusColor: "blue" | "green" | "red" = "blue"
   let statusTimestamp = fulfillment.created_at
 
   if (fulfillment.canceled_at) {
-    statusText = "Canceled"
+    statusText = t("orders.fulfillment.status.canceled")
     statusColor = "red"
     statusTimestamp = fulfillment.canceled_at
   } else if (fulfillment.delivered_at) {
-    statusText = "Delivered"
+    statusText = t("orders.fulfillment.status.delivered")
     statusColor = "green"
     statusTimestamp = fulfillment.delivered_at
   } else if (fulfillment.shipped_at) {
-    statusText = "Shipped"
+    statusText = t("orders.fulfillment.status.shipped")
     statusColor = "green"
     statusTimestamp = fulfillment.shipped_at
   }

--- a/packages/vendor/src/pages/orders/[id]/_components/order-payment-section/order-payment-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-payment-section/order-payment-section.tsx
@@ -76,7 +76,7 @@ const Total = ({ order }: { order: HttpTypes.AdminOrder }) => {
       {totalRefunded > 0 && (
         <div className="flex items-center justify-between px-6 py-4">
           <Text size="small" weight="plus" leading="compact">
-            Refunded
+            {t("orders.payment.totalRefunded")}
           </Text>
 
           <Text size="small" weight="plus" leading="compact">
@@ -88,7 +88,7 @@ const Total = ({ order }: { order: HttpTypes.AdminOrder }) => {
       {order.status !== "canceled" && totalPending > 0 && (
         <div className="flex items-center justify-between px-6 py-4">
           <Text size="small" weight="plus" leading="compact">
-            Total pending
+            {t("orders.payment.totalPending")}
           </Text>
 
           <Text size="small" weight="plus" leading="compact">

--- a/packages/vendor/src/pages/orders/[id]/shipment/index.tsx
+++ b/packages/vendor/src/pages/orders/[id]/shipment/index.tsx
@@ -1,4 +1,4 @@
-// Route: /orders/:id/fulfillments/:f_id/shipment
+// Route: /orders/:id/:f_id/create-shipment
 import { useParams } from "react-router-dom"
 
 import { RouteFocusModal } from "@components/modals"

--- a/packages/vendor/src/pages/orders/[id]/shipment/order-create-shipment-form/order-create-shipment-form.tsx
+++ b/packages/vendor/src/pages/orders/[id]/shipment/order-create-shipment-form/order-create-shipment-form.tsx
@@ -107,12 +107,16 @@ export function OrderCreateShipmentForm({
                         return (
                           <Form.Item className="mb-4">
                             {index === 0 && (
-                              <Form.Label>Tracking URL</Form.Label>
+                              <Form.Label>
+                                {t("orders.shipment.trackingUrl")}
+                              </Form.Label>
                             )}
                             <Form.Control>
                               <Input
                                 {...field}
-                                placeholder="https://www.dhl.com/shipment/1234567890"
+                                placeholder={t(
+                                  "orders.shipment.trackingUrlPlaceholder"
+                                )}
                               />
                             </Form.Control>
                             <Form.ErrorMessage />
@@ -128,7 +132,7 @@ export function OrderCreateShipmentForm({
                     className="self-end"
                     variant="secondary"
                   >
-                    Add tracking URL
+                    {t("orders.shipment.addTrackingUrl")}
                   </Button>
                 </div>
               </div>

--- a/packages/vendor/src/pages/payouts/[id]/_components/payout-general-section.tsx
+++ b/packages/vendor/src/pages/payouts/[id]/_components/payout-general-section.tsx
@@ -22,8 +22,10 @@ const payoutStatusColor = (status: string) => {
 export const PayoutGeneralSection = ({ payout }: { payout: PayoutDTO }) => {
   const { t } = useTranslation();
 
-  const statusText =
-    payout.status.charAt(0).toUpperCase() + payout.status.slice(1);
+  const statusText = t(`payouts.status.${payout.status}`, {
+    defaultValue:
+      payout.status.charAt(0).toUpperCase() + payout.status.slice(1),
+  });
 
   return (
     <Container className="divide-y p-0">

--- a/packages/vendor/src/pages/payouts/_components/payout-list-table/payout-list-data-table.tsx
+++ b/packages/vendor/src/pages/payouts/_components/payout-list-table/payout-list-data-table.tsx
@@ -60,7 +60,7 @@ export const PayoutListDataTable = () => {
       ]}
       queryObject={raw}
       noRecords={{
-        message: "No payouts found",
+        message: t("payouts.noRecords"),
       }}
     />
   );

--- a/packages/vendor/src/pages/payouts/_components/payout-list-table/payout-list-header.tsx
+++ b/packages/vendor/src/pages/payouts/_components/payout-list-table/payout-list-header.tsx
@@ -1,8 +1,10 @@
 import { Children, ReactNode } from "react";
 import { Heading } from "@medusajs/ui";
+import { useTranslation } from "react-i18next";
 
 export const PayoutListTitle = () => {
-  return <Heading>Payouts</Heading>;
+  const { t } = useTranslation();
+  return <Heading>{t("payouts.domain")}</Heading>;
 };
 
 export const PayoutListActions = ({

--- a/packages/vendor/src/pages/products/[id]/_components/product-additional-attribute-section/ProductAdditionalAttributesSection.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-additional-attribute-section/ProductAdditionalAttributesSection.tsx
@@ -54,7 +54,7 @@ const InformationalAttributeRowActions = ({ productId, attribute }: { productId:
   const handleDelete = async () => {
     const res = await prompt({
       title: t("general.areYouSure"),
-      description: "You are about to remove this attribute from the product. This action cannot be undone.",
+      description: t("products.attributesSection.removeWarning"),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
     })

--- a/packages/vendor/src/pages/products/[id]/_components/product-general-section/product-general-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-general-section/product-general-section.tsx
@@ -90,7 +90,7 @@ export const ProductGeneralSection = () => {
       <SectionRow title={t("fields.handle")} value={`/${product.handle}`} />
       <SectionRow
         title={t("fields.discountable")}
-        value={product.discountable ? "True" : "False"}
+        value={product.discountable ? t("general.true") : t("general.false")}
       />
     </Container>
   );

--- a/packages/vendor/src/pages/products/create/constants.ts
+++ b/packages/vendor/src/pages/products/create/constants.ts
@@ -133,11 +133,13 @@ export const PRODUCT_CREATE_FORM_DEFAULTS: Partial<
   options: [],
   variants: decorateVariantsWithDefaultValues([
     {
-      title: "Default variant",
+      title: i18n.t("products.create.defaults.variantTitle"),
       should_create: true,
       variant_rank: 0,
       options: {
-        "Default option": "Default option value",
+        [i18n.t("products.create.defaults.optionTitle")]: i18n.t(
+          "products.create.defaults.optionValue"
+        ),
       },
       inventory: [{ inventory_item_id: "", required_quantity: "" }],
       is_default: true,

--- a/packages/vendor/src/pages/products/create/product-create-details-form/components/product-create-details-variant-section/product-create-details-variant-section.tsx
+++ b/packages/vendor/src/pages/products/create/product-create-details-form/components/product-create-details-variant-section/product-create-details-variant-section.tsx
@@ -258,21 +258,24 @@ export const ProductCreateVariantsSection = () => {
   }
 
   const createDefaultOptionAndVariant = () => {
+    const defaultOptionTitle = t("products.create.defaults.optionTitle")
+    const defaultOptionValue = t("products.create.defaults.optionValue")
+
     form.setValue("options", [
       {
-        title: "Default option",
-        values: ["Default option value"],
+        title: defaultOptionTitle,
+        values: [defaultOptionValue],
       },
     ])
     form.setValue(
       "variants",
       decorateVariantsWithDefaultValues([
         {
-          title: "Default variant",
+          title: t("products.create.defaults.variantTitle"),
           should_create: true,
           variant_rank: 0,
           options: {
-            "Default option": "Default option value",
+            [defaultOptionTitle]: defaultOptionValue,
           },
           inventory: [{ inventory_item_id: "", required_quantity: "" }],
           is_default: true,

--- a/packages/vendor/src/pages/products/create/product-create-form/product-create-form.tsx
+++ b/packages/vendor/src/pages/products/create/product-create-form/product-create-form.tsx
@@ -661,7 +661,11 @@ export const ProductCreateForm = ({
           options:
             Object.keys(mappedOptions).length > 0
               ? mappedOptions
-              : { "Default option": "Default option value" },
+              : {
+                  [t("products.create.defaults.optionTitle")]: t(
+                    "products.create.defaults.optionValue"
+                  ),
+                },
           ...(variantImageKey && {
             metadata: { variant_image_key: variantImageKey },
           }),
@@ -695,8 +699,8 @@ export const ProductCreateForm = ({
           ? allOptions
           : [
               {
-                title: "Default option",
-                values: ["Default option value"],
+                title: t("products.create.defaults.optionTitle"),
+                values: [t("products.create.defaults.optionValue")],
               },
             ],
       metadata: (() => {

--- a/packages/vendor/src/pages/products/create/product-create-variants-form/product-create-variants-form.tsx
+++ b/packages/vendor/src/pages/products/create/product-create-variants-form/product-create-variants-form.tsx
@@ -452,14 +452,14 @@ const useColumns = ({
               ? variantAttributes
                   .map((attr) => attr.name)
                   .join(" / ")
-              : "Options",
+              : t("products.create.variants.optionsHeader"),
           header: () => {
             const label =
               variantAttributes.length > 0
                 ? variantAttributes
                     .map((attr) => attr.name)
                     .join(" / ")
-                : "Options"
+                : t("products.create.variants.optionsHeader")
 
             return (
               <Tooltip content={label}>

--- a/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/shipping-option/create/_components/create-shipping-option-details-form.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/shipping-option/create/_components/create-shipping-option-details-form.tsx
@@ -6,6 +6,7 @@ import { VendorExtendedAdminServiceZone } from "@custom-types/stock-location"
 
 import { Form } from "@components/common/form"
 import { Combobox } from "@components/inputs/combobox"
+import { shippingProfileQueryKeys } from "@hooks/api/shipping-profiles"
 import { useComboboxData } from "@hooks/use-combobox-data"
 import { fetchQuery } from "@lib/client"
 import {
@@ -36,7 +37,7 @@ export const CreateShippingOptionDetailsForm = ({
       fetchQuery(`/vendor/shipping-profiles`, {
         method: "GET",
       }),
-    queryKey: ["shipping_profiles_create_shipping_option"],
+    queryKey: shippingProfileQueryKeys.lists(),
     getOptions: (data) =>
       (data.shipping_profiles || []).map((profile: any) => {
         const name = profile.shipping_profile?.name ?? profile.name ?? ""


### PR DESCRIPTION
## Summary

- Localizes hardcoded strings across admin and vendor dashboards — commission rates, payouts, fulfillment statuses, product create defaults, and assorted polish — adding matching `en.json` / `pl.json` entries and `$schema.json` updates.
- Exposes a new `OnboardingCompanyExtraFields` component slot on `MercurConfig.components`, with `additional_data` pass-through wired from `useOnboarding` to the create-seller mutation so plugins can extend the vendor onboarding wizard's company step.
- Threads `WithAdditionalData` / `AdditionalData` through admin and vendor seller validators (create, update, address upsert, payment details, professional details).
- Minor layout, table, and select polish across pages touched by the above.

## Test plan

- [ ] Admin: navigate Commission Rates list / create / detail / edit / delete flows and confirm all UI strings come from i18n (verify in both `en` and `pl`).
- [ ] Admin: confirm payouts list/detail and orders list/detail render localized statuses (incl. new `awaitingPickup` / `awaitingShipping` / `awaitingDelivery`).
- [ ] Vendor: walk through the onboarding wizard — company step still works with the default fields, and an injected `OnboardingCompanyExtraFields` component renders and forwards values via `additional_data` on submit.
- [ ] Vendor: payouts and product create pages render localized copy; product create still produces a valid default variant/option.
- [ ] Verify seller create/update payloads accept extension fields via `additional_data` without breaking schema validation on the admin API.
- [ ] Run typecheck / build for `packages/admin`, `packages/vendor`, `packages/core`, `packages/dashboard-sdk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)