### PR TITLE
fix(cli): corrected DIST_DIR path of codegen

### DIFF
--- a/packages/cli/src/codegen/constants.ts
+++ b/packages/cli/src/codegen/constants.ts
@@ -1,4 +1,4 @@
-export const DIST_DIR = ".mercur";
+export const DIST_DIR = ".mercur/_generated";
 export const ROUTE_FILE_PATTERN = /route\.(ts|js)$/;
 
 export const defaultMedusaRoutes = {


### PR DESCRIPTION
## Summary

the codegen command generates a path depth mismatch for the generated routes


## Changes
Changed the value of the DIST_DIR constant to :

```ts
// Fix
export const DIST_DIR = ".mercur/_generated";

```


## Linked issues

addresses [ this issue ](https://github.com/mercurjs/mercur/issues/924)
