### PR TITLE
fix(vendor): refactor fulfillment auto-init to survive Radix BubbleSelect race

### DIFF
--- a/packages/vendor/src/pages/orders/[id]/fulfillment/index.tsx
+++ b/packages/vendor/src/pages/orders/[id]/fulfillment/index.tsx
@@ -11,7 +11,7 @@ export const Component = () => {
   const requiresShipping = searchParams.get("requires_shipping") === "true"
 
   const { order, isLoading, isError, error } = useOrder(id!, {
-    fields: "*items.variant.product.shipping_profile",
+    fields: "*items.variant.product.shipping_profile,*shipping_methods",
   })
 
   if (isError) {

--- a/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-form.tsx
+++ b/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-form.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
 
@@ -74,15 +74,37 @@ export function OrderCreateFulfillmentForm({
       fields: "+service_zone.fulfillment_set.location.id,*rules",
     })
 
-  const filteredShippingOptions = shipping_options.filter(
-    (o) =>
-      o !== null && !isReturnOption(o) && isSameLocation(o, selectedLocationId)
+  const filteredShippingOptions = useMemo(
+    () =>
+      shipping_options.filter(
+        (o) =>
+          o !== null &&
+          !isReturnOption(o) &&
+          isSameLocation(o, selectedLocationId)
+      ),
+    [shipping_options, selectedLocationId]
   )
 
   const shippingOptionId = useWatch({
     name: "shipping_option_id",
     control: form.control,
   })
+
+  // The shipping method the customer chose at checkout. We pre-select both
+  // the location and the method on mount so the vendor doesn't have to
+  // re-pick them.
+  const initialShippingOptionId =
+    order.shipping_methods?.[0]?.shipping_option_id ?? null
+
+  const initialShippingOption = useMemo(() => {
+    if (!initialShippingOptionId) return null
+    return (
+      shipping_options.find((o) => o?.id === initialShippingOptionId) ?? null
+    )
+  }, [initialShippingOptionId, shipping_options])
+
+  const initialLocationId =
+    initialShippingOption?.service_zone?.fulfillment_set?.location?.id ?? null
 
   const handleSubmit = form.handleSubmit(async (data) => {
     const selectedShippingOption = shipping_options.find(
@@ -144,35 +166,51 @@ export function OrderCreateFulfillmentForm({
     }
   })
 
+  // Pre-select the customer's location once both the option-lookup and
+  // the location list have arrived. The customer's chosen shipping option
+  // lives on a specific fulfillment_set → service_zone → location, so we
+  // copy that location id into the form.
   useEffect(() => {
-    if (stock_locations?.length && shipping_options?.length) {
-      const initialShippingOptionId =
-        order.shipping_methods?.[0]?.shipping_option_id
+    if (!initialLocationId || !stock_locations?.length) return
+    if (selectedLocationId === initialLocationId) return
+    form.setValue("location_id", initialLocationId)
+  }, [initialLocationId, stock_locations?.length, selectedLocationId, form])
 
-      if (initialShippingOptionId) {
-        const shippingOption = shipping_options.find(
-          (o) => o?.id === initialShippingOptionId
-        )
-
-        if (shippingOption) {
-          const locationId =
-            shippingOption.service_zone.fulfillment_set.location.id
-
-          form.setValue("location_id", locationId)
-          form.setValue(
-            "shipping_option_id",
-            initialShippingOptionId || undefined
-          )
-        } // else -> TODO: what if original shipping option is deleted?
-      }
-    }
+  // Pre-select the customer's shipping option once:
+  //   (a) the location has propagated (so `filteredShippingOptions`
+  //       reflects the right service zone), and
+  //   (b) the option is present in the filtered list (so the matching
+  //       `<Select.Item>` has rendered).
+  //
+  // `shippingOptionId` is deliberately a dep on this effect. Radix Select
+  // maintains a hidden native `<select>` (`BubbleSelect`) for form /
+  // accessibility integration; its `<option>` children come from a
+  // `nativeOptionsSet` that each `<Select.Item>` registers into via
+  // `useLayoutEffect → setState`. Item registration therefore lands one
+  // render after the value assignment, and on the first render where
+  // `value` changes the browser silently rejects the not-yet-registered
+  // value and dispatches `change` with `""`, which propagates through the
+  // controlled `onValueChange` and clobbers the form field back to `""`.
+  // When that happens this effect's `shippingOptionId` dep changes from
+  // the target to `""`, so React re-runs the effect and it re-applies the
+  // value. Once Item registration catches up, the assignment sticks and
+  // the `shippingOptionId === initialShippingOptionId` early-return
+  // short-circuits.
+  useEffect(() => {
+    if (!initialShippingOptionId || !selectedLocationId) return
+    if (
+      !filteredShippingOptions.some((o) => o?.id === initialShippingOptionId)
+    )
+      return
+    if (shippingOptionId === initialShippingOptionId) return
+    form.setValue("shipping_option_id", initialShippingOptionId)
   }, [
-	stock_locations?.length,
-	shipping_options?.length,
-	order.shipping_methods,
-	form,
-	shipping_options
-])
+    initialShippingOptionId,
+    selectedLocationId,
+    filteredShippingOptions,
+    shippingOptionId,
+    form,
+  ])
 
   const fulfilledQuantityArray = (order.items || []).map(
     (item) =>


### PR DESCRIPTION
## What

Two fixes in `packages/vendor/src/pages/orders/[id]/fulfillment/`:

1. **`index.tsx`** — add `*shipping_methods` to the order loader's field set.
2. **`order-create-fulfillment-form.tsx`** — split the auto-init effect into two focused effects, memoize `filteredShippingOptions`, and lift derived values into `useMemo`s.

## Why

The Fulfill items dialog should mount with the customer's chosen shipping method pre-selected. In `2.1.2` it doesn't, and every line shows *"The shipping option you have selected don't allow fulfillment of this item"* until the vendor manually re-picks the method.

- Without `*shipping_methods` on the loader, `order.shipping_methods?.[0]?.shipping_option_id` is `undefined` and the auto-init bails before any `setValue`.
- With `shipping_methods` present, the original auto-init still fails: it calls `setValue("location_id", X)` and `setValue("shipping_option_id", Y)` in the same tick, and Radix Select's hidden native `<select>` (`BubbleSelect`) silently clobbers the value back to `""`. The `<option>`s in the hidden select come from a `nativeOptionsSet` populated by each `<Select.Item>`'s `useLayoutEffect → setState`, which lands one render *after* the value assignment. The browser rejects the not-yet-registered value and fires `change` with `""`, which propagates through `Controller.onChange` and resets the form field.

A `setTimeout(0)` defer fixes fresh page loads but breaks again on dialog reopen with cached React Query data (StrictMode re-runs the effect, refetches change reference identity, `<Select.Item>`s remount, race fires again).

The refactor side-steps the race instead of fighting it: the second effect takes `shippingOptionId` as a dep, so when BubbleSelect clobbers it the effect re-runs and re-applies. Once Item registration catches up the value sticks and the `shippingOptionId === initialShippingOptionId` early-return short-circuits. No retry counter, no `requestAnimationFrame`, no `setTimeout`.

#920 already added `order.shipping_methods` to the original effect's deps — necessary but not sufficient on its own.

## Verified

Built `@mercurjs/vendor` from this branch and ran it against a live mercur 2.1.2 stack. Dialog now pre-selects across fresh load, navigation-based reopen, and repeated open/close cycles.

## Test plan

- [ ] Place an order with a non-default shipping method.
- [ ] In the vendor portal, click **Fulfill items** — the customer's method is pre-selected, no per-line gate errors.
- [ ] Navigate away and back, reopen the dialog — still pre-selected.
- [ ] Submit — fulfillment created successfully.