### PR TITLE
fix(dashboard-sdk): drop double quotes around resolved component path

### DIFF
--- a/packages/dashboard-sdk/src/virtual-modules.ts
+++ b/packages/dashboard-sdk/src/virtual-modules.ts
@@ -66,7 +66,7 @@ function loadComponentsModule(mercurConfig: BuiltMercurConfig, cwd: string): str
 
     Object.entries(components).forEach(([name, componentPath]) => {
         const resolvedPath = path.resolve(cwd, 'src', componentPath)
-        imports.push(`import _${name} from "${JSON.stringify(resolvedPath)}"`)
+        imports.push(`import _${name} from ${JSON.stringify(resolvedPath)}`)
         exports.push(`${name}: _${name}`)
     })
 


### PR DESCRIPTION
## What changes

One-character fix in [`packages/dashboard-sdk/src/virtual-modules.ts`](packages/dashboard-sdk/src/virtual-modules.ts) — drops the literal `"..."` characters wrapping a `JSON.stringify` call that already returns a quoted string.

## Why

The Windows-path escaping landed in #920 wrapped `resolvedPath` in `JSON.stringify`, which already produces a quoted string literal (`"path"`), but the surrounding template kept the literal `"..."` characters. The generated `virtual:mercur/components` module ends up as:

```js
import _TopbarActions from ""/abs/path/to/topbar-actions""
```

Vite rejects this with:

```
[plugin:vite:import-analysis] Failed to resolve import "" from "virtual:mercur/components". Does the file exist?
```

Any vendor-panel config that supplies the `components` override (e.g. `{ TopbarActions: "components/topbar/topbar-actions" }`) hits this on dev-server start and the page won't load.

After this fix:

```js
import _TopbarActions from "/abs/path/to/topbar-actions"
```

`JSON.stringify`'s own quotes remain — so the original Windows-path escaping (the reason `JSON.stringify` was added) keeps working: backslashes in `C:\Users\...\topbar-actions.tsx` are emitted as `\\` inside the string literal exactly as Windows needs. The literal duplicates are gone, so Vite's import-analysis is happy on every platform.

## Test plan

- [ ] Provide a `components` override to `mercurDashboardPlugin` (e.g. `{ TopbarActions: "components/topbar/topbar-actions" }`).
- [ ] Start the vendor-panel dev server.
- [ ] Page loads without the `Failed to resolve import ""` Vite error on macOS, Linux, and Windows.
- [ ] The custom component renders in the topbar.