### PR TITLE
[AICS-292] Add Dijie role billing bridge

### DIFF
--- a/apps/admin-test/index.html
+++ b/apps/admin-test/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/public/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mercur Admin</title>
+    <title>迭界AI岗位商场</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/admin-test/vite.config.ts
+++ b/apps/admin-test/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(({ mode }) => {
       react(),
       mercurDashboardPlugin({
         medusaConfigPath: '../api/medusa-config.ts',
+        name: '迭界AI岗位商场',
         ...(backendUrl ? { backendUrl } : {}),
         ...(vendorUrl ? { vendorUrl } : {}),
       }),

--- a/apps/api/medusa-config.ts
+++ b/apps/api/medusa-config.ts
@@ -35,5 +35,8 @@ module.exports = withMercur({
         disable: true
       }
     },
+    {
+      resolve: './src/modules/dijie-audit',
+    },
   ],
 })

--- a/apps/api/src/api/dijie/audit/route.test.ts
+++ b/apps/api/src/api/dijie/audit/route.test.ts
@@ -1,0 +1,280 @@
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  DIJIE_AUDIT_MODULE,
+  recordDijieAuditSummaryWithRepository,
+} from "../../../lib/dijie/audit-store";
+import { createDijieExecutionToken, type DijieExecutionTokenClaims } from "../../../lib/dijie/execution-token";
+import { POST } from "./route";
+
+const keyPair = crypto.generateKeyPairSync("ed25519");
+const privateKeyPem = keyPair.privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+const publicKeyPem = keyPair.publicKey.export({ format: "pem", type: "spki" }).toString();
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000 as const,
+  platformFeeBps: 0 as const,
+};
+
+type TestResponse = {
+  statusCode: number;
+  body: unknown;
+  status: (statusCode: number) => TestResponse;
+  json: (body: unknown) => unknown;
+};
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(statusCode: number) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return body;
+    },
+  };
+}
+
+function token(scopes = ["role.execute", "audit.write"]) {
+  const signed = createDijieExecutionToken(
+    {
+      executionId: "exec_123",
+      actorId: "cus_123",
+      roleListingId: "role_123",
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "seller_001",
+      billingBeneficiaryRef: "dev_001",
+      entitlementId: "ent_123",
+      deviceId: "device_123",
+      workspaceRef: "workspace_123",
+      localGatewayId: "gateway_123",
+      scopes,
+      pricing: {
+        kind: "one_time_authorization",
+        authorizationFeeCents: 29900,
+        currency: "CNY",
+        platformFeeBps: 0,
+        developerReceivableCents: 29900,
+      },
+      roleTokenPricing,
+      nowMs: Date.now(),
+      ttlSeconds: 300,
+    },
+    privateKeyPem,
+  );
+  if (!signed.ok) {
+    throw new Error(signed.error);
+  }
+  return signed.token;
+}
+
+function request(body: Record<string, unknown>, bearer = token(), store?: unknown) {
+  return {
+    body,
+    headers: {
+      authorization: `Bearer ${bearer}`,
+    },
+    scope: {
+      resolve(name: string) {
+        if (store && name === DIJIE_AUDIT_MODULE) {
+          return store;
+        }
+        throw new Error(`Unknown dependency: ${name}`);
+      },
+    },
+  };
+}
+
+function auditSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    executionId: "exec_123",
+    deviceId: "device_123",
+    workspaceRef: "workspace_123",
+    roleListingId: "role_123",
+    packageId: "pkg_role_123",
+    packageVersion: "1.0.0",
+    developerRef: "dev_001",
+    listingOwnerRef: "seller_001",
+    billingBeneficiaryRef: "dev_001",
+    entitlementId: "ent_123",
+    localGatewayId: "gateway_123",
+    status: "completed",
+    startedAt: "2026-05-31T08:00:00.000Z",
+    endedAt: "2026-05-31T08:01:00.000Z",
+    modelProxyUsage: {
+      requestCount: 1,
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+    },
+    toolUsage: {
+      shellCommands: 2,
+      testsRun: 1,
+      filesRead: 4,
+      filesChanged: 2,
+    },
+    result: {
+      executionId: "exec_123",
+      roleListingId: "role_123",
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "seller_001",
+      billingBeneficiaryRef: "dev_001",
+      status: "completed",
+      startedAt: "2026-05-31T08:00:00.000Z",
+      endedAt: "2026-05-31T08:01:00.000Z",
+      changedFiles: ["role_package/manifest.json"],
+      artifacts: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("POST /dijie/audit", () => {
+  afterEach(() => {
+    delete process.env.DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM;
+  });
+
+  it("fails closed when token verification key is missing", async () => {
+    const res = response();
+    await POST(request({ auditSummary: auditSummary() }) as never, res as never);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM is required for audit upload.",
+    });
+  });
+
+  it("records an audit summary through the configured audit record store", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM = publicKeyPem;
+    let persisted:
+      | {
+          execution_id?: string;
+          actor_id?: string;
+          package_id?: string;
+          package_version?: string;
+          developer_ref?: string;
+          listing_owner_ref?: string;
+          billing_beneficiary_ref?: string;
+          role_usage_ledger?: { developerReceivableCents?: number };
+          changed_files?: string[];
+        }
+      | undefined;
+    const store = {
+      recordDijieAuditSummary: (record: never) =>
+        recordDijieAuditSummaryWithRepository(
+          {
+            async createDijieAuditRecords(data) {
+              persisted = data;
+              return { id: "djaudit_123" };
+            },
+          },
+          record,
+        ),
+    };
+
+    const res = response();
+    await POST(request({ auditSummary: auditSummary() }, token(), store) as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      executionId: "exec_123",
+      auditRecordId: "djaudit_123",
+      billingSummary: {
+        source: "role_usage",
+        inputTokens: 1_000_000,
+        outputTokens: 500_000,
+        developerReceivableCents: 300,
+        platformReceivableCents: 0,
+      },
+    });
+    expect(persisted).toMatchObject({
+      execution_id: "exec_123",
+      actor_id: "cus_123",
+      package_id: "pkg_role_123",
+      package_version: "1.0.0",
+      developer_ref: "dev_001",
+      listing_owner_ref: "seller_001",
+      billing_beneficiary_ref: "dev_001",
+      role_usage_ledger: {
+        executionId: "exec_123",
+        developerReceivableCents: 300,
+      },
+      changed_files: ["role_package/manifest.json"],
+    });
+  });
+
+  it("rejects audit uploads without model proxy usage for role token settlement", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM = publicKeyPem;
+
+    const { modelProxyUsage: _modelProxyUsage, ...summaryWithoutModelUsage } = auditSummary();
+    const res = response();
+    await POST(
+      request({
+        auditSummary: summaryWithoutModelUsage,
+      }) as never,
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({
+      ok: false,
+    });
+    expect((res.body as { error: string }).error).toContain("modelProxyUsage");
+  });
+
+  it("rejects audit uploads without audit.write scope", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM = publicKeyPem;
+
+    const res = response();
+    await POST(request({ auditSummary: auditSummary() }, token(["role.execute"])) as never, res as never);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "Dijie execution token is missing audit.write scope.",
+    });
+  });
+
+  it("rejects audit summaries that do not match the execution token", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM = publicKeyPem;
+
+    const res = response();
+    await POST(
+      request({
+        auditSummary: auditSummary({
+          entitlementId: "ent_other",
+        }),
+      }) as never,
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({
+      ok: false,
+    });
+    expect((res.body as { error: string }).error).toContain("entitlementId");
+  });
+
+  it("fails closed when no audit record store is configured", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM = publicKeyPem;
+
+    const res = response();
+    await POST(request({ auditSummary: auditSummary() }) as never, res as never);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "Dijie audit record store is not configured.",
+    });
+  });
+});

--- a/apps/api/src/api/dijie/audit/route.ts
+++ b/apps/api/src/api/dijie/audit/route.ts
@@ -1,0 +1,148 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import {
+  createDijieAuditRecord,
+  type DijieAuditRecord,
+} from "../../../lib/dijie/audit-summary";
+import {
+  DIJIE_AUDIT_MODULE,
+  type DijieAuditRecordStore,
+} from "../../../lib/dijie/audit-store";
+import { verifyDijieExecutionToken } from "../../../lib/dijie/execution-token";
+import { createDijieRoleTokenUsageLedgerEntryFromAudit } from "../../../lib/dijie/ledgers";
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function bearerFromRequest(req: MedusaRequest): string | undefined {
+  const authorization = req.headers.authorization;
+  if (Array.isArray(authorization)) {
+    return undefined;
+  }
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim();
+}
+
+function isAuditRecordStore(value: unknown): value is DijieAuditRecordStore {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { recordDijieAuditSummary?: unknown })
+      .recordDijieAuditSummary === "function"
+  );
+}
+
+function resolveAuditStore(req: MedusaRequest): DijieAuditRecordStore | undefined {
+  try {
+    const store = req.scope.resolve(DIJIE_AUDIT_MODULE) as unknown;
+    if (isAuditRecordStore(store)) {
+      return store;
+    }
+  } catch {
+    // Continue to the legacy name below. Both paths fail closed when absent.
+  }
+
+  try {
+    const legacyStore = req.scope.resolve("dijieAuditSink") as unknown;
+    if (isAuditRecordStore(legacyStore)) {
+      return legacyStore;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const publicKeyPem = process.env.DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM;
+  if (!publicKeyPem?.trim()) {
+    return res.status(503).json({
+      ok: false,
+      error: "DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM is required for audit upload.",
+    });
+  }
+
+  const executionToken = bearerFromRequest(req);
+  if (!executionToken) {
+    return res.status(401).json({
+      ok: false,
+      error: "Dijie audit upload requires a bearer execution token.",
+    });
+  }
+
+  const verified = verifyDijieExecutionToken(executionToken, publicKeyPem);
+  if (!verified.ok) {
+    return res.status(401).json({
+      ok: false,
+      error: verified.error,
+    });
+  }
+
+  const body = asRecord(req.body);
+  const summary = body.auditSummary ?? body.summary ?? body;
+  const record = createDijieAuditRecord({
+    claims: verified.claims,
+    summary,
+  });
+  if (!record.ok) {
+    return res.status(400).json({
+      ok: false,
+      error: record.error,
+    });
+  }
+
+  const roleUsageLedger = createDijieRoleTokenUsageLedgerEntryFromAudit(record.record);
+  if (!roleUsageLedger.ok) {
+    return res.status(400).json({
+      ok: false,
+      error: roleUsageLedger.error,
+    });
+  }
+
+  const auditRecord: DijieAuditRecord = {
+    ...record.record,
+    roleUsageLedger: roleUsageLedger.value,
+  };
+
+  const store = resolveAuditStore(req);
+  if (!store) {
+    return res.status(503).json({
+      ok: false,
+      error: "Dijie audit record store is not configured.",
+    });
+  }
+
+  let storeResult: { auditRecordId?: string } | void;
+  try {
+    storeResult = await store.recordDijieAuditSummary(auditRecord);
+  } catch {
+    return res.status(502).json({
+      ok: false,
+      error: "Dijie audit record store failed to persist the audit summary.",
+    });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    executionId: auditRecord.summary.executionId,
+    auditRecordId: storeResult?.auditRecordId,
+    billingSummary: {
+      source: "role_usage",
+      executionId: roleUsageLedger.value.executionId,
+      roleListingId: roleUsageLedger.value.roleListingId,
+      packageVersion: roleUsageLedger.value.packageVersion,
+      entitlementId: roleUsageLedger.value.entitlementId,
+      developerRef: roleUsageLedger.value.developerRef,
+      billingBeneficiaryRef: roleUsageLedger.value.billingBeneficiaryRef,
+      inputTokens: auditRecord.summary.modelProxyUsage?.inputTokens ?? 0,
+      outputTokens: auditRecord.summary.modelProxyUsage?.outputTokens ?? 0,
+      currency: roleUsageLedger.value.currency,
+      platformReceivableCents: 0,
+      developerReceivableCents: roleUsageLedger.value.developerReceivableCents,
+    },
+  });
+}

--- a/apps/api/src/api/dijie/entitlements/verify/route.test.ts
+++ b/apps/api/src/api/dijie/entitlements/verify/route.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { POST } from "./route";
+
+const validBody = {
+  actorId: "cus_123",
+  roleListingId: "prod_role_developer_agent",
+  entitlementId: "ordgrp_123",
+  deviceId: "device_123",
+  workspaceRef: "workspace_123",
+  localGatewayId: "gateway_123",
+};
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000,
+  platformFeeBps: 0,
+};
+
+type TestResponse = {
+  statusCode: number;
+  body: unknown;
+  status: (statusCode: number) => TestResponse;
+  json: (body: unknown) => unknown;
+};
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(statusCode: number) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return body;
+    },
+  };
+}
+
+function request(options: {
+  body?: Record<string, unknown>;
+  authorization?: string;
+  queryGraph?: (query: { entity: string }) => Promise<{ data: unknown[] }>;
+}) {
+  return {
+    body: options.body ?? validBody,
+    headers: {
+      authorization: options.authorization,
+    },
+    scope: {
+      resolve() {
+        return {
+          graph: options.queryGraph ?? (async ({ entity }) => {
+            if (entity === "product") {
+              return {
+                data: [
+                  {
+                    id: validBody.roleListingId,
+                    status: "published",
+                    metadata: {
+                      dijieRole: {
+                        kind: "role_product",
+                        protocolVersion: "2026-05",
+                        packageId: "pkg_developer",
+                        packageVersion: "1.0.0",
+                        developerRef: "dev_001",
+                        listingStatus: "published",
+                        reviewState: "approved",
+                        pricing: {
+                          kind: "one_time_authorization",
+                          authorizationFeeCents: 29900,
+                          currency: "CNY",
+                          platformFeeBps: 0,
+                          developerReceivableCents: 29900,
+                        },
+                        roleTokenPricing,
+                      },
+                    },
+                  },
+                ],
+              };
+            }
+            if (entity === "order_group") {
+              return {
+                data: [
+                  {
+                    id: validBody.entitlementId,
+                    customer_id: validBody.actorId,
+                    orders: [
+                      {
+                        id: "order_123",
+                        status: "completed",
+                        payment_collections: [
+                          { status: "captured", amount: 29900, captured_amount: 29900 },
+                        ],
+                        items: [{ product_id: validBody.roleListingId }],
+                      },
+                    ],
+                  },
+                ],
+              };
+            }
+            return { data: [] };
+          }),
+        };
+      },
+    },
+  };
+}
+
+describe("POST /dijie/entitlements/verify", () => {
+  afterEach(() => {
+    delete process.env.DIJIE_INTERNAL_BRIDGE_BEARER;
+  });
+
+  it("fails closed when the internal bearer is not configured", async () => {
+    const res = response();
+    await POST(request({ authorization: "Bearer bridge-secret" }) as never, res as never);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({ ok: false });
+  });
+
+  it("rejects callers without the internal bearer", async () => {
+    process.env.DIJIE_INTERNAL_BRIDGE_BEARER = "bridge-secret";
+
+    const res = response();
+    await POST(request({ authorization: "Bearer wrong" }) as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ ok: false });
+  });
+
+  it("approves paid one-time role entitlements", async () => {
+    process.env.DIJIE_INTERNAL_BRIDGE_BEARER = "bridge-secret";
+
+    const res = response();
+    await POST(request({ authorization: "Bearer bridge-secret" }) as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      pricing: {
+        kind: "one_time_authorization",
+        authorizationFeeCents: 29900,
+        currency: "CNY",
+        platformFeeBps: 0,
+        developerReceivableCents: 29900,
+      },
+      roleTokenPricing,
+      scopes: ["role.execute", "audit.write"],
+    });
+  });
+});

--- a/apps/api/src/api/dijie/entitlements/verify/route.ts
+++ b/apps/api/src/api/dijie/entitlements/verify/route.ts
@@ -1,0 +1,74 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { verifyDijieEntitlement } from "../../../../lib/dijie/entitlement-verifier";
+
+type UnknownRecord = Record<string, unknown>;
+
+const REQUIRED_FIELDS = [
+  "actorId",
+  "roleListingId",
+  "entitlementId",
+  "deviceId",
+  "workspaceRef",
+  "localGatewayId",
+] as const;
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function stringField(record: UnknownRecord, field: string): string | undefined {
+  const value = record[field];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function bearerFromRequest(req: MedusaRequest): string | undefined {
+  const authorization = req.headers.authorization;
+  if (Array.isArray(authorization)) {
+    return undefined;
+  }
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim();
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const internalBearer = process.env.DIJIE_INTERNAL_BRIDGE_BEARER?.trim();
+  if (!internalBearer) {
+    return res.status(503).json({
+      ok: false,
+      error: "DIJIE_INTERNAL_BRIDGE_BEARER is required for entitlement verification.",
+    });
+  }
+
+  if (bearerFromRequest(req) !== internalBearer) {
+    return res.status(401).json({
+      ok: false,
+      error: "Dijie entitlement verifier requires an internal bridge bearer.",
+    });
+  }
+
+  const body = asRecord(req.body);
+  const missing = REQUIRED_FIELDS.filter((field) => !stringField(body, field));
+  if (missing.length > 0) {
+    return res.status(400).json({
+      ok: false,
+      error: `Missing required fields: ${missing.join(", ")}`,
+    });
+  }
+
+  const query = req.scope.resolve("query");
+  const result = await verifyDijieEntitlement(
+    {
+      actorId: stringField(body, "actorId")!,
+      roleListingId: stringField(body, "roleListingId")!,
+      entitlementId: stringField(body, "entitlementId")!,
+      deviceId: stringField(body, "deviceId")!,
+      workspaceRef: stringField(body, "workspaceRef")!,
+      localGatewayId: stringField(body, "localGatewayId")!,
+    },
+    (queryInput) => query.graph(queryInput),
+  );
+
+  return res.status(result.ok ? 200 : result.status).json(result);
+}

--- a/apps/api/src/api/dijie/execution-token/route.test.ts
+++ b/apps/api/src/api/dijie/execution-token/route.test.ts
@@ -1,0 +1,224 @@
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it } from "bun:test";
+import { verifyDijieExecutionToken } from "../../../lib/dijie/execution-token";
+import { POST } from "./route";
+
+const keyPair = crypto.generateKeyPairSync("ed25519");
+const privateKeyPem = keyPair.privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+const publicKeyPem = keyPair.publicKey.export({ format: "pem", type: "spki" }).toString();
+const pricing = {
+  kind: "one_time_authorization",
+  authorizationFeeCents: 29900,
+  currency: "CNY",
+  platformFeeBps: 0,
+  developerReceivableCents: 29900,
+};
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000,
+  platformFeeBps: 0,
+};
+
+type TestResponse = {
+  statusCode: number;
+  body: unknown;
+  status: (statusCode: number) => TestResponse;
+  json: (body: unknown) => unknown;
+};
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(statusCode: number) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return body;
+    },
+  };
+}
+
+function request(body: Record<string, unknown>, actorId = "cus_123") {
+  return {
+    body,
+    auth_context: {
+      actor_id: actorId,
+    },
+  };
+}
+
+function validBody() {
+  return {
+    roleListingId: "role_developer_agent",
+    entitlementId: "ent_123",
+    deviceId: "device_123",
+    workspaceRef: "workspace_123",
+    localGatewayId: "gateway_123",
+  };
+}
+
+describe("POST /dijie/execution-token", () => {
+  afterEach(() => {
+    delete process.env.DIJIE_EXECUTION_TOKEN_ISSUER_ENABLED;
+    delete process.env.DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM;
+    delete process.env.DIJIE_ENTITLEMENT_VERIFY_URL;
+    delete process.env.DIJIE_EXECUTION_TOKEN_TTL_SECONDS;
+  });
+
+  it("fails closed when the entitlement verifier is not configured", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_ISSUER_ENABLED = "true";
+    process.env.DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM = privateKeyPem;
+
+    const res = response();
+    await POST(request(validBody()) as never, res as never);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "DIJIE_ENTITLEMENT_VERIFY_URL is required before minting execution tokens.",
+    });
+  });
+
+  it("mints a signed grant only after entitlement verifier approval", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_ISSUER_ENABLED = "true";
+    process.env.DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM = privateKeyPem;
+    process.env.DIJIE_ENTITLEMENT_VERIFY_URL = "https://dijie.test/verify-entitlement";
+    process.env.DIJIE_EXECUTION_TOKEN_TTL_SECONDS = "120";
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          ok: true,
+          packageId: "pkg_developer_agent",
+          packageVersion: "1.0.0",
+          developerRef: "dev_001",
+          listingOwnerRef: "seller_001",
+          billingBeneficiaryRef: "dev_001",
+          pricing,
+          roleTokenPricing,
+          scopes: ["role.execute", "audit.write"],
+        }),
+        { status: 200 },
+      );
+
+    try {
+      const res = response();
+      await POST(request(validBody()) as never, res as never);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        ok: true,
+        grant: {
+          roleListingId: "role_developer_agent",
+          packageId: "pkg_developer_agent",
+          packageVersion: "1.0.0",
+          developerRef: "dev_001",
+          listingOwnerRef: "seller_001",
+          billingBeneficiaryRef: "dev_001",
+          entitlementId: "ent_123",
+          deviceId: "device_123",
+          workspaceRef: "workspace_123",
+          localGatewayId: "gateway_123",
+          pricing,
+          roleTokenPricing,
+          scopes: ["role.execute", "audit.write"],
+        },
+      });
+
+      const grant = (res.body as { grant: { token: string } }).grant;
+      const verified = verifyDijieExecutionToken(grant.token, publicKeyPem);
+      expect(verified.ok).toBe(true);
+      if (verified.ok) {
+        expect(verified.claims.packageId).toBe("pkg_developer_agent");
+        expect(verified.claims.developerRef).toBe("dev_001");
+        expect(verified.claims.roleTokenPricing).toEqual(roleTokenPricing);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("defaults execution-token scopes to local execution and audit upload", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_ISSUER_ENABLED = "true";
+    process.env.DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM = privateKeyPem;
+    process.env.DIJIE_ENTITLEMENT_VERIFY_URL = "https://dijie.test/verify-entitlement";
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          ok: true,
+          packageId: "pkg_developer_agent",
+          packageVersion: "1.0.0",
+          developerRef: "dev_001",
+          listingOwnerRef: "seller_001",
+          billingBeneficiaryRef: "dev_001",
+          pricing,
+          roleTokenPricing,
+        }),
+        { status: 200 },
+      );
+
+    try {
+      const res = response();
+      await POST(request(validBody()) as never, res as never);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toMatchObject({
+        ok: true,
+        grant: {
+          scopes: ["role.execute", "audit.write"],
+        },
+      });
+
+      const grant = (res.body as { grant: { token: string } }).grant;
+      const verified = verifyDijieExecutionToken(grant.token, publicKeyPem);
+      expect(verified.ok).toBe(true);
+      if (verified.ok) {
+        expect(verified.claims.scopes).toEqual(["role.execute", "audit.write"]);
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("fails closed when entitlement verifier omits role token pricing", async () => {
+    process.env.DIJIE_EXECUTION_TOKEN_ISSUER_ENABLED = "true";
+    process.env.DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM = privateKeyPem;
+    process.env.DIJIE_ENTITLEMENT_VERIFY_URL = "https://dijie.test/verify-entitlement";
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          ok: true,
+          packageId: "pkg_developer_agent",
+          packageVersion: "1.0.0",
+          developerRef: "dev_001",
+          listingOwnerRef: "seller_001",
+          billingBeneficiaryRef: "dev_001",
+          pricing,
+        }),
+        { status: 200 },
+      );
+
+    try {
+      const res = response();
+      await POST(request(validBody()) as never, res as never);
+
+      expect(res.statusCode).toBe(502);
+      expect(res.body).toMatchObject({
+        ok: false,
+      });
+      expect((res.body as { error: string }).error).toContain("roleTokenPricing");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/api/src/api/dijie/execution-token/route.ts
+++ b/apps/api/src/api/dijie/execution-token/route.ts
@@ -1,0 +1,291 @@
+import { randomUUID } from "node:crypto";
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import {
+  createDijieExecutionToken,
+  normalizeOneTimeAuthorizationPricing,
+  normalizeRoleTokenPricing,
+  type DijieExecutionTokenPricing,
+  type DijieRoleTokenPricing,
+} from "../../../lib/dijie/execution-token";
+
+type UnknownRecord = Record<string, unknown>;
+type RequiredField = (typeof REQUIRED_FIELDS)[number];
+
+type EntitlementVerificationInput = Record<RequiredField, string> & {
+  actorId: string;
+};
+
+type EntitlementVerificationResult =
+  | {
+      ok: true;
+      packageId: string;
+      packageVersion: string;
+      developerRef: string;
+      listingOwnerRef: string;
+      billingBeneficiaryRef: string;
+      pricing: DijieExecutionTokenPricing;
+      roleTokenPricing: DijieRoleTokenPricing;
+      scopes: string[];
+    }
+  | {
+      ok: false;
+      status: number;
+      error: string;
+    };
+
+const REQUIRED_FIELDS = [
+  "roleListingId",
+  "entitlementId",
+  "deviceId",
+  "workspaceRef",
+  "localGatewayId",
+] as const;
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function stringField(record: UnknownRecord, field: string): string | undefined {
+  const value = record[field];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function optionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const normalized = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function parseTtlSeconds(value: string | undefined): number | undefined {
+  if (!value) {
+    return 300;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 30 && parsed <= 900 ? parsed : undefined;
+}
+
+function actorIdFromRequest(req: MedusaRequest): string | undefined {
+  const authContext = (req as MedusaRequest & { auth_context?: UnknownRecord }).auth_context;
+  return authContext ? stringField(authContext, "actor_id") : undefined;
+}
+
+async function verifyEntitlement(
+  input: EntitlementVerificationInput,
+): Promise<EntitlementVerificationResult> {
+  const verifierUrl = process.env.DIJIE_ENTITLEMENT_VERIFY_URL?.trim();
+  if (!verifierUrl) {
+    return {
+      ok: false,
+      status: 503,
+      error: "DIJIE_ENTITLEMENT_VERIFY_URL is required before minting execution tokens.",
+    };
+  }
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  const verifierBearer = process.env.DIJIE_ENTITLEMENT_VERIFY_BEARER?.trim();
+  if (verifierBearer) {
+    headers.authorization = `Bearer ${verifierBearer}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(verifierUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(input),
+    });
+  } catch {
+    return {
+      ok: false,
+      status: 502,
+      error: "Dijie entitlement verifier is unavailable.",
+    };
+  }
+
+  let payload: UnknownRecord = {};
+  try {
+    payload = asRecord(await response.json());
+  } catch {
+    payload = {};
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status === 401 ? 401 : 403,
+      error:
+        stringField(payload, "error") ??
+        stringField(payload, "reason") ??
+        "Dijie entitlement verifier rejected the execution request.",
+    };
+  }
+
+  if (payload.ok !== true) {
+    return {
+      ok: false,
+      status: 403,
+      error:
+        stringField(payload, "error") ??
+        stringField(payload, "reason") ??
+        "Dijie entitlement verifier did not approve the execution request.",
+    };
+  }
+
+  const pricing = normalizeOneTimeAuthorizationPricing(payload.pricing);
+  const roleTokenPricing = normalizeRoleTokenPricing(payload.roleTokenPricing);
+  const packageId = stringField(payload, "packageId");
+  const packageVersion = stringField(payload, "packageVersion");
+  const developerRef = stringField(payload, "developerRef");
+  const listingOwnerRef = stringField(payload, "listingOwnerRef");
+  const billingBeneficiaryRef = stringField(payload, "billingBeneficiaryRef");
+  if (!pricing) {
+    return {
+      ok: false,
+      status: 502,
+      error:
+        "Dijie entitlement verifier must return one_time_authorization pricing. Runtime-duration billing is not allowed.",
+    };
+  }
+  if (!roleTokenPricing) {
+    return {
+      ok: false,
+      status: 502,
+      error:
+        "Dijie entitlement verifier must return roleTokenPricing with input/output token cents per million, platformFeeBps=0, and developerReceivableBps=10000.",
+    };
+  }
+  if (!packageId || !packageVersion || !developerRef || !listingOwnerRef || !billingBeneficiaryRef) {
+    return {
+      ok: false,
+      status: 502,
+      error:
+        "Dijie entitlement verifier must return packageId, packageVersion, developerRef, listingOwnerRef, and billingBeneficiaryRef.",
+    };
+  }
+
+  return {
+    ok: true,
+    packageId,
+    packageVersion,
+    developerRef,
+    listingOwnerRef,
+    billingBeneficiaryRef,
+    pricing,
+    roleTokenPricing,
+    scopes: optionalStringArray(payload.scopes) ?? ["role.execute", "audit.write"],
+  };
+}
+
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const actorId = actorIdFromRequest(req);
+  if (!actorId) {
+    return res.status(401).json({
+      ok: false,
+      error: "Dijie execution token requests require an authenticated Mercur actor.",
+    });
+  }
+
+  const body = asRecord(req.body);
+  const missing = REQUIRED_FIELDS.filter((field) => !stringField(body, field));
+  if (missing.length > 0) {
+    return res.status(400).json({
+      ok: false,
+      error: `Missing required fields: ${missing.join(", ")}`,
+    });
+  }
+
+  if (process.env.DIJIE_EXECUTION_TOKEN_ISSUER_ENABLED !== "true") {
+    return res.status(503).json({
+      ok: false,
+      error: "Dijie execution token issuer is not enabled.",
+    });
+  }
+
+  const ttlSeconds = parseTtlSeconds(process.env.DIJIE_EXECUTION_TOKEN_TTL_SECONDS);
+  if (!ttlSeconds) {
+    return res.status(503).json({
+      ok: false,
+      error: "DIJIE_EXECUTION_TOKEN_TTL_SECONDS must be between 30 and 900 seconds.",
+    });
+  }
+
+  const executionRequest: EntitlementVerificationInput = {
+    actorId,
+    roleListingId: stringField(body, "roleListingId")!,
+    entitlementId: stringField(body, "entitlementId")!,
+    deviceId: stringField(body, "deviceId")!,
+    workspaceRef: stringField(body, "workspaceRef")!,
+    localGatewayId: stringField(body, "localGatewayId")!,
+  };
+
+  const entitlement = await verifyEntitlement(executionRequest);
+  if (!entitlement.ok) {
+    return res.status(entitlement.status).json({
+      ok: false,
+      error: entitlement.error,
+    });
+  }
+
+  const signed = createDijieExecutionToken(
+    {
+      executionId: randomUUID(),
+      actorId,
+      roleListingId: executionRequest.roleListingId,
+      packageId: entitlement.packageId,
+      packageVersion: entitlement.packageVersion,
+      developerRef: entitlement.developerRef,
+      listingOwnerRef: entitlement.listingOwnerRef,
+      billingBeneficiaryRef: entitlement.billingBeneficiaryRef,
+      entitlementId: executionRequest.entitlementId,
+      deviceId: executionRequest.deviceId,
+      workspaceRef: executionRequest.workspaceRef,
+      localGatewayId: executionRequest.localGatewayId,
+      pricing: entitlement.pricing,
+      roleTokenPricing: entitlement.roleTokenPricing,
+      scopes: entitlement.scopes,
+      ttlSeconds,
+    },
+    process.env.DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM,
+  );
+  if (!signed.ok) {
+    return res.status(503).json({
+      ok: false,
+      error: signed.error,
+    });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    grant: {
+      executionId: signed.claims.executionId,
+      roleListingId: signed.claims.roleListingId,
+      packageId: signed.claims.packageId,
+      packageVersion: signed.claims.packageVersion,
+      developerRef: signed.claims.developerRef,
+      listingOwnerRef: signed.claims.listingOwnerRef,
+      billingBeneficiaryRef: signed.claims.billingBeneficiaryRef,
+      entitlementId: signed.claims.entitlementId,
+      deviceId: signed.claims.deviceId,
+      workspaceRef: signed.claims.workspaceRef,
+      localGatewayId: signed.claims.localGatewayId,
+      token: signed.token,
+      issuedAt: new Date(signed.claims.iat * 1000).toISOString(),
+      expiresAt: new Date(signed.claims.exp * 1000).toISOString(),
+      pricing: signed.claims.pricing,
+      roleTokenPricing: signed.claims.roleTokenPricing,
+      scopes: signed.claims.scopes,
+    },
+  });
+}

--- a/apps/api/src/api/dijie/executions/[executionId]/route.test.ts
+++ b/apps/api/src/api/dijie/executions/[executionId]/route.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createDijieAuditStorageRecord,
+  DIJIE_AUDIT_MODULE,
+} from "../../../../lib/dijie/audit-store";
+import type { DijieAuditRecord } from "../../../../lib/dijie/audit-summary";
+import { GET } from "./route";
+
+type TestResponse = {
+  statusCode: number;
+  body: unknown;
+  status: (statusCode: number) => TestResponse;
+  json: (body: unknown) => unknown;
+};
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(statusCode: number) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return body;
+    },
+  };
+}
+
+function request(
+  store?: unknown,
+  params: Record<string, string> = { executionId: "exec_123" },
+  actorId: string | null = "cus_123",
+) {
+  return {
+    params,
+    ...(actorId
+      ? {
+          auth_context: {
+            actor_id: actorId,
+          },
+        }
+      : {}),
+    scope: {
+      resolve(name: string) {
+        if (store && name === DIJIE_AUDIT_MODULE) {
+          return store;
+        }
+        throw new Error(`Unknown dependency: ${name}`);
+      },
+    },
+  };
+}
+
+function queryRequest(data: unknown[]) {
+  return {
+    params: {
+      executionId: "exec_123",
+    },
+    auth_context: {
+      actor_id: "cus_123",
+    },
+    scope: {
+      resolve(name: string) {
+        if (name === "query") {
+          return {
+            async graph(input: { entity: string; filters: { execution_id: string } }) {
+              expect(input).toMatchObject({
+                entity: "dijie_audit_record",
+                filters: {
+                  execution_id: "exec_123",
+                },
+              });
+              return { data };
+            },
+          };
+        }
+        throw new Error(`Unknown dependency: ${name}`);
+      },
+    },
+  };
+}
+
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000 as const,
+  platformFeeBps: 0 as const,
+};
+
+const record: DijieAuditRecord = {
+  auditRecordVersion: 1,
+  actorId: "cus_123",
+  packageId: "pkg_role_123",
+  packageVersion: "1.0.0",
+  developerRef: "dev_001",
+  listingOwnerRef: "seller_001",
+  billingBeneficiaryRef: "dev_001",
+  receivedAt: "2026-05-31T08:02:00.000Z",
+  executionTokenIssuedAt: "2026-05-31T08:00:00.000Z",
+  executionTokenExpiresAt: "2026-05-31T08:05:00.000Z",
+  pricing: {
+    kind: "one_time_authorization",
+    authorizationFeeCents: 29900,
+    currency: "CNY",
+    platformFeeBps: 0,
+    developerReceivableCents: 29900,
+  },
+  roleTokenPricing,
+  roleUsageLedger: {
+    ledger: "usage",
+    source: "role_usage",
+    entryId: "role_usage_exec_123",
+    executionId: "exec_123",
+    actorId: "cus_123",
+    developerId: "dev_001",
+    developerRef: "dev_001",
+    billingBeneficiaryRef: "dev_001",
+    roleListingId: "role_123",
+    packageId: "pkg_role_123",
+    packageVersion: "1.0.0",
+    entitlementId: "ent_123",
+    workspaceRef: "workspace_123",
+    usageKind: "model_tokens",
+    meters: [
+      { name: "request_count", quantity: 1, unit: "request" },
+      { name: "input_tokens", quantity: 1000, unit: "token" },
+      { name: "output_tokens", quantity: 500, unit: "token" },
+    ],
+    currency: "CNY",
+    grossAmountCents: 1,
+    platformReceivableCents: 0,
+    developerReceivableCents: 1,
+    occurredAt: "2026-05-31T08:02:00.000Z",
+  },
+  summary: {
+    executionId: "exec_123",
+    deviceId: "device_123",
+    workspaceRef: "workspace_123",
+    roleListingId: "role_123",
+    packageId: "pkg_role_123",
+    packageVersion: "1.0.0",
+    developerRef: "dev_001",
+    listingOwnerRef: "seller_001",
+    billingBeneficiaryRef: "dev_001",
+    entitlementId: "ent_123",
+    localGatewayId: "gateway_123",
+    status: "failed",
+    startedAt: "2026-05-31T08:00:00.000Z",
+    endedAt: "2026-05-31T08:01:00.000Z",
+    modelProxyUsage: {
+      requestCount: 1,
+      inputTokens: 1000,
+      outputTokens: 500,
+    },
+    toolUsage: {
+      shellCommands: 2,
+      testsRun: 1,
+      filesRead: 4,
+      filesChanged: 2,
+    },
+    result: {
+      executionId: "exec_123",
+      roleListingId: "role_123",
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "seller_001",
+      billingBeneficiaryRef: "dev_001",
+      status: "failed",
+      startedAt: "2026-05-31T08:00:00.000Z",
+      endedAt: "2026-05-31T08:01:00.000Z",
+      changedFiles: ["/Users/alice/workspace/private.ts", "role_package/manifest.json"],
+      artifacts: [
+        {
+          id: "artifact_123",
+          type: "role_package",
+          title: "Role package",
+          sizeBytes: 2048,
+          sha256: "abc123",
+        },
+      ],
+      error: "Validation failed.",
+    },
+  },
+};
+
+describe("GET /dijie/executions/:executionId", () => {
+  it("requires an authenticated Mercur actor", async () => {
+    const res = response();
+    await GET(request(undefined, { executionId: "exec_123" }, null) as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "Dijie execution audit reads require an authenticated Mercur actor.",
+    });
+  });
+
+  it("rejects requests without an execution id path parameter", async () => {
+    const res = response();
+    await GET(request(undefined, {}) as never, res as never);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "Dijie executionId path parameter is required.",
+    });
+  });
+
+  it("returns a safe audit read model from the audit module service", async () => {
+    const storageRecord = createDijieAuditStorageRecord(record);
+    const store = {
+      async retrieveDijieAuditRecordByExecutionId(executionId: string) {
+        expect(executionId).toBe("exec_123");
+        return storageRecord;
+      },
+    };
+
+    const res = response();
+    await GET(request(store) as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      roleListingId: "role_123",
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "seller_001",
+      billingBeneficiaryRef: "dev_001",
+      status: "failed",
+      pricing: {
+        authorizationFeeCents: 29900,
+      },
+      roleTokenPricing: {
+        inputTokenCentsPerMillion: 120,
+        outputTokenCentsPerMillion: 360,
+      },
+      billingSummary: {
+        source: "role_usage",
+        inputTokens: 1000,
+        outputTokens: 500,
+        inputTokenCentsPerMillion: 120,
+        outputTokenCentsPerMillion: 360,
+        platformReceivableCents: 0,
+        developerReceivableCents: 1,
+      },
+      toolUsage: {
+        filesChanged: 2,
+      },
+      modelProxyUsage: {
+        requestCount: 1,
+      },
+      changedFiles: ["private.ts", "role_package/manifest.json"],
+      artifacts: [
+        {
+          id: "artifact_123",
+          type: "role_package",
+          title: "Role package",
+        },
+      ],
+      errorSummary: "Validation failed.",
+      receivedAt: "2026-05-31T08:02:00.000Z",
+    });
+    const bodyText = JSON.stringify(res.body);
+    expect(bodyText).not.toContain("/Users/alice");
+    expect(bodyText).not.toContain("exec_123");
+    expect(bodyText).not.toContain("cus_123");
+    expect(bodyText).not.toContain("ent_123");
+    expect(bodyText).not.toContain("device_123");
+    expect(bodyText).not.toContain("workspace_123");
+    expect(bodyText).not.toContain("gateway_123");
+    expect(res.body).not.toHaveProperty("executionId");
+    expect(res.body).not.toHaveProperty("actorId");
+    expect(res.body).not.toHaveProperty("entitlementId");
+    expect(res.body).not.toHaveProperty("deviceId");
+    expect(res.body).not.toHaveProperty("workspaceRef");
+    expect(res.body).not.toHaveProperty("localGatewayId");
+    expect(res.body).not.toHaveProperty("payload");
+  });
+
+  it("rejects reads for a different actor", async () => {
+    const storageRecord = createDijieAuditStorageRecord(record);
+    const store = {
+      async retrieveDijieAuditRecordByExecutionId() {
+        return storageRecord;
+      },
+    };
+
+    const res = response();
+    await GET(request(store, { executionId: "exec_123" }, "cus_other") as never, res as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "Dijie execution audit record is not available to this actor.",
+    });
+  });
+
+  it("redacts local paths, provider auth, model keys, and raw tokens from the read response", async () => {
+    const storageRecord = createDijieAuditStorageRecord(record);
+    storageRecord.workspace_ref = "/Users/alice/private-workspace";
+    storageRecord.changed_files = [
+      "/Users/alice/private-workspace/role.ts",
+      "file:///Users/alice/private-workspace/report.json",
+    ];
+    storageRecord.artifacts = [
+      {
+        id: "artifact_123",
+        type: "role_package",
+        title: "/Users/alice/private-workspace/output.zip",
+        sizeBytes: 2048,
+      },
+    ];
+    storageRecord.error_summary =
+      "provider_auth=cloud-secret api_key=sk-local-secret Authorization: Bearer cloud-bearer failed at /Users/alice/private-workspace/role.ts token eyJhbGciOiJFZERTQSJ9.eyJleHAiOjE4MDB9.signature";
+    const store = {
+      async retrieveDijieAuditRecordByExecutionId() {
+        return storageRecord;
+      },
+    };
+
+    const res = response();
+    await GET(request(store) as never, res as never);
+
+    const bodyText = JSON.stringify(res.body);
+    expect(res.statusCode).toBe(200);
+    expect(bodyText).not.toContain("/Users/alice");
+    expect(bodyText).not.toContain("file:///Users/alice");
+    expect(bodyText).not.toContain("cloud-secret");
+    expect(bodyText).not.toContain("sk-local-secret");
+    expect(bodyText).not.toContain("eyJhbGciOiJFZERTQSJ9");
+    expect(res.body).toMatchObject({
+      changedFiles: ["role.ts", "report.json"],
+      artifacts: [
+        {
+          title: "[redacted-local-path]",
+        },
+      ],
+      errorSummary:
+        "provider_auth=[redacted-secret] api_key=[redacted-secret] Authorization: Bearer [redacted-secret] failed at [redacted-local-path] token [redacted-token]",
+    });
+  });
+
+  it("returns 404 when the execution audit record is missing", async () => {
+    const store = {
+      async retrieveDijieAuditRecordByExecutionId() {
+        return undefined;
+      },
+    };
+
+    const res = response();
+    await GET(request(store) as never, res as never);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("fails closed when no audit read source is configured", async () => {
+    const res = response();
+    await GET(request() as never, res as never);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: "Dijie audit record store is not configured.",
+    });
+  });
+
+  it("returns an internal read error when the audit store throws", async () => {
+    const store = {
+      async retrieveDijieAuditRecordByExecutionId() {
+        throw new Error("database unavailable");
+      },
+    };
+
+    const res = response();
+    await GET(request(store) as never, res as never);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("can read the audit record through query graph when the module service is absent", async () => {
+    const storageRecord = createDijieAuditStorageRecord(record);
+    const res = response();
+    await GET(queryRequest([storageRecord]) as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      billingBeneficiaryRef: "dev_001",
+      changedFiles: ["private.ts", "role_package/manifest.json"],
+    });
+    expect(res.body).not.toHaveProperty("executionId");
+    expect(res.body).not.toHaveProperty("actorId");
+    expect(res.body).not.toHaveProperty("entitlementId");
+    expect(res.body).not.toHaveProperty("deviceId");
+    expect(res.body).not.toHaveProperty("workspaceRef");
+    expect(res.body).not.toHaveProperty("localGatewayId");
+  });
+});

--- a/apps/api/src/api/dijie/executions/[executionId]/route.ts
+++ b/apps/api/src/api/dijie/executions/[executionId]/route.ts
@@ -1,0 +1,305 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import {
+  createDijieAuditExecutionReadModel,
+  DIJIE_AUDIT_MODULE,
+  type DijieAuditExecutionReadModel,
+  type DijieAuditExecutionRecordReader,
+  type DijieAuditStorageRecord,
+} from "../../../../lib/dijie/audit-store";
+
+type UnknownRecord = Record<string, unknown>;
+
+type QueryGraph = {
+  graph: (input: {
+    entity: string;
+    fields: string[];
+    filters: { execution_id: string };
+    pagination: { take: number };
+  }) => Promise<{ data?: unknown[] }>;
+};
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function stringField(record: UnknownRecord, field: string): string | undefined {
+  const value = record[field];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function actorIdFromRequest(req: MedusaRequest): string | undefined {
+  const authContext = (req as MedusaRequest & { auth_context?: UnknownRecord }).auth_context;
+  return authContext ? stringField(authContext, "actor_id") : undefined;
+}
+
+function arrayField(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted-secret]")
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[redacted-token]")
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "[redacted-secret]")
+    .replace(
+      /\b(api[_-]?key|secret|provider[_ -]?auth|access[_-]?token|refresh[_-]?token)\s*[:=]\s*["']?[^"'\s,;]+/gi,
+      "$1=[redacted-secret]",
+    )
+    .replace(/\bfile:\/\/[^\s)]+/g, "[redacted-local-path]")
+    .replace(/\b[A-Za-z]:[\\/][^\s)]+/g, "[redacted-local-path]")
+    .replace(/(^|[\s(["'])(\/(?:Users|home|private|var|tmp|Volumes)\/[^\s)"']+)/g, "$1[redacted-local-path]");
+}
+
+function sanitizeReadModelForGateway(
+  readModel: DijieAuditExecutionReadModel,
+): DijieAuditExecutionReadModel {
+  return {
+    ...readModel,
+    changedFiles: readModel.changedFiles.map(redactSensitiveText),
+    artifacts: readModel.artifacts.map((artifact) => ({
+      ...artifact,
+      id: redactSensitiveText(artifact.id),
+      type: redactSensitiveText(artifact.type),
+      title: redactSensitiveText(artifact.title),
+    })),
+    errorSummary:
+      readModel.errorSummary === null ? null : redactSensitiveText(readModel.errorSummary),
+  };
+}
+
+function isAuditRecordReader(value: unknown): value is DijieAuditExecutionRecordReader {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { retrieveDijieAuditRecordByExecutionId?: unknown })
+      .retrieveDijieAuditRecordByExecutionId === "function"
+  );
+}
+
+function resolveAuditRecordReader(
+  req: MedusaRequest,
+): DijieAuditExecutionRecordReader | undefined {
+  try {
+    const store = req.scope.resolve(DIJIE_AUDIT_MODULE) as unknown;
+    if (isAuditRecordReader(store)) {
+      return store;
+    }
+  } catch {
+    // Query graph fallback below keeps the read endpoint usable in tests and admin surfaces.
+  }
+
+  try {
+    const legacyStore = req.scope.resolve("dijieAuditSink") as unknown;
+    if (isAuditRecordReader(legacyStore)) {
+      return legacyStore;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveQueryGraph(req: MedusaRequest): QueryGraph | undefined {
+  try {
+    const query = req.scope.resolve("query") as unknown;
+    if (
+      query &&
+      typeof query === "object" &&
+      typeof (query as { graph?: unknown }).graph === "function"
+    ) {
+      return query as QueryGraph;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function storageRecordFromGraphResult(value: unknown): DijieAuditStorageRecord | undefined {
+  const record = asRecord(value);
+  const executionId = stringField(record, "execution_id");
+  const actorId = stringField(record, "actor_id");
+  const roleListingId = stringField(record, "role_listing_id");
+  const packageId = stringField(record, "package_id");
+  const packageVersion = stringField(record, "package_version");
+  const developerRef = stringField(record, "developer_ref");
+  const listingOwnerRef = stringField(record, "listing_owner_ref");
+  const billingBeneficiaryRef = stringField(record, "billing_beneficiary_ref");
+  const entitlementId = stringField(record, "entitlement_id");
+  const deviceId = stringField(record, "device_id");
+  const workspaceRef = stringField(record, "workspace_ref");
+  const localGatewayId = stringField(record, "local_gateway_id");
+  const status = stringField(record, "status");
+  const receivedAt = record.received_at;
+
+  if (
+    !executionId ||
+    !actorId ||
+    !roleListingId ||
+    !packageId ||
+    !packageVersion ||
+    !developerRef ||
+    !listingOwnerRef ||
+    !billingBeneficiaryRef ||
+    !entitlementId ||
+    !deviceId ||
+    !workspaceRef ||
+    !localGatewayId ||
+    !status ||
+    !(receivedAt instanceof Date || typeof receivedAt === "string")
+  ) {
+    return undefined;
+  }
+
+  return {
+    execution_id: executionId,
+    actor_id: actorId,
+    role_listing_id: roleListingId,
+    package_id: packageId,
+    package_version: packageVersion,
+    developer_ref: developerRef,
+    listing_owner_ref: listingOwnerRef,
+    billing_beneficiary_ref: billingBeneficiaryRef,
+    entitlement_id: entitlementId,
+    device_id: deviceId,
+    workspace_ref: workspaceRef,
+    local_gateway_id: localGatewayId,
+    status,
+    execution_token_issued_at: new Date(0),
+    execution_token_expires_at: new Date(0),
+    received_at: receivedAt instanceof Date ? receivedAt : new Date(receivedAt),
+    pricing: record.pricing as DijieAuditStorageRecord["pricing"],
+    role_token_pricing: record.role_token_pricing as DijieAuditStorageRecord["role_token_pricing"],
+    role_usage_ledger:
+      record.role_usage_ledger === undefined || record.role_usage_ledger === null
+        ? null
+        : (record.role_usage_ledger as DijieAuditStorageRecord["role_usage_ledger"]),
+    model_proxy_usage:
+      record.model_proxy_usage === undefined
+        ? null
+        : (record.model_proxy_usage as DijieAuditStorageRecord["model_proxy_usage"]),
+    tool_usage: record.tool_usage as DijieAuditStorageRecord["tool_usage"],
+    changed_files: arrayField(record.changed_files) as string[],
+    artifacts: arrayField(record.artifacts) as DijieAuditStorageRecord["artifacts"],
+    error_summary:
+      record.error_summary === undefined || record.error_summary === null
+        ? null
+        : String(record.error_summary),
+    payload: {} as DijieAuditStorageRecord["payload"],
+  };
+}
+
+async function retrieveAuditRecord(
+  req: MedusaRequest,
+  executionId: string,
+): Promise<{ configured: boolean; record?: DijieAuditStorageRecord }> {
+  const reader = resolveAuditRecordReader(req);
+  if (reader) {
+    return {
+      configured: true,
+      record: await reader.retrieveDijieAuditRecordByExecutionId(executionId),
+    };
+  }
+
+  const query = resolveQueryGraph(req);
+  if (!query) {
+    return { configured: false };
+  }
+
+  const { data = [] } = await query.graph({
+    entity: "dijie_audit_record",
+    fields: [
+      "execution_id",
+      "actor_id",
+      "role_listing_id",
+      "package_id",
+      "package_version",
+      "developer_ref",
+      "listing_owner_ref",
+      "billing_beneficiary_ref",
+      "entitlement_id",
+      "device_id",
+      "workspace_ref",
+      "local_gateway_id",
+      "status",
+      "pricing",
+      "role_token_pricing",
+      "role_usage_ledger",
+      "model_proxy_usage",
+      "tool_usage",
+      "changed_files",
+      "artifacts",
+      "error_summary",
+      "received_at",
+    ],
+    filters: {
+      execution_id: executionId,
+    },
+    pagination: {
+      take: 1,
+    },
+  });
+
+  return {
+    configured: true,
+    record: storageRecordFromGraphResult(data[0]),
+  };
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const actorId = actorIdFromRequest(req);
+  if (!actorId) {
+    return res.status(401).json({
+      ok: false,
+      error: "Dijie execution audit reads require an authenticated Mercur actor.",
+    });
+  }
+
+  const params = (req as MedusaRequest & { params?: Record<string, string> }).params ?? {};
+  const executionId = params.executionId?.trim();
+
+  if (!executionId) {
+    return res.status(400).json({
+      ok: false,
+      error: "Dijie executionId path parameter is required.",
+    });
+  }
+
+  let result: { configured: boolean; record?: DijieAuditStorageRecord };
+  try {
+    result = await retrieveAuditRecord(req, executionId);
+  } catch {
+    return res.status(502).json({
+      ok: false,
+      error: "Dijie audit record store failed to read the execution audit record.",
+    });
+  }
+
+  if (!result.configured) {
+    return res.status(503).json({
+      ok: false,
+      error: "Dijie audit record store is not configured.",
+    });
+  }
+
+  if (!result.record) {
+    return res.status(404).json({
+      ok: false,
+      error: "Dijie execution audit record was not found.",
+    });
+  }
+
+  if (result.record.actor_id !== actorId) {
+    return res.status(403).json({
+      ok: false,
+      error: "Dijie execution audit record is not available to this actor.",
+    });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    ...sanitizeReadModelForGateway(createDijieAuditExecutionReadModel(result.record)),
+  });
+}

--- a/apps/api/src/api/dijie/my-roles/route.test.ts
+++ b/apps/api/src/api/dijie/my-roles/route.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { GET } from "./route";
+
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000,
+  platformFeeBps: 0,
+};
+
+type TestResponse = {
+  statusCode: number;
+  body: unknown;
+  status: (statusCode: number) => TestResponse;
+  json: (body: unknown) => unknown;
+};
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(statusCode: number) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return body;
+    },
+  };
+}
+
+function request(actorId?: string) {
+  return {
+    auth_context: actorId ? { actor_id: actorId } : undefined,
+    scope: {
+      resolve() {
+        return {
+          graph: async ({ entity }: { entity: string }) => {
+            if (entity === "product") {
+              return {
+                data: [
+                  {
+                    id: "prod_role_developer",
+                    title: "开发岗位",
+                    status: "published",
+                    metadata: {
+                      dijieRole: {
+                        kind: "role_product",
+                        protocolVersion: "2026-05",
+                        packageId: "pkg_developer",
+                        packageVersion: "1.0.0",
+                        developerRef: "dev_001",
+                        listingStatus: "published",
+                        reviewState: "approved",
+                        capabilities: ["代码生成"],
+                        pricing: {
+                          kind: "one_time_authorization",
+                          authorizationFeeCents: 29900,
+                          currency: "CNY",
+                          platformFeeBps: 0,
+                          developerReceivableCents: 29900,
+                        },
+                        roleTokenPricing,
+                      },
+                    },
+                  },
+                ],
+              };
+            }
+            if (entity === "order_group") {
+              return {
+                data: [
+                  {
+                    id: "ordgrp_001",
+                    customer_id: actorId,
+                    orders: [
+                      {
+                        id: "order_001",
+                        status: "completed",
+                        payment_collections: [
+                          { status: "captured", amount: 29900, captured_amount: 29900 },
+                        ],
+                        items: [{ product_id: "prod_role_developer" }],
+                      },
+                    ],
+                  },
+                ],
+              };
+            }
+            return { data: [] };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("GET /dijie/my-roles", () => {
+  it("requires an authenticated Dijie customer actor", async () => {
+    const res = response();
+    await GET(request() as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ ok: false });
+  });
+
+  it("returns roles installed through paid marketplace orders", async () => {
+    const res = response();
+    await GET(request("cus_001") as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      roles: [
+        {
+          entitlementId: "ordgrp_001",
+          entitlementSource: "order_group",
+          orderId: "order_001",
+          role: {
+            id: "prod_role_developer",
+            title: "开发岗位",
+            packageId: "pkg_developer",
+            packageVersion: "1.0.0",
+          },
+        },
+      ],
+    });
+  });
+});

--- a/apps/api/src/api/dijie/my-roles/route.ts
+++ b/apps/api/src/api/dijie/my-roles/route.ts
@@ -1,0 +1,47 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { listDijieInstalledRoles } from "../../../lib/dijie/role-listings";
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function stringField(record: UnknownRecord, field: string): string | undefined {
+  const value = record[field];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function actorIdFromRequest(req: MedusaRequest): string | undefined {
+  const authContext = (req as MedusaRequest & { auth_context?: UnknownRecord }).auth_context;
+  return authContext ? stringField(authContext, "actor_id") : undefined;
+}
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const actorId = actorIdFromRequest(req);
+  if (!actorId) {
+    return res.status(401).json({
+      ok: false,
+      error: "读取我的岗位需要先登录迭界AI账号。",
+    });
+  }
+
+  const query = req.scope.resolve("query");
+  try {
+    const roles = await listDijieInstalledRoles({
+      actorId,
+      queryGraph: (queryInput) => query.graph(queryInput),
+    });
+    return res.status(200).json({
+      ok: true,
+      roles,
+    });
+  } catch {
+    return res.status(502).json({
+      ok: false,
+      error: "迭界AI岗位商场暂时无法读取我的岗位。",
+    });
+  }
+}

--- a/apps/api/src/api/dijie/roles/route.test.ts
+++ b/apps/api/src/api/dijie/roles/route.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "bun:test";
+import { GET } from "./route";
+
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000,
+  platformFeeBps: 0,
+};
+
+type TestResponse = {
+  statusCode: number;
+  body: unknown;
+  status: (statusCode: number) => TestResponse;
+  json: (body: unknown) => unknown;
+};
+
+function response(): TestResponse {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(statusCode: number) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return body;
+    },
+  };
+}
+
+function request() {
+  return {
+    scope: {
+      resolve() {
+        return {
+          graph: async () => ({
+            data: [
+              {
+                id: "prod_role_developer",
+                title: "开发岗位",
+                status: "published",
+                metadata: {
+                  dijieRole: {
+                    kind: "role_product",
+                    protocolVersion: "2026-05",
+                    packageId: "pkg_developer",
+                    packageVersion: "1.0.0",
+                    developerRef: "dev_001",
+                    listingStatus: "published",
+                    reviewState: "approved",
+                    capabilities: ["代码生成"],
+                    pricing: {
+                      kind: "one_time_authorization",
+                      authorizationFeeCents: 29900,
+                      currency: "CNY",
+                      platformFeeBps: 0,
+                      developerReceivableCents: 29900,
+                    },
+                    roleTokenPricing,
+                  },
+                },
+              },
+              {
+                id: "prod_regular",
+                title: "普通商品",
+                status: "published",
+                metadata: {},
+              },
+            ],
+          }),
+        };
+      },
+    },
+  };
+}
+
+describe("GET /dijie/roles", () => {
+  it("returns public Dijie role listings from marketplace products", async () => {
+    const res = response();
+    await GET(request() as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      roles: [
+        {
+          id: "prod_role_developer",
+          title: "开发岗位",
+          listingStatus: "published",
+          reviewState: "approved",
+          packageId: "pkg_developer",
+          packageVersion: "1.0.0",
+          protocolVersion: "2026-05",
+          capabilities: ["代码生成"],
+          pricing: {
+            kind: "one_time_authorization",
+            authorizationFeeCents: 29900,
+            currency: "CNY",
+            platformFeeBps: 0,
+            developerReceivableCents: 29900,
+          },
+          roleTokenPricing,
+        },
+      ],
+    });
+  });
+});

--- a/apps/api/src/api/dijie/roles/route.ts
+++ b/apps/api/src/api/dijie/roles/route.ts
@@ -1,0 +1,19 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { listDijieRoleListings } from "../../../lib/dijie/role-listings";
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const query = req.scope.resolve("query");
+
+  try {
+    const roles = await listDijieRoleListings((queryInput) => query.graph(queryInput));
+    return res.status(200).json({
+      ok: true,
+      roles,
+    });
+  } catch {
+    return res.status(502).json({
+      ok: false,
+      error: "迭界AI岗位商场暂时无法读取岗位商品。",
+    });
+  }
+}

--- a/apps/api/src/api/middlewares.ts
+++ b/apps/api/src/api/middlewares.ts
@@ -1,5 +1,70 @@
+import { authenticate } from "@medusajs/framework";
 import { defineMiddlewares } from "@medusajs/medusa";
 
+import { findDijieRoleMetadataPrivacyIssues } from "../lib/dijie/role-product-metadata";
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+    return value && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+};
+
+const rejectPrivateDijieRoleMetadata = (req: any, res: any, next: any) => {
+    const body = asRecord(req.body);
+    const metadata = asRecord(body.metadata);
+    const role = asRecord(metadata.dijieRole);
+
+    if (!Object.keys(role).length) {
+        return next();
+    }
+
+    const issues = findDijieRoleMetadataPrivacyIssues(role);
+    if (issues.length > 0) {
+        return res.status(400).json({
+            message: "metadata.dijieRole contains private developer-mode or platform bridge fields.",
+            issues,
+        });
+    }
+
+    return next();
+};
+
 export default defineMiddlewares({
-    routes: [],
+    routes: [
+        {
+            matcher: "/admin/products",
+            method: ["POST", "PUT", "PATCH"],
+            middlewares: [rejectPrivateDijieRoleMetadata],
+        },
+        {
+            matcher: "/admin/products/:id",
+            method: ["POST", "PUT", "PATCH"],
+            middlewares: [rejectPrivateDijieRoleMetadata],
+        },
+        {
+            matcher: "/vendor/products",
+            method: ["POST", "PUT", "PATCH"],
+            middlewares: [rejectPrivateDijieRoleMetadata],
+        },
+        {
+            matcher: "/vendor/products/:id",
+            method: ["POST", "PUT", "PATCH"],
+            middlewares: [rejectPrivateDijieRoleMetadata],
+        },
+        {
+            matcher: "/dijie/execution-token",
+            method: ["POST"],
+            middlewares: [authenticate("customer", ["session", "bearer"])],
+        },
+        {
+            matcher: "/dijie/my-roles",
+            method: ["GET"],
+            middlewares: [authenticate("customer", ["session", "bearer"])],
+        },
+        {
+            matcher: "/dijie/executions/:executionId",
+            method: ["GET"],
+            middlewares: [authenticate("customer", ["session", "bearer"])],
+        },
+    ],
 });

--- a/apps/api/src/lib/dijie/audit-store.test.ts
+++ b/apps/api/src/lib/dijie/audit-store.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createDijieAuditExecutionReadModel,
+  createDijieAuditStorageRecord,
+  retrieveDijieAuditRecordByExecutionIdWithRepository,
+  recordDijieAuditSummaryWithRepository,
+  type DijieAuditStorageRecord,
+} from "./audit-store";
+import type { DijieAuditRecord } from "./audit-summary";
+
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000 as const,
+  platformFeeBps: 0 as const,
+};
+
+const record: DijieAuditRecord = {
+  auditRecordVersion: 1,
+  actorId: "cus_123",
+  packageId: "pkg_role_123",
+  packageVersion: "1.0.0",
+  developerRef: "dev_001",
+  listingOwnerRef: "seller_001",
+  billingBeneficiaryRef: "dev_001",
+  receivedAt: "2026-05-31T08:02:00.000Z",
+  executionTokenIssuedAt: "2026-05-31T08:00:00.000Z",
+  executionTokenExpiresAt: "2026-05-31T08:05:00.000Z",
+  pricing: {
+    kind: "one_time_authorization",
+    authorizationFeeCents: 29900,
+    currency: "CNY",
+    platformFeeBps: 0,
+    developerReceivableCents: 29900,
+  },
+  roleTokenPricing,
+  roleUsageLedger: {
+    ledger: "usage",
+    source: "role_usage",
+    entryId: "role_usage_exec_123",
+    executionId: "exec_123",
+    actorId: "cus_123",
+    developerId: "dev_001",
+    developerRef: "dev_001",
+    billingBeneficiaryRef: "dev_001",
+    roleListingId: "role_123",
+    packageId: "pkg_role_123",
+    packageVersion: "1.0.0",
+    entitlementId: "ent_123",
+    workspaceRef: "workspace_123",
+    usageKind: "model_tokens",
+    meters: [
+      { name: "request_count", quantity: 1, unit: "request" },
+      { name: "input_tokens", quantity: 1000, unit: "token" },
+      { name: "output_tokens", quantity: 500, unit: "token" },
+    ],
+    currency: "CNY",
+    grossAmountCents: 1,
+    platformReceivableCents: 0,
+    developerReceivableCents: 1,
+    occurredAt: "2026-05-31T08:02:00.000Z",
+  },
+  summary: {
+    executionId: "exec_123",
+    deviceId: "device_123",
+    workspaceRef: "workspace_123",
+    roleListingId: "role_123",
+    packageId: "pkg_role_123",
+    packageVersion: "1.0.0",
+    developerRef: "dev_001",
+    listingOwnerRef: "seller_001",
+    billingBeneficiaryRef: "dev_001",
+    entitlementId: "ent_123",
+    localGatewayId: "gateway_123",
+    status: "failed",
+    startedAt: "2026-05-31T08:00:00.000Z",
+    endedAt: "2026-05-31T08:01:00.000Z",
+    modelProxyUsage: {
+      requestCount: 1,
+      inputTokens: 1000,
+      outputTokens: 500,
+    },
+    toolUsage: {
+      shellCommands: 2,
+      testsRun: 1,
+      filesRead: 4,
+      filesChanged: 2,
+    },
+    result: {
+      executionId: "exec_123",
+      roleListingId: "role_123",
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "seller_001",
+      billingBeneficiaryRef: "dev_001",
+      status: "failed",
+      startedAt: "2026-05-31T08:00:00.000Z",
+      endedAt: "2026-05-31T08:01:00.000Z",
+      changedFiles: ["role_package/manifest.json"],
+      artifacts: [
+        {
+          id: "artifact_123",
+          type: "role_package",
+          title: "Role package",
+          sizeBytes: 2048,
+          sha256: "abc123",
+        },
+      ],
+      error: "Validation failed.",
+    },
+  },
+};
+
+describe("Dijie audit store", () => {
+  it("maps an audit record to the durable storage shape", () => {
+    const storageRecord = createDijieAuditStorageRecord(record);
+
+    expect(storageRecord).toMatchObject({
+      execution_id: "exec_123",
+      actor_id: "cus_123",
+      role_listing_id: "role_123",
+      package_id: "pkg_role_123",
+      package_version: "1.0.0",
+      developer_ref: "dev_001",
+      listing_owner_ref: "seller_001",
+      billing_beneficiary_ref: "dev_001",
+      entitlement_id: "ent_123",
+      device_id: "device_123",
+      workspace_ref: "workspace_123",
+      local_gateway_id: "gateway_123",
+      status: "failed",
+      pricing: {
+        platformFeeBps: 0,
+        developerReceivableCents: 29900,
+      },
+      role_token_pricing: roleTokenPricing,
+      role_usage_ledger: {
+        developerReceivableCents: 1,
+      },
+      tool_usage: {
+        filesChanged: 2,
+      },
+      changed_files: ["role_package/manifest.json"],
+      error_summary: "Validation failed.",
+    });
+    expect(storageRecord.execution_token_issued_at.toISOString()).toBe(
+      "2026-05-31T08:00:00.000Z",
+    );
+    expect(storageRecord.payload).toEqual(record);
+  });
+
+  it("sanitizes sensitive payload fields before durable storage", () => {
+    const storageRecord = createDijieAuditStorageRecord({
+      ...record,
+      summary: {
+        ...record.summary,
+        workspaceRef: "/Users/alice/private/workspace",
+        result: {
+          ...record.summary.result,
+          changedFiles: [
+            "/Users/alice/private/project/secret.ts",
+            "role_package/manifest.json",
+          ],
+          artifacts: [
+            {
+              id: "artifact_123",
+              type: "role_package",
+              title: "file:///Users/alice/private/package.zip",
+              sizeBytes: 2048,
+              sha256: "abc123",
+            },
+          ],
+          error:
+            "Bearer cloud-secret-token sk-local-secret provider_auth=raw-value /Users/alice/private/log.txt",
+        },
+      },
+    });
+
+    const storedJson = JSON.stringify(storageRecord);
+    expect(storageRecord.workspace_ref).toBe("workspace");
+    expect(storageRecord.changed_files).toEqual(["secret.ts", "role_package/manifest.json"]);
+    expect(storageRecord.error_summary).toContain("Bearer [redacted-token]");
+    expect(storageRecord.error_summary).toContain("[redacted-model-key]");
+    expect(storageRecord.error_summary).toContain("provider_auth=[redacted-secret]");
+    expect(storageRecord.error_summary).toContain("log.txt");
+    expect(storedJson).not.toContain("/Users/alice");
+    expect(storedJson).not.toContain("cloud-secret-token");
+    expect(storedJson).not.toContain("sk-local-secret");
+    expect(storedJson).not.toContain("raw-value");
+  });
+
+  it("persists through a repository-backed store instead of returning a fake success", async () => {
+    let persisted: DijieAuditStorageRecord | undefined;
+    const result = await recordDijieAuditSummaryWithRepository(
+      {
+        async createDijieAuditRecords(data) {
+          persisted = data;
+          return { id: "djaudit_123" };
+        },
+      },
+      record,
+    );
+
+    expect(result).toEqual({ auditRecordId: "djaudit_123" });
+    expect(persisted).toMatchObject({
+      execution_id: "exec_123",
+      status: "failed",
+      error_summary: "Validation failed.",
+    });
+  });
+
+  it("reads the latest audit record by execution id", async () => {
+    const storageRecord = createDijieAuditStorageRecord(record);
+    let filters: { execution_id: string } | undefined;
+    let config: { take?: number; order?: Record<string, "ASC" | "DESC"> } | undefined;
+
+    const result = await retrieveDijieAuditRecordByExecutionIdWithRepository(
+      {
+        async listDijieAuditRecords(inputFilters, inputConfig) {
+          filters = inputFilters;
+          config = inputConfig;
+          return [storageRecord];
+        },
+      },
+      "exec_123",
+    );
+
+    expect(result).toBe(storageRecord);
+    expect(filters).toEqual({ execution_id: "exec_123" });
+    expect(config).toMatchObject({
+      take: 1,
+      order: {
+        received_at: "DESC",
+      },
+    });
+  });
+
+  it("projects a safe execution read model without payload or local absolute paths", () => {
+    const storageRecord = createDijieAuditStorageRecord(record);
+    storageRecord.changed_files = [
+      "/Users/alice/project/secret-local-file.ts",
+      "role_package/manifest.json",
+    ];
+    storageRecord.payload = {
+      ...record,
+      summary: {
+        ...record.summary,
+        result: {
+          ...record.summary.result,
+          error: "provider key sk-local-secret",
+        },
+      },
+    };
+
+    const readModel = createDijieAuditExecutionReadModel(storageRecord);
+
+    expect(readModel).toMatchObject({
+      roleListingId: "role_123",
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "seller_001",
+      billingBeneficiaryRef: "dev_001",
+      status: "failed",
+      roleTokenPricing,
+      billingSummary: {
+        source: "role_usage",
+        developerRef: "dev_001",
+        billingBeneficiaryRef: "dev_001",
+        inputTokens: 1000,
+        outputTokens: 500,
+        platformReceivableCents: 0,
+        developerReceivableCents: 1,
+      },
+      changedFiles: ["secret-local-file.ts", "role_package/manifest.json"],
+      errorSummary: "Validation failed.",
+      receivedAt: "2026-05-31T08:02:00.000Z",
+    });
+    expect(JSON.stringify(readModel)).not.toContain("/Users/alice");
+    expect(JSON.stringify(readModel)).not.toContain("sk-local-secret");
+    expect(JSON.stringify(readModel)).not.toContain("exec_123");
+    expect(JSON.stringify(readModel)).not.toContain("cus_123");
+    expect(JSON.stringify(readModel)).not.toContain("ent_123");
+    expect(JSON.stringify(readModel)).not.toContain("device_123");
+    expect(JSON.stringify(readModel)).not.toContain("workspace_123");
+    expect(JSON.stringify(readModel)).not.toContain("gateway_123");
+    expect(readModel).not.toHaveProperty("executionId");
+    expect(readModel).not.toHaveProperty("actorId");
+    expect(readModel).not.toHaveProperty("entitlementId");
+    expect(readModel).not.toHaveProperty("deviceId");
+    expect(readModel).not.toHaveProperty("workspaceRef");
+    expect(readModel).not.toHaveProperty("localGatewayId");
+    expect(readModel).not.toHaveProperty("payload");
+  });
+});

--- a/apps/api/src/lib/dijie/audit-store.ts
+++ b/apps/api/src/lib/dijie/audit-store.ts
@@ -1,0 +1,315 @@
+import type { DijieAuditRecord } from "./audit-summary";
+
+export const DIJIE_AUDIT_MODULE = "dijieAuditRecordStore";
+
+export type DijieAuditStorageRecord = {
+  execution_id: string;
+  actor_id: string;
+  role_listing_id: string;
+  package_id: string;
+  package_version: string;
+  developer_ref: string;
+  listing_owner_ref: string;
+  billing_beneficiary_ref: string;
+  entitlement_id: string;
+  device_id: string;
+  workspace_ref: string;
+  local_gateway_id: string;
+  status: string;
+  execution_token_issued_at: Date;
+  execution_token_expires_at: Date;
+  received_at: Date;
+  pricing: DijieAuditRecord["pricing"];
+  role_token_pricing: DijieAuditRecord["roleTokenPricing"];
+  role_usage_ledger: DijieAuditRecord["roleUsageLedger"] | null;
+  model_proxy_usage: DijieAuditRecord["summary"]["modelProxyUsage"] | null;
+  tool_usage: DijieAuditRecord["summary"]["toolUsage"];
+  changed_files: string[];
+  artifacts: DijieAuditRecord["summary"]["result"]["artifacts"];
+  error_summary: string | null;
+  payload: DijieAuditRecord;
+};
+
+export type DijieAuditRecordRepository = {
+  createDijieAuditRecords: (
+    data: DijieAuditStorageRecord,
+  ) => Promise<{ id?: string }>;
+};
+
+export type DijieAuditRecordLookupRepository = {
+  listDijieAuditRecords: (
+    filters: { execution_id: string },
+    config?: {
+      take?: number;
+      order?: Record<string, "ASC" | "DESC">;
+    },
+  ) => Promise<DijieAuditStorageRecord[]>;
+};
+
+export type DijieAuditRecordStore = {
+  recordDijieAuditSummary: (
+    record: DijieAuditRecord,
+  ) => Promise<{ auditRecordId?: string }>;
+};
+
+export type DijieAuditExecutionRecordReader = {
+  retrieveDijieAuditRecordByExecutionId: (
+    executionId: string,
+  ) => Promise<DijieAuditStorageRecord | undefined>;
+};
+
+export type DijieAuditExecutionReadModel = {
+  roleListingId: string;
+  packageId: string;
+  packageVersion: string;
+  developerRef: string;
+  listingOwnerRef: string;
+  billingBeneficiaryRef: string;
+  status: string;
+  pricing: DijieAuditRecord["pricing"];
+  roleTokenPricing: DijieAuditRecord["roleTokenPricing"];
+  billingSummary: {
+    source: "role_usage";
+    roleListingId: string;
+    packageId: string;
+    packageVersion: string;
+    developerRef: string;
+    billingBeneficiaryRef: string;
+    inputTokens: number;
+    outputTokens: number;
+    inputTokenCentsPerMillion: number;
+    outputTokenCentsPerMillion: number;
+    currency: string;
+    platformReceivableCents: 0;
+    developerReceivableCents: number;
+  } | null;
+  toolUsage: DijieAuditRecord["summary"]["toolUsage"];
+  modelProxyUsage: DijieAuditRecord["summary"]["modelProxyUsage"] | null;
+  changedFiles: string[];
+  artifacts: DijieAuditRecord["summary"]["result"]["artifacts"];
+  errorSummary: string | null;
+  receivedAt: string;
+};
+
+export function createDijieAuditStorageRecord(
+  record: DijieAuditRecord,
+): DijieAuditStorageRecord {
+  const sanitizedPayload = sanitizeAuditRecordForStorage(record);
+  return {
+    execution_id: record.summary.executionId,
+    actor_id: record.actorId,
+    role_listing_id: record.summary.roleListingId,
+    package_id: record.packageId,
+    package_version: record.packageVersion,
+    developer_ref: record.developerRef,
+    listing_owner_ref: record.listingOwnerRef,
+    billing_beneficiary_ref: record.billingBeneficiaryRef,
+    entitlement_id: record.summary.entitlementId,
+    device_id: record.summary.deviceId,
+    workspace_ref: sanitizeSensitiveText(record.summary.workspaceRef),
+    local_gateway_id: record.summary.localGatewayId,
+    status: record.summary.status,
+    execution_token_issued_at: new Date(record.executionTokenIssuedAt),
+    execution_token_expires_at: new Date(record.executionTokenExpiresAt),
+    received_at: new Date(record.receivedAt),
+    pricing: record.pricing,
+    role_token_pricing: record.roleTokenPricing,
+    role_usage_ledger: record.roleUsageLedger
+      ? (sanitizeStorageValue(record.roleUsageLedger) as DijieAuditRecord["roleUsageLedger"])
+      : null,
+    model_proxy_usage: record.summary.modelProxyUsage ?? null,
+    tool_usage: record.summary.toolUsage,
+    changed_files: sanitizeChangedFiles(record.summary.result.changedFiles),
+    artifacts: sanitizeStorageArtifacts(record.summary.result.artifacts),
+    error_summary: record.summary.result.error ? sanitizeSensitiveText(record.summary.result.error) : null,
+    payload: sanitizedPayload,
+  };
+}
+
+function toIsoString(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function sanitizePathReference(value: string): string {
+  const trimmed = value.trim();
+  const normalized = trimmed.replace(/\\/g, "/");
+  const isLocalAbsolutePath =
+    normalized.startsWith("/") ||
+    /^[a-zA-Z]:\//.test(normalized) ||
+    normalized.startsWith("//") ||
+    normalized.startsWith("file://");
+
+  if (!isLocalAbsolutePath) {
+    return trimmed;
+  }
+
+  const basename = normalized.split("/").filter(Boolean).at(-1);
+  return basename ?? "[redacted-local-path]";
+}
+
+function sanitizeSensitiveText(value: string): string {
+  return sanitizePathReference(value)
+    .replace(
+      /(?:file:\/\/)?\/(?:Users|private|var|tmp|Volumes)\/[^\s"',)]+/giu,
+      (match) => sanitizePathReference(match),
+    )
+    .replace(/[A-Za-z]:\/[^\s"',)]+/giu, (match) => sanitizePathReference(match))
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/giu, "Bearer [redacted-token]")
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/gu, "[redacted-model-key]")
+    .replace(
+      /\b(api[_-]?key|provider[_-]?auth|secret|token)\s*[:=]\s*["']?[^"',}\s]+/giu,
+      "$1=[redacted-secret]",
+    )
+    .replace(
+      /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/gu,
+      "[redacted-jwt]",
+    );
+}
+
+function sanitizeStorageValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return sanitizeSensitiveText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeStorageValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, entry]) => {
+      const normalizedKey = key.replaceAll("_", "").toLowerCase();
+      if (
+        normalizedKey.includes("secret") ||
+        normalizedKey.includes("apikey") ||
+        normalizedKey.includes("providerauth") ||
+        normalizedKey === "authorization" ||
+        normalizedKey === "token"
+      ) {
+        return [key, "[redacted-secret]"];
+      }
+      return [key, sanitizeStorageValue(entry)];
+    }),
+  );
+}
+
+function sanitizeAuditRecordForStorage(record: DijieAuditRecord): DijieAuditRecord {
+  return sanitizeStorageValue(record) as DijieAuditRecord;
+}
+
+function sanitizeChangedFiles(value: string[]): string[] {
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map(sanitizePathReference)
+    .filter(Boolean);
+}
+
+function sanitizeArtifacts(
+  value: DijieAuditStorageRecord["artifacts"],
+): DijieAuditExecutionReadModel["artifacts"] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((artifact) => {
+      if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) {
+        return undefined;
+      }
+
+      return {
+        id: String(artifact.id),
+        type: String(artifact.type),
+        title: String(artifact.title),
+        ...(artifact.sizeBytes === undefined ? {} : { sizeBytes: artifact.sizeBytes }),
+        ...(artifact.sha256 === undefined ? {} : { sha256: artifact.sha256 }),
+      };
+    })
+    .filter((artifact): artifact is DijieAuditExecutionReadModel["artifacts"][number] =>
+      Boolean(artifact?.id && artifact.type && artifact.title),
+    );
+}
+
+function sanitizeStorageArtifacts(
+  value: DijieAuditStorageRecord["artifacts"],
+): DijieAuditStorageRecord["artifacts"] {
+  return sanitizeStorageValue(value) as DijieAuditStorageRecord["artifacts"];
+}
+
+function createBillingSummary(
+  record: DijieAuditStorageRecord,
+): DijieAuditExecutionReadModel["billingSummary"] {
+  if (!record.role_usage_ledger || !record.model_proxy_usage) {
+    return null;
+  }
+
+  return {
+    source: "role_usage",
+    roleListingId: record.role_usage_ledger.roleListingId,
+    packageId: record.role_usage_ledger.packageId,
+    packageVersion: record.role_usage_ledger.packageVersion,
+    developerRef: record.role_usage_ledger.developerRef,
+    billingBeneficiaryRef: record.role_usage_ledger.billingBeneficiaryRef,
+    inputTokens: record.model_proxy_usage.inputTokens,
+    outputTokens: record.model_proxy_usage.outputTokens,
+    inputTokenCentsPerMillion: record.role_token_pricing.inputTokenCentsPerMillion,
+    outputTokenCentsPerMillion: record.role_token_pricing.outputTokenCentsPerMillion,
+    currency: record.role_usage_ledger.currency,
+    platformReceivableCents: 0,
+    developerReceivableCents: record.role_usage_ledger.developerReceivableCents,
+  };
+}
+
+export function createDijieAuditExecutionReadModel(
+  record: DijieAuditStorageRecord,
+): DijieAuditExecutionReadModel {
+  return {
+    roleListingId: record.role_listing_id,
+    packageId: record.package_id,
+    packageVersion: record.package_version,
+    developerRef: record.developer_ref,
+    listingOwnerRef: record.listing_owner_ref,
+    billingBeneficiaryRef: record.billing_beneficiary_ref,
+    status: record.status,
+    pricing: record.pricing,
+    roleTokenPricing: record.role_token_pricing,
+    billingSummary: createBillingSummary(record),
+    toolUsage: record.tool_usage,
+    modelProxyUsage: record.model_proxy_usage,
+    changedFiles: sanitizeChangedFiles(record.changed_files),
+    artifacts: sanitizeArtifacts(record.artifacts),
+    errorSummary: record.error_summary,
+    receivedAt: toIsoString(record.received_at),
+  };
+}
+
+export async function recordDijieAuditSummaryWithRepository(
+  repository: DijieAuditRecordRepository,
+  record: DijieAuditRecord,
+): Promise<{ auditRecordId?: string }> {
+  const stored = await repository.createDijieAuditRecords(
+    createDijieAuditStorageRecord(record),
+  );
+
+  return {
+    auditRecordId: stored.id,
+  };
+}
+
+export async function retrieveDijieAuditRecordByExecutionIdWithRepository(
+  repository: DijieAuditRecordLookupRepository,
+  executionId: string,
+): Promise<DijieAuditStorageRecord | undefined> {
+  const [record] = await repository.listDijieAuditRecords(
+    { execution_id: executionId },
+    {
+      take: 1,
+      order: {
+        received_at: "DESC",
+      },
+    },
+  );
+
+  return record;
+}

--- a/apps/api/src/lib/dijie/audit-summary.test.ts
+++ b/apps/api/src/lib/dijie/audit-summary.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "bun:test";
+import { createDijieAuditRecord } from "./audit-summary";
+import type { DijieExecutionTokenClaims } from "./execution-token";
+
+const claims: DijieExecutionTokenClaims = {
+  iss: "dijie-cloud",
+  typ: "dijie_execution",
+  executionId: "exec_123",
+  actorId: "cus_123",
+  roleListingId: "role_123",
+  packageId: "pkg_role_123",
+  packageVersion: "1.0.0",
+  developerRef: "dev_001",
+  listingOwnerRef: "seller_001",
+  billingBeneficiaryRef: "dev_001",
+  entitlementId: "ent_123",
+  deviceId: "device_123",
+  workspaceRef: "workspace_123",
+  localGatewayId: "gateway_123",
+  scopes: ["role.execute", "audit.write"],
+  pricing: {
+    kind: "one_time_authorization",
+    authorizationFeeCents: 29900,
+    currency: "CNY",
+    platformFeeBps: 0,
+    developerReceivableCents: 29900,
+  },
+  roleTokenPricing: {
+    inputTokenCentsPerMillion: 120,
+    outputTokenCentsPerMillion: 360,
+    currency: "CNY",
+    developerReceivableBps: 10000,
+    platformFeeBps: 0,
+  },
+  iat: 1_800_000_000,
+  exp: 1_800_000_300,
+};
+
+function auditSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    executionId: "exec_123",
+    deviceId: "device_123",
+    workspaceRef: "workspace_123",
+    roleListingId: "role_123",
+    packageId: "pkg_role_123",
+    packageVersion: "1.0.0",
+    developerRef: "dev_001",
+    listingOwnerRef: "seller_001",
+    billingBeneficiaryRef: "dev_001",
+    entitlementId: "ent_123",
+    localGatewayId: "gateway_123",
+    status: "completed",
+    startedAt: "2026-05-31T08:00:00.000Z",
+    endedAt: "2026-05-31T08:01:00.000Z",
+    modelProxyUsage: {
+      requestCount: 1,
+      inputTokens: 1000,
+      outputTokens: 500,
+    },
+    toolUsage: {
+      shellCommands: 2,
+      testsRun: 1,
+      filesRead: 4,
+      filesChanged: 2,
+    },
+    result: {
+      executionId: "exec_123",
+      roleListingId: "role_123",
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "seller_001",
+      billingBeneficiaryRef: "dev_001",
+      status: "completed",
+      startedAt: "2026-05-31T08:00:00.000Z",
+      endedAt: "2026-05-31T08:01:00.000Z",
+      summary: "Generated role package.",
+      changedFiles: ["role_package/manifest.json"],
+      artifacts: [
+        {
+          id: "artifact_123",
+          type: "role_package",
+          title: "Role package",
+          sizeBytes: 2048,
+          sha256: "abc123",
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("Dijie audit summaries", () => {
+  it("creates an audit record when summary matches the execution token", () => {
+    const result = createDijieAuditRecord({
+      claims,
+      summary: auditSummary(),
+      receivedAt: "2026-05-31T08:02:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.record).toMatchObject({
+      auditRecordVersion: 1,
+      actorId: "cus_123",
+      packageId: "pkg_role_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "seller_001",
+      billingBeneficiaryRef: "dev_001",
+      roleTokenPricing: {
+        inputTokenCentsPerMillion: 120,
+        outputTokenCentsPerMillion: 360,
+      },
+      receivedAt: "2026-05-31T08:02:00.000Z",
+      summary: {
+        executionId: "exec_123",
+        result: {
+          changedFiles: ["role_package/manifest.json"],
+        },
+      },
+    });
+  });
+
+  it("rejects summaries when token scope is missing audit.write", () => {
+    const result = createDijieAuditRecord({
+      claims: {
+        ...claims,
+        scopes: ["role.execute"],
+      },
+      summary: auditSummary(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("audit.write");
+    }
+  });
+
+  it("rejects summaries that do not match the execution token", () => {
+    const result = createDijieAuditRecord({
+      claims,
+      summary: auditSummary({
+        roleListingId: "role_other",
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("roleListingId");
+    }
+  });
+
+  it("rejects empty changed file placeholders", () => {
+    const result = createDijieAuditRecord({
+      claims,
+      summary: auditSummary({
+        result: {
+          executionId: "exec_123",
+          roleListingId: "role_123",
+          packageId: "pkg_role_123",
+          packageVersion: "1.0.0",
+          developerRef: "dev_001",
+          listingOwnerRef: "seller_001",
+          billingBeneficiaryRef: "dev_001",
+          status: "completed",
+          startedAt: "2026-05-31T08:00:00.000Z",
+          endedAt: "2026-05-31T08:01:00.000Z",
+          changedFiles: [""],
+          artifacts: [],
+        },
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/api/src/lib/dijie/audit-summary.ts
+++ b/apps/api/src/lib/dijie/audit-summary.ts
@@ -1,0 +1,367 @@
+import type { DijieExecutionTokenClaims } from "./execution-token";
+import type { DijieRoleUsageLedgerEntry } from "./ledgers";
+
+export type DijieExecutionStatus = "completed" | "failed" | "cancelled" | "timed_out";
+
+export type DijieRoleArtifact = {
+  id: string;
+  type: string;
+  title: string;
+  sizeBytes?: number;
+  sha256?: string;
+};
+
+export type DijieRoleResult = {
+  executionId: string;
+  roleListingId: string;
+  packageId: string;
+  packageVersion: string;
+  developerRef: string;
+  listingOwnerRef: string;
+  billingBeneficiaryRef: string;
+  status: DijieExecutionStatus;
+  startedAt: string | number;
+  endedAt: string | number;
+  summary?: string;
+  changedFiles: string[];
+  artifacts: DijieRoleArtifact[];
+  error?: string;
+};
+
+export type DijieAuditSummary = {
+  executionId: string;
+  deviceId: string;
+  workspaceRef: string;
+  roleListingId: string;
+  packageId: string;
+  packageVersion: string;
+  developerRef: string;
+  listingOwnerRef: string;
+  billingBeneficiaryRef: string;
+  entitlementId: string;
+  localGatewayId: string;
+  status: DijieExecutionStatus;
+  startedAt: string | number;
+  endedAt: string | number;
+  modelProxyUsage?: {
+    requestCount: number;
+    inputTokens: number;
+    outputTokens: number;
+  };
+  toolUsage: {
+    shellCommands: number;
+    testsRun: number;
+    filesRead: number;
+    filesChanged: number;
+  };
+  result: DijieRoleResult;
+};
+
+export type DijieAuditRecord = {
+  auditRecordVersion: 1;
+  actorId: string;
+  packageId: string;
+  packageVersion: string;
+  developerRef: string;
+  listingOwnerRef: string;
+  billingBeneficiaryRef: string;
+  receivedAt: string;
+  executionTokenIssuedAt: string;
+  executionTokenExpiresAt: string;
+  pricing: DijieExecutionTokenClaims["pricing"];
+  roleTokenPricing: DijieExecutionTokenClaims["roleTokenPricing"];
+  roleUsageLedger?: DijieRoleUsageLedgerEntry;
+  summary: DijieAuditSummary;
+};
+
+export type DijieAuditSummaryResult =
+  | {
+      ok: true;
+      record: DijieAuditRecord;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+const STATUSES = new Set<DijieExecutionStatus>(["completed", "failed", "cancelled", "timed_out"]);
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function timestamp(value: unknown): string | number | undefined {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  return Number.isInteger(value) && Number(value) >= 0 ? Number(value) : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+  return Number.isInteger(value) && Number(value) >= 0 ? Number(value) : undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const normalized = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return normalized.length === value.length ? normalized : undefined;
+}
+
+function normalizeArtifacts(value: unknown): DijieRoleArtifact[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const artifacts = value.map((item) => {
+    const record = asRecord(item);
+    const id = nonEmptyString(record.id);
+    const type = nonEmptyString(record.type);
+    const title = nonEmptyString(record.title);
+    const sizeBytes = record.sizeBytes === undefined ? undefined : nonNegativeInteger(record.sizeBytes);
+    const sha256 = record.sha256 === undefined ? undefined : nonEmptyString(record.sha256);
+    if (
+      !id ||
+      !type ||
+      !title ||
+      (sizeBytes === undefined && record.sizeBytes !== undefined) ||
+      (!sha256 && record.sha256 !== undefined)
+    ) {
+      return undefined;
+    }
+    return {
+      id,
+      type,
+      title,
+      ...(sizeBytes === undefined ? {} : { sizeBytes }),
+      ...(sha256 === undefined ? {} : { sha256 }),
+    };
+  });
+
+  return artifacts.every(Boolean) ? (artifacts as DijieRoleArtifact[]) : undefined;
+}
+
+function normalizeRoleResult(value: unknown): DijieRoleResult | undefined {
+  const record = asRecord(value);
+  const executionId = nonEmptyString(record.executionId);
+  const roleListingId = nonEmptyString(record.roleListingId);
+  const packageId = nonEmptyString(record.packageId);
+  const packageVersion = nonEmptyString(record.packageVersion);
+  const developerRef = nonEmptyString(record.developerRef);
+  const listingOwnerRef = nonEmptyString(record.listingOwnerRef);
+  const billingBeneficiaryRef = nonEmptyString(record.billingBeneficiaryRef);
+  const status = nonEmptyString(record.status) as DijieExecutionStatus | undefined;
+  const startedAt = timestamp(record.startedAt);
+  const endedAt = timestamp(record.endedAt);
+  const changedFiles = stringArray(record.changedFiles);
+  const artifacts = normalizeArtifacts(record.artifacts);
+  const summary = record.summary === undefined ? undefined : String(record.summary);
+  const error = record.error === undefined ? undefined : String(record.error);
+
+  if (
+    !executionId ||
+    !roleListingId ||
+    !packageId ||
+    !packageVersion ||
+    !developerRef ||
+    !listingOwnerRef ||
+    !billingBeneficiaryRef ||
+    !status ||
+    !STATUSES.has(status) ||
+    startedAt === undefined ||
+    endedAt === undefined ||
+    !changedFiles ||
+    !artifacts
+  ) {
+    return undefined;
+  }
+
+  return {
+    executionId,
+    roleListingId,
+    packageId,
+    packageVersion,
+    developerRef,
+    listingOwnerRef,
+    billingBeneficiaryRef,
+    status,
+    startedAt,
+    endedAt,
+    ...(summary === undefined ? {} : { summary }),
+    changedFiles,
+    artifacts,
+    ...(error === undefined ? {} : { error }),
+  };
+}
+
+function normalizeToolUsage(value: unknown): DijieAuditSummary["toolUsage"] | undefined {
+  const record = asRecord(value);
+  const shellCommands = nonNegativeInteger(record.shellCommands);
+  const testsRun = nonNegativeInteger(record.testsRun);
+  const filesRead = nonNegativeInteger(record.filesRead);
+  const filesChanged = nonNegativeInteger(record.filesChanged);
+  if (
+    shellCommands === undefined ||
+    testsRun === undefined ||
+    filesRead === undefined ||
+    filesChanged === undefined
+  ) {
+    return undefined;
+  }
+  return { shellCommands, testsRun, filesRead, filesChanged };
+}
+
+function normalizeModelProxyUsage(value: unknown): DijieAuditSummary["modelProxyUsage"] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const record = asRecord(value);
+  const requestCount = nonNegativeInteger(record.requestCount);
+  const inputTokens = nonNegativeInteger(record.inputTokens);
+  const outputTokens = nonNegativeInteger(record.outputTokens);
+  if (requestCount === undefined || inputTokens === undefined || outputTokens === undefined) {
+    return undefined;
+  }
+  return { requestCount, inputTokens, outputTokens };
+}
+
+export function normalizeDijieAuditSummary(value: unknown): DijieAuditSummary | undefined {
+  const record = asRecord(value);
+  const executionId = nonEmptyString(record.executionId);
+  const deviceId = nonEmptyString(record.deviceId);
+  const workspaceRef = nonEmptyString(record.workspaceRef);
+  const roleListingId = nonEmptyString(record.roleListingId);
+  const packageId = nonEmptyString(record.packageId);
+  const packageVersion = nonEmptyString(record.packageVersion);
+  const developerRef = nonEmptyString(record.developerRef);
+  const listingOwnerRef = nonEmptyString(record.listingOwnerRef);
+  const billingBeneficiaryRef = nonEmptyString(record.billingBeneficiaryRef);
+  const entitlementId = nonEmptyString(record.entitlementId);
+  const localGatewayId = nonEmptyString(record.localGatewayId);
+  const status = nonEmptyString(record.status) as DijieExecutionStatus | undefined;
+  const startedAt = timestamp(record.startedAt);
+  const endedAt = timestamp(record.endedAt);
+  const modelProxyUsage = normalizeModelProxyUsage(record.modelProxyUsage);
+  const toolUsage = normalizeToolUsage(record.toolUsage);
+  const result = normalizeRoleResult(record.result);
+
+  if (
+    !executionId ||
+    !deviceId ||
+    !workspaceRef ||
+    !roleListingId ||
+    !packageId ||
+    !packageVersion ||
+    !developerRef ||
+    !listingOwnerRef ||
+    !billingBeneficiaryRef ||
+    !entitlementId ||
+    !localGatewayId ||
+    !status ||
+    !STATUSES.has(status) ||
+    startedAt === undefined ||
+    endedAt === undefined ||
+    !toolUsage ||
+    !result ||
+    modelProxyUsage === undefined && record.modelProxyUsage !== undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    executionId,
+    deviceId,
+    workspaceRef,
+    roleListingId,
+    packageId,
+    packageVersion,
+    developerRef,
+    listingOwnerRef,
+    billingBeneficiaryRef,
+    entitlementId,
+    localGatewayId,
+    status,
+    startedAt,
+    endedAt,
+    ...(modelProxyUsage === undefined ? {} : { modelProxyUsage }),
+    toolUsage,
+    result,
+  };
+}
+
+export function createDijieAuditRecord(input: {
+  claims: DijieExecutionTokenClaims;
+  summary: unknown;
+  receivedAt?: string;
+}): DijieAuditSummaryResult {
+  if (!input.claims.scopes.includes("audit.write")) {
+    return { ok: false, error: "Dijie execution token is missing audit.write scope." };
+  }
+
+  const summary = normalizeDijieAuditSummary(input.summary);
+  if (!summary) {
+    return { ok: false, error: "Invalid Dijie audit summary." };
+  }
+
+  const mismatches = [
+    ["executionId", input.claims.executionId, summary.executionId],
+    ["roleListingId", input.claims.roleListingId, summary.roleListingId],
+    ["packageId", input.claims.packageId, summary.packageId],
+    ["packageVersion", input.claims.packageVersion, summary.packageVersion],
+    ["developerRef", input.claims.developerRef, summary.developerRef],
+    ["listingOwnerRef", input.claims.listingOwnerRef, summary.listingOwnerRef],
+    ["billingBeneficiaryRef", input.claims.billingBeneficiaryRef, summary.billingBeneficiaryRef],
+    ["entitlementId", input.claims.entitlementId, summary.entitlementId],
+    ["deviceId", input.claims.deviceId, summary.deviceId],
+    ["workspaceRef", input.claims.workspaceRef, summary.workspaceRef],
+    ["localGatewayId", input.claims.localGatewayId, summary.localGatewayId],
+    ["result.executionId", summary.executionId, summary.result.executionId],
+    ["result.roleListingId", summary.roleListingId, summary.result.roleListingId],
+    ["result.packageId", summary.packageId, summary.result.packageId],
+    ["result.packageVersion", summary.packageVersion, summary.result.packageVersion],
+    ["result.developerRef", summary.developerRef, summary.result.developerRef],
+    ["result.listingOwnerRef", summary.listingOwnerRef, summary.result.listingOwnerRef],
+    ["result.billingBeneficiaryRef", summary.billingBeneficiaryRef, summary.result.billingBeneficiaryRef],
+    ["result.status", summary.status, summary.result.status],
+  ].filter(([, expected, actual]) => expected !== actual);
+
+  if (mismatches.length > 0) {
+    return {
+      ok: false,
+      error: `Dijie audit summary does not match execution token: ${mismatches
+        .map(([field]) => field)
+        .join(", ")}`,
+    };
+  }
+
+  return {
+    ok: true,
+    record: {
+      auditRecordVersion: 1,
+      actorId: input.claims.actorId,
+      packageId: input.claims.packageId,
+      packageVersion: input.claims.packageVersion,
+      developerRef: input.claims.developerRef,
+      listingOwnerRef: input.claims.listingOwnerRef,
+      billingBeneficiaryRef: input.claims.billingBeneficiaryRef,
+      receivedAt: input.receivedAt ?? new Date().toISOString(),
+      executionTokenIssuedAt: new Date(input.claims.iat * 1000).toISOString(),
+      executionTokenExpiresAt: new Date(input.claims.exp * 1000).toISOString(),
+      pricing: input.claims.pricing,
+      roleTokenPricing: input.claims.roleTokenPricing,
+      summary,
+    },
+  };
+}

--- a/apps/api/src/lib/dijie/entitlement-verifier.test.ts
+++ b/apps/api/src/lib/dijie/entitlement-verifier.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type DijieQueryGraph,
+  verifyDijieEntitlement,
+} from "./entitlement-verifier";
+
+const input = {
+  actorId: "cus_123",
+  roleListingId: "prod_role_developer_agent",
+  entitlementId: "ordgrp_123",
+  deviceId: "device_123",
+  workspaceRef: "workspace_123",
+  localGatewayId: "gateway_123",
+};
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000,
+  platformFeeBps: 0,
+};
+
+function product(overrides: Record<string, unknown> = {}) {
+  return {
+    id: input.roleListingId,
+    status: "published",
+    metadata: {
+      dijieRole: {
+        kind: "role_product",
+        protocolVersion: "2026-05",
+        packageId: "pkg_developer",
+        packageVersion: "1.0.0",
+        developerRef: "dev_001",
+        listingStatus: "published",
+        reviewState: "approved",
+        pricing: {
+          kind: "one_time_authorization",
+          authorizationFeeCents: 29900,
+          currency: "CNY",
+          platformFeeBps: 0,
+          developerReceivableCents: 29900,
+        },
+        roleTokenPricing,
+        scopes: ["role.execute", "audit.write"],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function paidOrder(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "order_123",
+    customer_id: input.actorId,
+    status: "completed",
+    payment_collections: [{ status: "captured", amount: 29900, captured_amount: 29900 }],
+    items: [{ product_id: input.roleListingId }],
+    ...overrides,
+  };
+}
+
+function queryGraph(fixtures: {
+  products?: unknown[];
+  orderGroups?: unknown[];
+  orders?: unknown[];
+}): DijieQueryGraph {
+  return async ({ entity }) => {
+    if (entity === "product") {
+      return { data: fixtures.products ?? [product()] };
+    }
+    if (entity === "order_group") {
+      return { data: fixtures.orderGroups ?? [{ id: input.entitlementId, orders: [paidOrder()] }] };
+    }
+    if (entity === "order") {
+      return { data: fixtures.orders ?? [] };
+    }
+    return { data: [] };
+  };
+}
+
+describe("verifyDijieEntitlement", () => {
+  it("approves a paid one-time role authorization", async () => {
+    const result = await verifyDijieEntitlement(input, queryGraph({}));
+
+    expect(result).toEqual({
+      ok: true,
+      packageId: "pkg_developer",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingOwnerRef: "dev_001",
+      billingBeneficiaryRef: "dev_001",
+      pricing: {
+        kind: "one_time_authorization",
+        authorizationFeeCents: 29900,
+        currency: "CNY",
+        platformFeeBps: 0,
+        developerReceivableCents: 29900,
+      },
+      roleTokenPricing,
+      scopes: ["role.execute", "audit.write"],
+    });
+  });
+
+  it("rejects role listings that include a marketplace platform cut", async () => {
+    const result = await verifyDijieEntitlement(
+      input,
+      queryGraph({
+        products: [
+          product({
+            metadata: {
+              dijieRole: {
+                kind: "role_product",
+                protocolVersion: "2026-05",
+                packageId: "pkg_developer",
+                packageVersion: "1.0.0",
+                developerRef: "dev_001",
+                listingStatus: "published",
+                reviewState: "approved",
+                pricing: {
+                  kind: "one_time_authorization",
+                  authorizationFeeCents: 29900,
+                  currency: "CNY",
+                  platformFeeBps: 1500,
+                  developerReceivableCents: 25300,
+                },
+                roleTokenPricing,
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 422,
+      error: "Role listing metadata is not a valid Dijie role product.",
+    });
+  });
+
+  it("rejects non-purchased role listings", async () => {
+    const result = await verifyDijieEntitlement(
+      input,
+      queryGraph({ orderGroups: [{ id: input.entitlementId, orders: [paidOrder({ items: [] })] }] }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      error: "No paid one-time role authorization was found for this customer.",
+    });
+  });
+
+  it("rejects unpaid orders", async () => {
+    const result = await verifyDijieEntitlement(
+      input,
+      queryGraph({
+        orderGroups: [
+          {
+            id: input.entitlementId,
+            orders: [paidOrder({ status: "pending", payment_collections: [] })],
+          },
+        ],
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+    }
+  });
+
+  it("rejects non-executable listing states", async () => {
+    const result = await verifyDijieEntitlement(
+      input,
+      queryGraph({
+        products: [
+          product({
+            status: "draft",
+            metadata: {
+              dijieRole: {
+                kind: "role_product",
+                protocolVersion: "2026-05",
+                packageId: "pkg_developer",
+                packageVersion: "1.0.0",
+                developerRef: "dev_001",
+                listingStatus: "draft",
+                reviewState: "approved",
+                pricing: {
+                  kind: "one_time_authorization",
+                  authorizationFeeCents: 29900,
+                  currency: "CNY",
+                  platformFeeBps: 0,
+                  developerReceivableCents: 29900,
+                },
+                roleTokenPricing,
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      error: "Role listing is not executable.",
+    });
+  });
+
+  it("rejects listings without one-time authorization pricing", async () => {
+    const result = await verifyDijieEntitlement(
+      input,
+      queryGraph({
+        products: [
+          product({
+            metadata: {
+              dijieRole: {
+                kind: "role_product",
+                protocolVersion: "2026-05",
+                packageId: "pkg_developer",
+                packageVersion: "1.0.0",
+                developerRef: "dev_001",
+                listingStatus: "published",
+                reviewState: "approved",
+                roleTokenPricing,
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 422,
+      error: "Role listing metadata is not a valid Dijie role product.",
+    });
+  });
+
+  it("rejects privileged role product scopes before execution token minting", async () => {
+    const result = await verifyDijieEntitlement(
+      input,
+      queryGraph({
+        products: [
+          product({
+            metadata: {
+              dijieRole: {
+                kind: "role_product",
+                protocolVersion: "2026-05",
+                packageId: "pkg_developer",
+                packageVersion: "1.0.0",
+                developerRef: "dev_001",
+                listingStatus: "published",
+                reviewState: "approved",
+                pricing: {
+                  kind: "one_time_authorization",
+                  authorizationFeeCents: 29900,
+                  currency: "CNY",
+                  platformFeeBps: 0,
+                  developerReceivableCents: 29900,
+                },
+                roleTokenPricing,
+                scopes: ["role.execute", "operator.write"],
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 422,
+      error: "Role listing metadata is not a valid Dijie role product.",
+    });
+  });
+});

--- a/apps/api/src/lib/dijie/entitlement-verifier.ts
+++ b/apps/api/src/lib/dijie/entitlement-verifier.ts
@@ -1,0 +1,249 @@
+import type { DijieExecutionTokenPricing, DijieRoleTokenPricing } from "./execution-token";
+import {
+  isPublicDijieRoleProduct,
+  normalizeDijieRoleProductMetadataFromProduct,
+} from "./role-product-metadata";
+
+export type DijieEntitlementVerificationInput = {
+  actorId: string;
+  roleListingId: string;
+  entitlementId: string;
+  deviceId: string;
+  workspaceRef: string;
+  localGatewayId: string;
+};
+
+export type DijieEntitlementVerificationResult =
+  | {
+      ok: true;
+      packageId: string;
+      packageVersion: string;
+      developerRef: string;
+      listingOwnerRef: string;
+      billingBeneficiaryRef: string;
+      pricing: DijieExecutionTokenPricing;
+      roleTokenPricing: DijieRoleTokenPricing;
+      scopes: string[];
+    }
+  | {
+      ok: false;
+      status: number;
+      error: string;
+    };
+
+export type DijieQueryGraph = (query: {
+  entity: string;
+  fields: string[];
+  filters?: Record<string, unknown>;
+  pagination?: Record<string, unknown>;
+}) => Promise<{ data?: unknown[] }>;
+
+type UnknownRecord = Record<string, unknown>;
+
+const BLOCKED_ORDER_STATUSES = new Set(["canceled", "cancelled"]);
+const PAID_ORDER_STATUSES = new Set(["completed"]);
+const PAID_PAYMENT_STATUSES = new Set(["captured", "paid", "completed"]);
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function metadata(record: UnknownRecord): UnknownRecord {
+  return asRecord(record.metadata);
+}
+
+function orderIsBlocked(order: UnknownRecord): boolean {
+  const status = nonEmptyString(order.status)?.toLowerCase();
+  return Boolean(status && BLOCKED_ORDER_STATUSES.has(status));
+}
+
+function orderIsPaid(order: UnknownRecord): boolean {
+  const status = nonEmptyString(order.status)?.toLowerCase();
+  if (status && PAID_ORDER_STATUSES.has(status)) {
+    return true;
+  }
+
+  const paymentStatus = nonEmptyString(order.payment_status)?.toLowerCase();
+  if (paymentStatus && PAID_PAYMENT_STATUSES.has(paymentStatus)) {
+    return true;
+  }
+
+  const paymentCollections = Array.isArray(order.payment_collections)
+    ? order.payment_collections
+    : [];
+  return paymentCollections.some((payment) => {
+    const record = asRecord(payment);
+    const collectionStatus = nonEmptyString(record.status)?.toLowerCase();
+    if (collectionStatus && PAID_PAYMENT_STATUSES.has(collectionStatus)) {
+      return true;
+    }
+
+    const amount = Number(record.amount);
+    const capturedAmount = Number(record.captured_amount);
+    return Number.isFinite(amount) && amount > 0 && Number.isFinite(capturedAmount) && capturedAmount >= amount;
+  });
+}
+
+function itemMatchesRoleListing(item: UnknownRecord, roleListingId: string): boolean {
+  const itemMetadata = metadata(item);
+  if (
+    item.product_id === roleListingId ||
+    itemMetadata.dijieRoleListingId === roleListingId ||
+    itemMetadata.dijie_role_listing_id === roleListingId
+  ) {
+    return true;
+  }
+
+  const product = asRecord(item.product);
+  if (product.id === roleListingId) {
+    return true;
+  }
+
+  const variant = asRecord(item.variant);
+  return variant.product_id === roleListingId || asRecord(variant.product).id === roleListingId;
+}
+
+function orderIncludesRoleListing(order: UnknownRecord, roleListingId: string): boolean {
+  const items = Array.isArray(order.items) ? order.items.map(asRecord) : [];
+  return items.some((item) => itemMatchesRoleListing(item, roleListingId));
+}
+
+function ordersFromOrderGroups(orderGroups: unknown[]): UnknownRecord[] {
+  return orderGroups.flatMap((orderGroup) => {
+    const group = asRecord(orderGroup);
+    return Array.isArray(group.orders) ? group.orders.map(asRecord) : [];
+  });
+}
+
+function assertRequiredInput(input: DijieEntitlementVerificationInput): string | undefined {
+  const missing = Object.entries(input)
+    .filter(([, value]) => !nonEmptyString(value))
+    .map(([key]) => key);
+
+  return missing.length > 0 ? `Missing required fields: ${missing.join(", ")}` : undefined;
+}
+
+export async function verifyDijieEntitlement(
+  input: DijieEntitlementVerificationInput,
+  queryGraph: DijieQueryGraph,
+): Promise<DijieEntitlementVerificationResult> {
+  const missing = assertRequiredInput(input);
+  if (missing) {
+    return { ok: false, status: 400, error: missing };
+  }
+
+  let products: unknown[] = [];
+  let orderGroups: unknown[] = [];
+  let ordersById: unknown[] = [];
+  try {
+    const [productResult, orderGroupResult, orderResult] = await Promise.all([
+      queryGraph({
+        entity: "product",
+        fields: ["id", "status", "title", "metadata", "seller.id"],
+        filters: { id: input.roleListingId },
+      }),
+      queryGraph({
+        entity: "order_group",
+        fields: [
+          "id",
+          "customer_id",
+          "orders.id",
+          "orders.status",
+          "orders.payment_status",
+          "orders.payment_collections.status",
+          "orders.payment_collections.amount",
+          "orders.payment_collections.captured_amount",
+          "orders.items.*",
+          "orders.items.product.id",
+          "orders.items.product_id",
+          "orders.items.variant.product_id",
+          "orders.items.metadata",
+        ],
+        filters: {
+          id: input.entitlementId,
+          customer_id: input.actorId,
+        },
+      }),
+      queryGraph({
+        entity: "order",
+        fields: [
+          "id",
+          "customer_id",
+          "status",
+          "payment_status",
+          "payment_collections.status",
+          "payment_collections.amount",
+          "payment_collections.captured_amount",
+          "items.*",
+          "items.product.id",
+          "items.product_id",
+          "items.variant.product_id",
+          "items.metadata",
+        ],
+        filters: {
+          id: input.entitlementId,
+          customer_id: input.actorId,
+        },
+      }),
+    ]);
+    products = productResult.data ?? [];
+    orderGroups = orderGroupResult.data ?? [];
+    ordersById = orderResult.data ?? [];
+  } catch {
+    return {
+      ok: false,
+      status: 502,
+      error: "Dijie entitlement verifier could not read marketplace facts.",
+    };
+  }
+
+  const product = asRecord(products[0]);
+  if (!product.id) {
+    return { ok: false, status: 404, error: "Role listing was not found." };
+  }
+
+  const roleProduct = normalizeDijieRoleProductMetadataFromProduct(product);
+  if (!roleProduct.ok) {
+    return {
+      ok: false,
+      status: 422,
+      error: "Role listing metadata is not a valid Dijie role product.",
+    };
+  }
+  if (!isPublicDijieRoleProduct(roleProduct.value)) {
+    return { ok: false, status: 403, error: "Role listing is not executable." };
+  }
+
+  const orders = [...ordersFromOrderGroups(orderGroups), ...ordersById.map(asRecord)];
+  const matchingOrder = orders.find(
+    (order) =>
+      !orderIsBlocked(order) &&
+      orderIsPaid(order) &&
+      orderIncludesRoleListing(order, input.roleListingId),
+  );
+  if (!matchingOrder) {
+    return {
+      ok: false,
+      status: 403,
+      error: "No paid one-time role authorization was found for this customer.",
+    };
+  }
+
+  return {
+    ok: true,
+    packageId: roleProduct.value.packageId,
+    packageVersion: roleProduct.value.packageVersion,
+    developerRef: roleProduct.value.developerRef,
+    listingOwnerRef: roleProduct.value.listingOwnerRef,
+    billingBeneficiaryRef: roleProduct.value.billingBeneficiaryRef,
+    pricing: roleProduct.value.pricing,
+    roleTokenPricing: roleProduct.value.roleTokenPricing,
+    scopes: roleProduct.value.scopes,
+  };
+}

--- a/apps/api/src/lib/dijie/execution-token.test.ts
+++ b/apps/api/src/lib/dijie/execution-token.test.ts
@@ -1,0 +1,208 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "bun:test";
+import {
+  createDijieExecutionToken,
+  normalizeOneTimeAuthorizationPricing,
+  normalizeRoleTokenPricing,
+  verifyDijieExecutionToken,
+} from "./execution-token";
+
+const keyPair = crypto.generateKeyPairSync("ed25519");
+const privateKeyPem = keyPair.privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+const publicKeyPem = keyPair.publicKey.export({ format: "pem", type: "spki" }).toString();
+const pricing = {
+  kind: "one_time_authorization" as const,
+  authorizationFeeCents: 19900,
+  currency: "CNY",
+  platformFeeBps: 0,
+  developerReceivableCents: 19900,
+};
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000 as const,
+  platformFeeBps: 0 as const,
+};
+
+const input = {
+  executionId: "exec_123",
+  actorId: "cus_123",
+  roleListingId: "role_developer_agent",
+  packageId: "pkg_developer_agent",
+  packageVersion: "1.0.0",
+  developerRef: "dev_001",
+  listingOwnerRef: "seller_001",
+  billingBeneficiaryRef: "dev_001",
+  entitlementId: "ent_123",
+  deviceId: "device_123",
+  workspaceRef: "workspace_123",
+  localGatewayId: "gateway_123",
+  scopes: ["role.execute"],
+  pricing,
+  roleTokenPricing,
+  nowMs: 1_800_000_000_000,
+  ttlSeconds: 300,
+};
+
+describe("Dijie execution tokens", () => {
+  it("normalizes one-time authorization pricing", () => {
+    expect(normalizeOneTimeAuthorizationPricing(pricing)).toEqual(pricing);
+  });
+
+  it("rejects runtime-duration pricing", () => {
+    expect(
+      normalizeOneTimeAuthorizationPricing({
+        kind: "runtime_duration",
+        centsPerMinute: 10,
+        currency: "CNY",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("rejects marketplace platform cuts", () => {
+    expect(
+      normalizeOneTimeAuthorizationPricing({
+        kind: "one_time_authorization",
+        authorizationFeeCents: 19900,
+        currency: "CNY",
+        platformFeeBps: 1500,
+        developerReceivableCents: 16915,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("rejects non-CNY one-time authorization pricing", () => {
+    expect(
+      normalizeOneTimeAuthorizationPricing({
+        ...pricing,
+        currency: "USD",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("normalizes developer role token pricing", () => {
+    expect(normalizeRoleTokenPricing(roleTokenPricing)).toEqual(roleTokenPricing);
+  });
+
+  it("rejects role token pricing with platform revenue", () => {
+    expect(
+      normalizeRoleTokenPricing({
+        ...roleTokenPricing,
+        platformFeeBps: 500,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("rejects non-CNY role token pricing", () => {
+    expect(
+      normalizeRoleTokenPricing({
+        ...roleTokenPricing,
+        currency: "USD",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("refuses missing private signing keys", () => {
+    const result = createDijieExecutionToken(input, undefined);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("PRIVATE_KEY_PEM");
+    }
+  });
+
+  it("refuses missing immutable business snapshot claims before signing", () => {
+    const result = createDijieExecutionToken(
+      {
+        ...input,
+        packageVersion: "",
+        billingBeneficiaryRef: "",
+      },
+      privateKeyPem,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("packageVersion");
+      expect(result.error).toContain("billingBeneficiaryRef");
+    }
+  });
+
+  it("refuses missing role token pricing before signing", () => {
+    const result = createDijieExecutionToken(
+      {
+        ...input,
+        roleTokenPricing: undefined as never,
+      },
+      privateKeyPem,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("roleTokenPricing");
+    }
+  });
+
+  it("creates and verifies a short-lived execution token", () => {
+    const signed = createDijieExecutionToken(input, privateKeyPem);
+
+    expect(signed.ok).toBe(true);
+    if (!signed.ok) {
+      throw new Error(signed.error);
+    }
+
+    const verified = verifyDijieExecutionToken(signed.token, publicKeyPem, input.nowMs + 1_000);
+    expect(verified.ok).toBe(true);
+    if (!verified.ok) {
+      throw new Error(verified.error);
+    }
+    expect(verified.claims.actorId).toBe(input.actorId);
+    expect(verified.claims.packageVersion).toBe("1.0.0");
+    expect(verified.claims.billingBeneficiaryRef).toBe("dev_001");
+    expect(verified.claims.pricing.kind).toBe("one_time_authorization");
+    expect(verified.claims.roleTokenPricing).toEqual(roleTokenPricing);
+  });
+
+  it("accepts escaped PEM newlines from environment variables", () => {
+    const signed = createDijieExecutionToken(input, privateKeyPem.replace(/\n/g, "\\n"));
+
+    expect(signed.ok).toBe(true);
+    if (!signed.ok) {
+      throw new Error(signed.error);
+    }
+    expect(
+      verifyDijieExecutionToken(signed.token, publicKeyPem.replace(/\n/g, "\\n"), input.nowMs + 1_000)
+        .ok,
+    ).toBe(true);
+  });
+
+  it("rejects a tampered token", () => {
+    const signed = createDijieExecutionToken(input, privateKeyPem);
+    if (!signed.ok) {
+      throw new Error(signed.error);
+    }
+
+    const tampered = `${signed.token.slice(0, -2)}xx`;
+    const verified = verifyDijieExecutionToken(tampered, publicKeyPem, input.nowMs + 1_000);
+
+    expect(verified.ok).toBe(false);
+    if (!verified.ok) {
+      expect(verified.error).toContain("signature");
+    }
+  });
+
+  it("rejects expired tokens", () => {
+    const signed = createDijieExecutionToken(input, privateKeyPem);
+    if (!signed.ok) {
+      throw new Error(signed.error);
+    }
+
+    const verified = verifyDijieExecutionToken(signed.token, publicKeyPem, input.nowMs + 301_000);
+
+    expect(verified.ok).toBe(false);
+    if (!verified.ok) {
+      expect(verified.error).toContain("expired");
+    }
+  });
+});

--- a/apps/api/src/lib/dijie/execution-token.ts
+++ b/apps/api/src/lib/dijie/execution-token.ts
@@ -1,0 +1,383 @@
+import crypto from "node:crypto";
+
+export type DijieExecutionTokenPricing = {
+  kind: "one_time_authorization";
+  authorizationFeeCents: number;
+  currency: string;
+  platformFeeBps: number;
+  developerReceivableCents: number;
+};
+
+export type DijieRoleTokenPricing = {
+  inputTokenCentsPerMillion: number;
+  outputTokenCentsPerMillion: number;
+  currency: string;
+  developerReceivableBps: 10000;
+  platformFeeBps: 0;
+};
+
+export type DijieExecutionTokenClaims = {
+  iss: "dijie-cloud";
+  typ: "dijie_execution";
+  executionId: string;
+  actorId: string;
+  roleListingId: string;
+  packageId: string;
+  packageVersion: string;
+  developerRef: string;
+  listingOwnerRef: string;
+  billingBeneficiaryRef: string;
+  entitlementId: string;
+  deviceId: string;
+  workspaceRef: string;
+  localGatewayId: string;
+  scopes: string[];
+  pricing: DijieExecutionTokenPricing;
+  roleTokenPricing: DijieRoleTokenPricing;
+  iat: number;
+  exp: number;
+};
+
+export type CreateDijieExecutionTokenInput = Omit<
+  DijieExecutionTokenClaims,
+  "iss" | "typ" | "iat" | "exp"
+> & {
+  nowMs?: number;
+  ttlSeconds: number;
+};
+
+export type DijieExecutionTokenResult =
+  | {
+      ok: true;
+      token: string;
+      claims: DijieExecutionTokenClaims;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function base64Url(input: Buffer | string): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+function normalizePem(value: string | undefined): string | undefined {
+  const normalized = value?.trim().replace(/\\n/g, "\n");
+  return normalized || undefined;
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  return Number.isInteger(value) && Number(value) >= 0 ? Number(value) : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const normalized = value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return normalized.length === value.length && normalized.length > 0 ? normalized : undefined;
+}
+
+export function normalizeOneTimeAuthorizationPricing(
+  value: unknown,
+): DijieExecutionTokenPricing | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.kind !== "one_time_authorization") {
+    return undefined;
+  }
+
+  const authorizationFeeCents = parsePositiveInteger(record.authorizationFeeCents);
+  const platformFeeBps = parsePositiveInteger(record.platformFeeBps) ?? 0;
+  const developerReceivableCents =
+    parsePositiveInteger(record.developerReceivableCents) ?? authorizationFeeCents;
+  const currency = typeof record.currency === "string" ? record.currency.trim() : "";
+
+  if (
+    authorizationFeeCents === undefined ||
+    developerReceivableCents === undefined ||
+    platformFeeBps !== 0 ||
+    developerReceivableCents !== authorizationFeeCents ||
+    currency !== "CNY"
+  ) {
+    return undefined;
+  }
+
+  return {
+    kind: "one_time_authorization",
+    authorizationFeeCents,
+    currency,
+    platformFeeBps,
+    developerReceivableCents,
+  };
+}
+
+export function normalizeRoleTokenPricing(value: unknown): DijieRoleTokenPricing | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const inputTokenCentsPerMillion = parsePositiveInteger(
+    record.inputTokenCentsPerMillion ??
+      record.input_token_cents_per_million ??
+      record.inputCentsPerMillion ??
+      record.input_cents_per_million,
+  );
+  const outputTokenCentsPerMillion = parsePositiveInteger(
+    record.outputTokenCentsPerMillion ??
+      record.output_token_cents_per_million ??
+      record.outputCentsPerMillion ??
+      record.output_cents_per_million,
+  );
+  const developerReceivableBps = parsePositiveInteger(
+    record.developerReceivableBps ?? record.developer_receivable_bps,
+  );
+  const platformFeeBps = parsePositiveInteger(record.platformFeeBps ?? record.platform_fee_bps);
+  const currency = nonEmptyString(record.currency);
+
+  if (
+    inputTokenCentsPerMillion === undefined ||
+    outputTokenCentsPerMillion === undefined ||
+    developerReceivableBps !== 10000 ||
+    platformFeeBps !== 0 ||
+    currency !== "CNY"
+  ) {
+    return undefined;
+  }
+
+  return {
+    inputTokenCentsPerMillion,
+    outputTokenCentsPerMillion,
+    currency,
+    developerReceivableBps: 10000,
+    platformFeeBps: 0,
+  };
+}
+
+function normalizeClaims(value: unknown): DijieExecutionTokenClaims | undefined {
+  const record = asRecord(value);
+  if (!record || record.iss !== "dijie-cloud" || record.typ !== "dijie_execution") {
+    return undefined;
+  }
+
+  const executionId = nonEmptyString(record.executionId);
+  const actorId = nonEmptyString(record.actorId);
+  const roleListingId = nonEmptyString(record.roleListingId);
+  const packageId = nonEmptyString(record.packageId);
+  const packageVersion = nonEmptyString(record.packageVersion);
+  const developerRef = nonEmptyString(record.developerRef);
+  const listingOwnerRef = nonEmptyString(record.listingOwnerRef);
+  const billingBeneficiaryRef = nonEmptyString(record.billingBeneficiaryRef);
+  const entitlementId = nonEmptyString(record.entitlementId);
+  const deviceId = nonEmptyString(record.deviceId);
+  const workspaceRef = nonEmptyString(record.workspaceRef);
+  const localGatewayId = nonEmptyString(record.localGatewayId);
+  const scopes = stringArray(record.scopes);
+  const pricing = normalizeOneTimeAuthorizationPricing(record.pricing);
+  const roleTokenPricing = normalizeRoleTokenPricing(record.roleTokenPricing);
+
+  if (
+    !executionId ||
+    !actorId ||
+    !roleListingId ||
+    !packageId ||
+    !packageVersion ||
+    !developerRef ||
+    !listingOwnerRef ||
+    !billingBeneficiaryRef ||
+    !entitlementId ||
+    !deviceId ||
+    !workspaceRef ||
+    !localGatewayId ||
+    !scopes ||
+    !pricing ||
+    !roleTokenPricing ||
+    !Number.isInteger(record.iat) ||
+    !Number.isInteger(record.exp)
+  ) {
+    return undefined;
+  }
+
+  return {
+    iss: "dijie-cloud",
+    typ: "dijie_execution",
+    executionId,
+    actorId,
+    roleListingId,
+    packageId,
+    packageVersion,
+    developerRef,
+    listingOwnerRef,
+    billingBeneficiaryRef,
+    entitlementId,
+    deviceId,
+    workspaceRef,
+    localGatewayId,
+    scopes,
+    pricing,
+    roleTokenPricing,
+    iat: Number(record.iat),
+    exp: Number(record.exp),
+  };
+}
+
+export function createDijieExecutionToken(
+  input: CreateDijieExecutionTokenInput,
+  privateKeyPem: string | undefined,
+): DijieExecutionTokenResult {
+  const normalizedPrivateKey = normalizePem(privateKeyPem);
+  if (!normalizedPrivateKey) {
+    return { ok: false, error: "DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM is required." };
+  }
+  if (!Number.isInteger(input.ttlSeconds) || input.ttlSeconds < 30 || input.ttlSeconds > 900) {
+    return { ok: false, error: "Execution token TTL must be between 30 and 900 seconds." };
+  }
+  const requiredClaims: Array<keyof CreateDijieExecutionTokenInput> = [
+    "executionId",
+    "actorId",
+    "roleListingId",
+    "packageId",
+    "packageVersion",
+    "developerRef",
+    "listingOwnerRef",
+    "billingBeneficiaryRef",
+    "entitlementId",
+    "deviceId",
+    "workspaceRef",
+    "localGatewayId",
+  ];
+  const missingClaims = requiredClaims.filter((field) => !nonEmptyString(input[field]));
+  if (missingClaims.length > 0) {
+    return {
+      ok: false,
+      error: `Execution token claims are missing required fields: ${missingClaims.join(", ")}`,
+    };
+  }
+  const pricing = normalizeOneTimeAuthorizationPricing(input.pricing);
+  if (!pricing) {
+    return {
+      ok: false,
+      error:
+        "Execution token pricing must be one_time_authorization with platformFeeBps=0 and full developer receivable.",
+    };
+  }
+  const roleTokenPricing = normalizeRoleTokenPricing(input.roleTokenPricing);
+  if (!roleTokenPricing) {
+    return {
+      ok: false,
+      error:
+        "Execution token roleTokenPricing must define non-negative input/output token cents per million with platformFeeBps=0 and developerReceivableBps=10000.",
+    };
+  }
+  const scopes = stringArray(input.scopes);
+  if (!scopes) {
+    return { ok: false, error: "Execution token scopes must be a non-empty string array." };
+  }
+
+  const issuedAtSeconds = Math.floor((input.nowMs ?? Date.now()) / 1000);
+  const claims: DijieExecutionTokenClaims = {
+    iss: "dijie-cloud",
+    typ: "dijie_execution",
+    executionId: input.executionId,
+    actorId: input.actorId,
+    roleListingId: input.roleListingId,
+    packageId: input.packageId,
+    packageVersion: input.packageVersion,
+    developerRef: input.developerRef,
+    listingOwnerRef: input.listingOwnerRef,
+    billingBeneficiaryRef: input.billingBeneficiaryRef,
+    entitlementId: input.entitlementId,
+    deviceId: input.deviceId,
+    workspaceRef: input.workspaceRef,
+    localGatewayId: input.localGatewayId,
+    scopes,
+    pricing,
+    roleTokenPricing,
+    iat: issuedAtSeconds,
+    exp: issuedAtSeconds + input.ttlSeconds,
+  };
+
+  const header = {
+    alg: "EdDSA",
+    typ: "JWT",
+    kid: "dijie-execution-token-v1",
+  };
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(claims))}`;
+  let signature: Buffer;
+  try {
+    signature = crypto.sign(null, Buffer.from(signingInput), normalizedPrivateKey);
+  } catch {
+    return { ok: false, error: "DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM is invalid." };
+  }
+
+  return {
+    ok: true,
+    token: `${signingInput}.${base64Url(signature)}`,
+    claims,
+  };
+}
+
+export function verifyDijieExecutionToken(
+  token: string,
+  publicKeyPem: string | undefined,
+  nowMs = Date.now(),
+): DijieExecutionTokenResult {
+  const normalizedPublicKey = normalizePem(publicKeyPem);
+  if (!normalizedPublicKey) {
+    return { ok: false, error: "DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM is required." };
+  }
+
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return { ok: false, error: "Invalid execution token format." };
+  }
+
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  let signatureIsValid = false;
+  try {
+    signatureIsValid = crypto.verify(
+      null,
+      Buffer.from(signingInput),
+      normalizedPublicKey,
+      Buffer.from(encodedSignature, "base64url"),
+    );
+  } catch {
+    return { ok: false, error: "DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM is invalid." };
+  }
+  if (!signatureIsValid) {
+    return { ok: false, error: "Invalid execution token signature." };
+  }
+
+  try {
+    const claims = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8"));
+    const normalizedClaims = normalizeClaims(claims);
+    if (!normalizedClaims) {
+      return { ok: false, error: "Invalid execution token claims." };
+    }
+    if (normalizedClaims.exp <= Math.floor(nowMs / 1000)) {
+      return { ok: false, error: "Execution token expired." };
+    }
+    return { ok: true, token, claims: normalizedClaims };
+  } catch {
+    return { ok: false, error: "Invalid execution token payload." };
+  }
+}

--- a/apps/api/src/lib/dijie/ledgers.test.ts
+++ b/apps/api/src/lib/dijie/ledgers.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createDijieMarketplaceRoleLedgerEntries,
+  createDijieRoleTokenUsageLedgerEntryFromAudit,
+  createDijieRoleUsageLedgerEntry,
+  createDijieUsageLedgerEntry,
+} from "./ledgers";
+import type { DijieAuditRecord } from "./audit-summary";
+
+const pricing = {
+  kind: "one_time_authorization" as const,
+  authorizationFeeCents: 29900,
+  currency: "CNY",
+  platformFeeBps: 0,
+  developerReceivableCents: 29900,
+};
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000 as const,
+  platformFeeBps: 0 as const,
+};
+
+function auditRecord(overrides: Partial<DijieAuditRecord> = {}): DijieAuditRecord {
+  return {
+    auditRecordVersion: 1,
+    actorId: "cus_123",
+    packageId: "pkg_123",
+    packageVersion: "1.0.0",
+    developerRef: "dev_123",
+    listingOwnerRef: "seller_123",
+    billingBeneficiaryRef: "dev_123",
+    receivedAt: "2026-05-31T08:20:00.000Z",
+    executionTokenIssuedAt: "2026-05-31T08:00:00.000Z",
+    executionTokenExpiresAt: "2026-05-31T08:05:00.000Z",
+    pricing,
+    roleTokenPricing,
+    summary: {
+      executionId: "exec_123",
+      deviceId: "device_123",
+      workspaceRef: "workspace_123",
+      roleListingId: "role_123",
+      packageId: "pkg_123",
+      packageVersion: "1.0.0",
+      developerRef: "dev_123",
+      listingOwnerRef: "seller_123",
+      billingBeneficiaryRef: "dev_123",
+      entitlementId: "ent_123",
+      localGatewayId: "gateway_123",
+      status: "completed",
+      startedAt: "2026-05-31T08:00:00.000Z",
+      endedAt: "2026-05-31T08:01:00.000Z",
+      modelProxyUsage: {
+        requestCount: 1,
+        inputTokens: 1_000_000,
+        outputTokens: 500_000,
+      },
+      toolUsage: {
+        shellCommands: 1,
+        testsRun: 0,
+        filesRead: 0,
+        filesChanged: 0,
+      },
+      result: {
+        executionId: "exec_123",
+        roleListingId: "role_123",
+        packageId: "pkg_123",
+        packageVersion: "1.0.0",
+        developerRef: "dev_123",
+        listingOwnerRef: "seller_123",
+        billingBeneficiaryRef: "dev_123",
+        status: "completed",
+        startedAt: "2026-05-31T08:00:00.000Z",
+        endedAt: "2026-05-31T08:01:00.000Z",
+        changedFiles: [],
+        artifacts: [],
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("Dijie ledgers", () => {
+  it("records main-system usage as platform receivable", () => {
+    const result = createDijieUsageLedgerEntry({
+      entryId: "usage_123",
+      actorId: "cus_123",
+      workspaceRef: "workspace_123",
+      usageKind: "model_tokens",
+      meters: [
+        { name: "input_tokens", quantity: 1200, unit: "token" },
+        { name: "output_tokens", quantity: 800, unit: "token" },
+      ],
+      currency: "CNY",
+      amountCents: 88,
+      occurredAt: "2026-05-31T08:00:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.value).toMatchObject({
+      ledger: "usage",
+      source: "main_system_usage",
+      grossAmountCents: 88,
+      platformReceivableCents: 88,
+      developerReceivableCents: 0,
+    });
+  });
+
+  it("records role authorization revenue as 100% developer receivable", () => {
+    const result = createDijieMarketplaceRoleLedgerEntries({
+      entryId: "market_123",
+      payoutEntryId: "payout_123",
+      eventKind: "role_authorization",
+      actorId: "cus_123",
+      developerId: "dev_123",
+      roleListingId: "role_123",
+      entitlementId: "ent_123",
+      pricing,
+      occurredAt: "2026-05-31T08:00:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.value.marketplaceOrder).toMatchObject({
+      ledger: "marketplace_order",
+      source: "role_marketplace",
+      grossAmountCents: 29900,
+      platformFeeBps: 0,
+      platformFeeCents: 0,
+      developerReceivableCents: 29900,
+    });
+    expect(result.value.developerPayout).toMatchObject({
+      ledger: "developer_payout",
+      source: "role_marketplace",
+      developerId: "dev_123",
+      amountCents: 29900,
+      status: "pending",
+    });
+  });
+
+  it("records model token usage inside a role run as developer receivable", () => {
+    const result = createDijieRoleUsageLedgerEntry({
+      entryId: "role_usage_123",
+      executionId: "exec_123",
+      actorId: "cus_123",
+      developerId: "dev_123",
+      developerRef: "dev_123",
+      billingBeneficiaryRef: "dev_123",
+      roleListingId: "role_123",
+      packageId: "pkg_123",
+      packageVersion: "1.0.0",
+      entitlementId: "ent_123",
+      workspaceRef: "workspace_123",
+      usageKind: "model_tokens",
+      meters: [
+        { name: "input_tokens", quantity: 3000, unit: "token" },
+        { name: "output_tokens", quantity: 1200, unit: "token" },
+      ],
+      currency: "CNY",
+      amountCents: 126,
+      occurredAt: "2026-05-31T08:20:00.000Z",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.value).toMatchObject({
+      ledger: "usage",
+      source: "role_usage",
+      executionId: "exec_123",
+      developerId: "dev_123",
+      developerRef: "dev_123",
+      billingBeneficiaryRef: "dev_123",
+      roleListingId: "role_123",
+      packageVersion: "1.0.0",
+      usageKind: "model_tokens",
+      grossAmountCents: 126,
+      platformReceivableCents: 0,
+      developerReceivableCents: 126,
+    });
+  });
+
+  it("derives developer role token receivable from audit model usage", () => {
+    const result = createDijieRoleTokenUsageLedgerEntryFromAudit(auditRecord());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.value).toMatchObject({
+      ledger: "usage",
+      source: "role_usage",
+      entryId: "role_usage_exec_123",
+      executionId: "exec_123",
+      developerRef: "dev_123",
+      billingBeneficiaryRef: "dev_123",
+      packageId: "pkg_123",
+      packageVersion: "1.0.0",
+      entitlementId: "ent_123",
+      currency: "CNY",
+      grossAmountCents: 300,
+      platformReceivableCents: 0,
+      developerReceivableCents: 300,
+    });
+  });
+
+  it("refuses to settle role token usage without model proxy usage", () => {
+    const record = auditRecord({
+      summary: {
+        ...auditRecord().summary,
+        modelProxyUsage: undefined,
+      },
+    });
+    const result = createDijieRoleTokenUsageLedgerEntryFromAudit(record);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("modelProxyUsage");
+    }
+  });
+
+  it("rejects role pricing with a marketplace platform cut", () => {
+    const result = createDijieMarketplaceRoleLedgerEntries({
+      entryId: "market_bad",
+      payoutEntryId: "payout_bad",
+      eventKind: "role_authorization",
+      actorId: "cus_123",
+      developerId: "dev_123",
+      roleListingId: "role_123",
+      entitlementId: "ent_123",
+      pricing: {
+        kind: "one_time_authorization",
+        authorizationFeeCents: 29900,
+        currency: "CNY",
+        platformFeeBps: 1500,
+        developerReceivableCents: 25415,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("platformFeeBps = 0");
+    }
+  });
+
+  it("rejects usage entries without real meters", () => {
+    const result = createDijieUsageLedgerEntry({
+      entryId: "usage_bad",
+      actorId: "cus_123",
+      workspaceRef: "workspace_123",
+      usageKind: "tool_execution",
+      meters: [],
+      currency: "CNY",
+      amountCents: 10,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("at least one meter");
+    }
+  });
+
+  it("rejects role token usage entries without a developer owner", () => {
+    const result = createDijieRoleUsageLedgerEntry({
+      entryId: "role_usage_bad",
+      executionId: "exec_123",
+      actorId: "cus_123",
+      developerId: "",
+      developerRef: "dev_123",
+      billingBeneficiaryRef: "dev_123",
+      roleListingId: "role_123",
+      packageId: "pkg_123",
+      packageVersion: "1.0.0",
+      entitlementId: "ent_123",
+      workspaceRef: "workspace_123",
+      usageKind: "model_tokens",
+      meters: [{ name: "input_tokens", quantity: 100, unit: "token" }],
+      currency: "CNY",
+      amountCents: 3,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("developerId");
+    }
+  });
+});

--- a/apps/api/src/lib/dijie/ledgers.ts
+++ b/apps/api/src/lib/dijie/ledgers.ts
@@ -1,0 +1,447 @@
+import {
+  normalizeOneTimeAuthorizationPricing,
+  normalizeRoleTokenPricing,
+  type DijieExecutionTokenPricing,
+} from "./execution-token";
+import type { DijieAuditRecord } from "./audit-summary";
+
+export type DijieLedgerResult<T> =
+  | {
+      ok: true;
+      value: T;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type DijieUsageKind =
+  | "model_tokens"
+  | "tool_execution"
+  | "runtime_resource"
+  | "download"
+  | "install"
+  | "other";
+
+export type DijieUsageMeter = {
+  name: string;
+  quantity: number;
+  unit: string;
+};
+
+export type DijieUsageLedgerEntry = {
+  ledger: "usage";
+  source: "main_system_usage";
+  entryId: string;
+  actorId: string;
+  workspaceRef: string;
+  usageKind: DijieUsageKind;
+  meters: DijieUsageMeter[];
+  currency: string;
+  grossAmountCents: number;
+  platformReceivableCents: number;
+  developerReceivableCents: 0;
+  occurredAt: string;
+};
+
+export type DijieRoleUsageLedgerEntry = {
+  ledger: "usage";
+  source: "role_usage";
+  entryId: string;
+  executionId: string;
+  actorId: string;
+  developerId: string;
+  developerRef: string;
+  billingBeneficiaryRef: string;
+  roleListingId: string;
+  packageId: string;
+  packageVersion: string;
+  entitlementId: string;
+  workspaceRef: string;
+  usageKind: DijieUsageKind;
+  meters: DijieUsageMeter[];
+  currency: string;
+  grossAmountCents: number;
+  platformReceivableCents: 0;
+  developerReceivableCents: number;
+  occurredAt: string;
+};
+
+export type DijieMarketplaceEventKind = "role_authorization";
+
+export type DijieMarketplaceOrderLedgerEntry = {
+  ledger: "marketplace_order";
+  source: "role_marketplace";
+  entryId: string;
+  eventKind: DijieMarketplaceEventKind;
+  actorId: string;
+  developerId: string;
+  roleListingId: string;
+  entitlementId: string;
+  currency: string;
+  grossAmountCents: number;
+  platformFeeBps: 0;
+  platformFeeCents: 0;
+  developerReceivableCents: number;
+  occurredAt: string;
+};
+
+export type DijieDeveloperPayoutLedgerEntry = {
+  ledger: "developer_payout";
+  source: "role_marketplace";
+  entryId: string;
+  marketplaceEntryId: string;
+  developerId: string;
+  roleListingId: string;
+  entitlementId: string;
+  currency: string;
+  amountCents: number;
+  status: "pending";
+  occurredAt: string;
+};
+
+export type DijieMarketplaceRoleLedgerEntries = {
+  marketplaceOrder: DijieMarketplaceOrderLedgerEntry;
+  developerPayout: DijieDeveloperPayoutLedgerEntry;
+};
+
+export type CreateDijieUsageLedgerEntryInput = {
+  entryId: string;
+  actorId: string;
+  workspaceRef: string;
+  usageKind: DijieUsageKind;
+  meters: DijieUsageMeter[];
+  currency: string;
+  amountCents: number;
+  occurredAt?: string;
+};
+
+export type CreateDijieRoleUsageLedgerEntryInput = CreateDijieUsageLedgerEntryInput & {
+  executionId: string;
+  developerId: string;
+  developerRef: string;
+  billingBeneficiaryRef: string;
+  roleListingId: string;
+  packageId: string;
+  packageVersion: string;
+  entitlementId: string;
+};
+
+export type CreateDijieMarketplaceRoleLedgerEntriesInput = {
+  entryId: string;
+  payoutEntryId: string;
+  eventKind: DijieMarketplaceEventKind;
+  actorId: string;
+  developerId: string;
+  roleListingId: string;
+  entitlementId: string;
+  pricing: DijieExecutionTokenPricing;
+  occurredAt?: string;
+};
+
+const USAGE_KINDS = new Set<DijieUsageKind>([
+  "model_tokens",
+  "tool_execution",
+  "runtime_resource",
+  "download",
+  "install",
+  "other",
+]);
+
+const MARKETPLACE_EVENT_KINDS = new Set<DijieMarketplaceEventKind>([
+  "role_authorization",
+]);
+
+function nonEmptyString(value: string | undefined): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function nonNegativeInteger(value: number): boolean {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function nonNegativeFiniteNumber(value: number): boolean {
+  return Number.isFinite(value) && value >= 0;
+}
+
+function isoTimestamp(value: string | undefined): string {
+  return value ?? new Date().toISOString();
+}
+
+function validateCommonFields(fields: Record<string, string | undefined>): string | undefined {
+  const missing = Object.entries(fields)
+    .filter(([, value]) => !nonEmptyString(value))
+    .map(([field]) => field);
+
+  return missing.length > 0 ? `Missing required ledger fields: ${missing.join(", ")}` : undefined;
+}
+
+export function createDijieUsageLedgerEntry(
+  input: CreateDijieUsageLedgerEntryInput,
+): DijieLedgerResult<DijieUsageLedgerEntry> {
+  const missing = validateCommonFields({
+    entryId: input.entryId,
+    actorId: input.actorId,
+    workspaceRef: input.workspaceRef,
+    currency: input.currency,
+  });
+  if (missing) {
+    return { ok: false, error: missing };
+  }
+
+  if (!USAGE_KINDS.has(input.usageKind)) {
+    return { ok: false, error: "Usage ledger entry has an unsupported usage kind." };
+  }
+
+  if (!nonNegativeInteger(input.amountCents)) {
+    return { ok: false, error: "Usage ledger amount must be a non-negative integer." };
+  }
+
+  if (input.meters.length === 0) {
+    return { ok: false, error: "Usage ledger entry requires at least one meter." };
+  }
+
+  const invalidMeter = input.meters.find(
+    (meter) =>
+      !nonEmptyString(meter.name) ||
+      !nonEmptyString(meter.unit) ||
+      !nonNegativeFiniteNumber(meter.quantity),
+  );
+  if (invalidMeter) {
+    return {
+      ok: false,
+      error: "Usage ledger meters require name, non-negative quantity, and unit.",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      ledger: "usage",
+      source: "main_system_usage",
+      entryId: input.entryId.trim(),
+      actorId: input.actorId.trim(),
+      workspaceRef: input.workspaceRef.trim(),
+      usageKind: input.usageKind,
+      meters: input.meters.map((meter) => ({
+        name: meter.name.trim(),
+        quantity: meter.quantity,
+        unit: meter.unit.trim(),
+      })),
+      currency: input.currency.trim(),
+      grossAmountCents: input.amountCents,
+      platformReceivableCents: input.amountCents,
+      developerReceivableCents: 0,
+      occurredAt: isoTimestamp(input.occurredAt),
+    },
+  };
+}
+
+export function createDijieRoleUsageLedgerEntry(
+  input: CreateDijieRoleUsageLedgerEntryInput,
+): DijieLedgerResult<DijieRoleUsageLedgerEntry> {
+  const missing = validateCommonFields({
+    entryId: input.entryId,
+    executionId: input.executionId,
+    actorId: input.actorId,
+    developerId: input.developerId,
+    developerRef: input.developerRef,
+    billingBeneficiaryRef: input.billingBeneficiaryRef,
+    roleListingId: input.roleListingId,
+    packageId: input.packageId,
+    packageVersion: input.packageVersion,
+    entitlementId: input.entitlementId,
+    workspaceRef: input.workspaceRef,
+    currency: input.currency,
+  });
+  if (missing) {
+    return { ok: false, error: missing };
+  }
+
+  if (!USAGE_KINDS.has(input.usageKind)) {
+    return { ok: false, error: "Role usage ledger entry has an unsupported usage kind." };
+  }
+
+  if (!nonNegativeInteger(input.amountCents)) {
+    return { ok: false, error: "Role usage amount must be a non-negative integer." };
+  }
+
+  if (input.meters.length === 0) {
+    return { ok: false, error: "Role usage ledger entry requires at least one meter." };
+  }
+
+  const invalidMeter = input.meters.find(
+    (meter) =>
+      !nonEmptyString(meter.name) ||
+      !nonEmptyString(meter.unit) ||
+      !nonNegativeFiniteNumber(meter.quantity),
+  );
+  if (invalidMeter) {
+    return {
+      ok: false,
+      error: "Role usage meters require name, non-negative quantity, and unit.",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      ledger: "usage",
+      source: "role_usage",
+      entryId: input.entryId.trim(),
+      executionId: input.executionId.trim(),
+      actorId: input.actorId.trim(),
+      developerId: input.developerId.trim(),
+      developerRef: input.developerRef.trim(),
+      billingBeneficiaryRef: input.billingBeneficiaryRef.trim(),
+      roleListingId: input.roleListingId.trim(),
+      packageId: input.packageId.trim(),
+      packageVersion: input.packageVersion.trim(),
+      entitlementId: input.entitlementId.trim(),
+      workspaceRef: input.workspaceRef.trim(),
+      usageKind: input.usageKind,
+      meters: input.meters.map((meter) => ({
+        name: meter.name.trim(),
+        quantity: meter.quantity,
+        unit: meter.unit.trim(),
+      })),
+      currency: input.currency.trim(),
+      grossAmountCents: input.amountCents,
+      platformReceivableCents: 0,
+      developerReceivableCents: input.amountCents,
+      occurredAt: isoTimestamp(input.occurredAt),
+    },
+  };
+}
+
+function amountCentsForRoleModelUsage(record: DijieAuditRecord): number | undefined {
+  const usage = record.summary.modelProxyUsage;
+  if (!usage) {
+    return undefined;
+  }
+
+  const numerator =
+    BigInt(usage.inputTokens) * BigInt(record.roleTokenPricing.inputTokenCentsPerMillion) +
+    BigInt(usage.outputTokens) * BigInt(record.roleTokenPricing.outputTokenCentsPerMillion);
+  const cents = (numerator + 999_999n) / 1_000_000n;
+  if (cents > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return undefined;
+  }
+  return Number(cents);
+}
+
+export function createDijieRoleTokenUsageLedgerEntryFromAudit(
+  record: DijieAuditRecord,
+): DijieLedgerResult<DijieRoleUsageLedgerEntry> {
+  const usage = record.summary.modelProxyUsage;
+  if (!usage) {
+    return {
+      ok: false,
+      error: "Role token usage settlement requires AuditSummary.modelProxyUsage.",
+    };
+  }
+
+  const roleTokenPricing = normalizeRoleTokenPricing(record.roleTokenPricing);
+  if (!roleTokenPricing) {
+    return {
+      ok: false,
+      error:
+        "Role token usage settlement requires roleTokenPricing with input/output token cents per million, platformFeeBps=0, and developerReceivableBps=10000.",
+    };
+  }
+
+  const amountCents = amountCentsForRoleModelUsage(record);
+  if (amountCents === undefined) {
+    return { ok: false, error: "Role token usage amount is outside the supported range." };
+  }
+
+  return createDijieRoleUsageLedgerEntry({
+    entryId: `role_usage_${record.summary.executionId}`,
+    executionId: record.summary.executionId,
+    actorId: record.actorId,
+    developerId: record.billingBeneficiaryRef,
+    developerRef: record.developerRef,
+    billingBeneficiaryRef: record.billingBeneficiaryRef,
+    roleListingId: record.summary.roleListingId,
+    packageId: record.packageId,
+    packageVersion: record.packageVersion,
+    entitlementId: record.summary.entitlementId,
+    workspaceRef: record.summary.workspaceRef,
+    usageKind: "model_tokens",
+    meters: [
+      { name: "request_count", quantity: usage.requestCount, unit: "request" },
+      { name: "input_tokens", quantity: usage.inputTokens, unit: "token" },
+      { name: "output_tokens", quantity: usage.outputTokens, unit: "token" },
+    ],
+    currency: roleTokenPricing.currency,
+    amountCents,
+    occurredAt: record.receivedAt,
+  });
+}
+
+export function createDijieMarketplaceRoleLedgerEntries(
+  input: CreateDijieMarketplaceRoleLedgerEntriesInput,
+): DijieLedgerResult<DijieMarketplaceRoleLedgerEntries> {
+  const missing = validateCommonFields({
+    entryId: input.entryId,
+    payoutEntryId: input.payoutEntryId,
+    actorId: input.actorId,
+    developerId: input.developerId,
+    roleListingId: input.roleListingId,
+    entitlementId: input.entitlementId,
+  });
+  if (missing) {
+    return { ok: false, error: missing };
+  }
+
+  if (!MARKETPLACE_EVENT_KINDS.has(input.eventKind)) {
+    return { ok: false, error: "Marketplace ledger entry has an unsupported event kind." };
+  }
+
+  const pricing = normalizeOneTimeAuthorizationPricing(input.pricing);
+  if (!pricing) {
+    return {
+      ok: false,
+      error:
+        "Marketplace role ledger requires one_time_authorization pricing with platformFeeBps = 0 and full developer receivable.",
+    };
+  }
+
+  const occurredAt = isoTimestamp(input.occurredAt);
+  const marketplaceOrder: DijieMarketplaceOrderLedgerEntry = {
+    ledger: "marketplace_order",
+    source: "role_marketplace",
+    entryId: input.entryId.trim(),
+    eventKind: input.eventKind,
+    actorId: input.actorId.trim(),
+    developerId: input.developerId.trim(),
+    roleListingId: input.roleListingId.trim(),
+    entitlementId: input.entitlementId.trim(),
+    currency: pricing.currency,
+    grossAmountCents: pricing.authorizationFeeCents,
+    platformFeeBps: 0,
+    platformFeeCents: 0,
+    developerReceivableCents: pricing.developerReceivableCents,
+    occurredAt,
+  };
+
+  return {
+    ok: true,
+    value: {
+      marketplaceOrder,
+      developerPayout: {
+        ledger: "developer_payout",
+        source: "role_marketplace",
+        entryId: input.payoutEntryId.trim(),
+        marketplaceEntryId: marketplaceOrder.entryId,
+        developerId: marketplaceOrder.developerId,
+        roleListingId: marketplaceOrder.roleListingId,
+        entitlementId: marketplaceOrder.entitlementId,
+        currency: marketplaceOrder.currency,
+        amountCents: marketplaceOrder.developerReceivableCents,
+        status: "pending",
+        occurredAt,
+      },
+    },
+  };
+}

--- a/apps/api/src/lib/dijie/role-listings.test.ts
+++ b/apps/api/src/lib/dijie/role-listings.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createDijieInstalledRolesFromMarketplaceFacts,
+  createDijieRoleListingFromProduct,
+} from "./role-listings";
+
+const roleTokenPricing = {
+  inputTokenCentsPerMillion: 120,
+  outputTokenCentsPerMillion: 360,
+  currency: "CNY",
+  developerReceivableBps: 10000,
+  platformFeeBps: 0,
+};
+
+const roleProduct = {
+  id: "prod_role_researcher",
+  title: "资料研究岗位",
+  subtitle: "整理资料并输出简报",
+  description: "适合做资料收集和结构化总结。",
+  handle: "research-role",
+  status: "published",
+  seller: {
+    id: "dev_001",
+    name: "迭界开发者",
+  },
+  metadata: {
+    dijieRole: {
+      kind: "role_product",
+      protocolVersion: "2026-05",
+      packageId: "pkg_researcher",
+      packageVersion: "1.0.0",
+      developerRef: "dev_001",
+      listingStatus: "published",
+      reviewState: "approved",
+      capabilities: ["资料收集"],
+      pricing: {
+        kind: "one_time_authorization",
+        authorizationFeeCents: 19900,
+        currency: "CNY",
+        platformFeeBps: 0,
+        developerReceivableCents: 19900,
+      },
+      roleTokenPricing,
+    },
+  },
+};
+
+describe("Dijie role listing projection", () => {
+  it("creates a public role listing from Mercur product facts", () => {
+    expect(createDijieRoleListingFromProduct(roleProduct)).toEqual({
+      id: "prod_role_researcher",
+      title: "资料研究岗位",
+      subtitle: "整理资料并输出简报",
+      description: "适合做资料收集和结构化总结。",
+      handle: "research-role",
+      listingStatus: "published",
+      reviewState: "approved",
+      developerId: "dev_001",
+      developerName: "迭界开发者",
+      packageId: "pkg_researcher",
+      packageVersion: "1.0.0",
+      protocolVersion: "2026-05",
+      capabilities: ["资料收集"],
+      pricing: {
+        kind: "one_time_authorization",
+        authorizationFeeCents: 19900,
+        currency: "CNY",
+        platformFeeBps: 0,
+        developerReceivableCents: 19900,
+      },
+      roleTokenPricing,
+      scopes: ["role.execute", "audit.write"],
+    });
+  });
+
+  it("does not publish products without one-time role authorization pricing", () => {
+    expect(
+      createDijieRoleListingFromProduct({
+        id: "prod_regular",
+        title: "普通商品",
+        status: "published",
+        metadata: {},
+      }),
+    ).toBeUndefined();
+  });
+
+  it("derives installed roles from paid orders only", () => {
+    const installed = createDijieInstalledRolesFromMarketplaceFacts({
+      products: [roleProduct],
+      orderGroups: [
+        {
+          id: "ordgrp_paid",
+          customer_id: "cus_001",
+          orders: [
+            {
+              id: "order_paid",
+              status: "completed",
+              created_at: "2026-05-31T00:00:00.000Z",
+              payment_collections: [
+                { status: "captured", amount: 19900, captured_amount: 19900 },
+              ],
+              items: [{ product_id: "prod_role_researcher" }],
+            },
+            {
+              id: "order_unpaid",
+              status: "pending",
+              items: [{ product_id: "prod_role_researcher" }],
+            },
+          ],
+        },
+      ],
+      orders: [],
+    });
+
+    expect(installed).toHaveLength(1);
+    expect(installed[0]).toMatchObject({
+      entitlementId: "ordgrp_paid",
+      entitlementSource: "order_group",
+      orderId: "order_paid",
+      authorizedAt: "2026-05-31T00:00:00.000Z",
+      role: {
+        id: "prod_role_researcher",
+        title: "资料研究岗位",
+      },
+    });
+  });
+});

--- a/apps/api/src/lib/dijie/role-listings.ts
+++ b/apps/api/src/lib/dijie/role-listings.ts
@@ -1,0 +1,333 @@
+import type { DijieExecutionTokenPricing, DijieRoleTokenPricing } from "./execution-token";
+import {
+  isPublicDijieRoleProduct,
+  normalizeDijieRoleProductMetadataFromProduct,
+} from "./role-product-metadata";
+
+export type DijieQueryGraph = (query: {
+  entity: string;
+  fields: string[];
+  filters?: Record<string, unknown>;
+  pagination?: Record<string, unknown>;
+}) => Promise<{ data?: unknown[] }>;
+
+export type DijieRoleListing = {
+  id: string;
+  title: string;
+  subtitle: string | null;
+  description: string | null;
+  handle: string | null;
+  listingStatus: string;
+  reviewState: string | null;
+  developerId: string | null;
+  developerName: string | null;
+  packageId: string | null;
+  packageVersion: string | null;
+  protocolVersion: string | null;
+  capabilities: string[];
+  pricing: DijieExecutionTokenPricing;
+  roleTokenPricing: DijieRoleTokenPricing;
+  scopes: string[];
+};
+
+export type DijieInstalledRole = {
+  entitlementId: string;
+  entitlementSource: "order_group" | "order";
+  orderId: string | null;
+  authorizedAt: string | null;
+  role: DijieRoleListing;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+const BLOCKED_ORDER_STATUSES = new Set(["canceled", "cancelled"]);
+const PAID_ORDER_STATUSES = new Set(["completed"]);
+const PAID_PAYMENT_STATUSES = new Set(["captured", "paid", "completed"]);
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function metadata(record: UnknownRecord): UnknownRecord {
+  return asRecord(record.metadata);
+}
+
+function sellerRecord(product: UnknownRecord): UnknownRecord {
+  return asRecord(product.seller);
+}
+
+export function createDijieRoleListingFromProduct(productInput: unknown): DijieRoleListing | undefined {
+  const product = asRecord(productInput);
+  const id = nonEmptyString(product.id);
+  if (!id) {
+    return undefined;
+  }
+
+  const roleResult = normalizeDijieRoleProductMetadataFromProduct(product);
+  if (!roleResult.ok || !isPublicDijieRoleProduct(roleResult.value)) {
+    return undefined;
+  }
+  const role = roleResult.value;
+  const seller = sellerRecord(product);
+  return {
+    id,
+    title: nonEmptyString(role.title) ?? nonEmptyString(product.title) ?? "未命名岗位",
+    subtitle: nonEmptyString(role.subtitle ?? product.subtitle) ?? null,
+    description: nonEmptyString(role.description ?? product.description) ?? null,
+    handle: nonEmptyString(product.handle) ?? null,
+    listingStatus: role.listingStatus,
+    reviewState: role.reviewState,
+    developerId:
+      nonEmptyString(role.developerRef) ??
+      nonEmptyString(seller.id) ??
+      null,
+    developerName:
+      nonEmptyString(seller.name) ??
+      null,
+    packageId: role.packageId,
+    packageVersion: role.packageVersion,
+    protocolVersion: role.protocolVersion,
+    capabilities: role.capabilities,
+    pricing: role.pricing,
+    roleTokenPricing: role.roleTokenPricing,
+    scopes: role.scopes,
+  };
+}
+
+function orderIsBlocked(order: UnknownRecord): boolean {
+  const status = nonEmptyString(order.status)?.toLowerCase();
+  return Boolean(status && BLOCKED_ORDER_STATUSES.has(status));
+}
+
+function orderIsPaid(order: UnknownRecord): boolean {
+  const status = nonEmptyString(order.status)?.toLowerCase();
+  if (status && PAID_ORDER_STATUSES.has(status)) {
+    return true;
+  }
+
+  const paymentStatus = nonEmptyString(order.payment_status)?.toLowerCase();
+  if (paymentStatus && PAID_PAYMENT_STATUSES.has(paymentStatus)) {
+    return true;
+  }
+
+  const paymentCollections = Array.isArray(order.payment_collections)
+    ? order.payment_collections
+    : [];
+  return paymentCollections.some((payment) => {
+    const record = asRecord(payment);
+    const collectionStatus = nonEmptyString(record.status)?.toLowerCase();
+    if (collectionStatus && PAID_PAYMENT_STATUSES.has(collectionStatus)) {
+      return true;
+    }
+
+    const amount = Number(record.amount);
+    const capturedAmount = Number(record.captured_amount);
+    return Number.isFinite(amount) && amount > 0 && Number.isFinite(capturedAmount) && capturedAmount >= amount;
+  });
+}
+
+function itemProductIds(itemInput: unknown): string[] {
+  const item = asRecord(itemInput);
+  const itemMetadata = metadata(item);
+  const product = asRecord(item.product);
+  const variant = asRecord(item.variant);
+  const variantProduct = asRecord(variant.product);
+  return [
+    nonEmptyString(item.product_id),
+    nonEmptyString(itemMetadata.dijieRoleListingId),
+    nonEmptyString(itemMetadata.dijie_role_listing_id),
+    nonEmptyString(product.id),
+    nonEmptyString(variant.product_id),
+    nonEmptyString(variantProduct.id),
+  ].filter((value): value is string => Boolean(value));
+}
+
+function ordersFromOrderGroups(orderGroups: unknown[]): UnknownRecord[] {
+  return orderGroups.flatMap((orderGroupInput) => {
+    const orderGroup = asRecord(orderGroupInput);
+    return Array.isArray(orderGroup.orders) ? orderGroup.orders.map(asRecord) : [];
+  });
+}
+
+function uniqueByEntitlementAndRole(roles: DijieInstalledRole[]): DijieInstalledRole[] {
+  const seen = new Set<string>();
+  return roles.filter((role) => {
+    const key = `${role.entitlementId}:${role.role.id}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export function createDijieInstalledRolesFromMarketplaceFacts(params: {
+  products: unknown[];
+  orderGroups: unknown[];
+  orders: unknown[];
+}): DijieInstalledRole[] {
+  const listings = new Map<string, DijieRoleListing>();
+  for (const product of params.products) {
+    const listing = createDijieRoleListingFromProduct(product);
+    if (listing) {
+      listings.set(listing.id, listing);
+    }
+  }
+
+  const installed: DijieInstalledRole[] = [];
+  const orderGroupsByOrderId = new Map<string, string>();
+  for (const orderGroupInput of params.orderGroups) {
+    const orderGroup = asRecord(orderGroupInput);
+    const orderGroupId = nonEmptyString(orderGroup.id);
+    if (!orderGroupId || !Array.isArray(orderGroup.orders)) {
+      continue;
+    }
+    for (const order of orderGroup.orders.map(asRecord)) {
+      const orderId = nonEmptyString(order.id);
+      if (orderId) {
+        orderGroupsByOrderId.set(orderId, orderGroupId);
+      }
+    }
+  }
+
+  for (const order of [...ordersFromOrderGroups(params.orderGroups), ...params.orders.map(asRecord)]) {
+    if (orderIsBlocked(order) || !orderIsPaid(order)) {
+      continue;
+    }
+    const orderId = nonEmptyString(order.id);
+    const entitlementId =
+      (orderId ? orderGroupsByOrderId.get(orderId) : undefined) ??
+      nonEmptyString(order.order_group_id) ??
+      orderId;
+    if (!entitlementId) {
+      continue;
+    }
+    const authorizedAt =
+      nonEmptyString(order.created_at) ??
+      nonEmptyString(order.updated_at) ??
+      nonEmptyString(order.completed_at) ??
+      null;
+    const items = Array.isArray(order.items) ? order.items : [];
+    for (const item of items) {
+      for (const productId of itemProductIds(item)) {
+        const role = listings.get(productId);
+        if (!role) {
+          continue;
+        }
+        installed.push({
+          entitlementId,
+          entitlementSource:
+            orderId && orderGroupsByOrderId.has(orderId) ? "order_group" : "order",
+          orderId: orderId ?? null,
+          authorizedAt,
+          role,
+        });
+      }
+    }
+  }
+
+  return uniqueByEntitlementAndRole(installed);
+}
+
+export async function listDijieRoleListings(queryGraph: DijieQueryGraph): Promise<DijieRoleListing[]> {
+  const { data = [] } = await queryGraph({
+    entity: "product",
+    fields: [
+      "id",
+      "title",
+      "subtitle",
+      "description",
+      "handle",
+      "status",
+      "metadata",
+      "seller.id",
+      "seller.name",
+    ],
+    pagination: { take: 100 },
+  });
+
+  return data
+    .map(createDijieRoleListingFromProduct)
+    .filter((listing): listing is DijieRoleListing => Boolean(listing));
+}
+
+export async function listDijieInstalledRoles(params: {
+  actorId: string;
+  queryGraph: DijieQueryGraph;
+}): Promise<DijieInstalledRole[]> {
+  const [productResult, orderGroupResult, orderResult] = await Promise.all([
+    params.queryGraph({
+      entity: "product",
+      fields: [
+        "id",
+        "title",
+        "subtitle",
+        "description",
+        "handle",
+        "status",
+        "metadata",
+        "seller.id",
+        "seller.name",
+      ],
+      pagination: { take: 100 },
+    }),
+    params.queryGraph({
+      entity: "order_group",
+      fields: [
+        "id",
+        "customer_id",
+        "orders.id",
+        "orders.status",
+        "orders.payment_status",
+        "orders.created_at",
+        "orders.updated_at",
+        "orders.completed_at",
+        "orders.payment_collections.status",
+        "orders.payment_collections.amount",
+        "orders.payment_collections.captured_amount",
+        "orders.items.product_id",
+        "orders.items.variant.product_id",
+        "orders.items.variant.product.id",
+        "orders.items.product.id",
+        "orders.items.metadata",
+      ],
+      filters: { customer_id: params.actorId },
+      pagination: { take: 100 },
+    }),
+    params.queryGraph({
+      entity: "order",
+      fields: [
+        "id",
+        "order_group_id",
+        "customer_id",
+        "status",
+        "payment_status",
+        "created_at",
+        "updated_at",
+        "completed_at",
+        "payment_collections.status",
+        "payment_collections.amount",
+        "payment_collections.captured_amount",
+        "items.product_id",
+        "items.variant.product_id",
+        "items.variant.product.id",
+        "items.product.id",
+        "items.metadata",
+      ],
+      filters: { customer_id: params.actorId },
+      pagination: { take: 100 },
+    }),
+  ]);
+
+  return createDijieInstalledRolesFromMarketplaceFacts({
+    products: productResult.data ?? [],
+    orderGroups: orderGroupResult.data ?? [],
+    orders: orderResult.data ?? [],
+  });
+}

--- a/apps/api/src/lib/dijie/role-product-metadata.test.ts
+++ b/apps/api/src/lib/dijie/role-product-metadata.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from "bun:test";
+import {
+  findDijieRoleMetadataPrivacyIssues,
+  normalizeDijieRoleProductMetadataFromProduct,
+} from "./role-product-metadata";
+
+function productWithRole(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "prod_role_researcher",
+    title: "资料研究岗位",
+    status: "published",
+    seller: { id: "dev_001" },
+    metadata: {
+      dijieRole: {
+        kind: "role_product",
+        protocolVersion: "2026-05",
+        packageId: "pkg_researcher",
+        packageVersion: "1.0.0",
+        developerRef: "dev_001",
+        listingStatus: "published",
+        reviewState: "approved",
+        capabilities: ["资料收集", "简报生成"],
+        manifestSummary: {
+          entrypoint: "role_package/manifest.json",
+          tools: ["browser.search"],
+          sandbox: "workspace-write",
+          secretsRequired: ["BROWSER_API_KEY"],
+        },
+        pricing: {
+          kind: "one_time_authorization",
+          authorizationFeeCents: 19900,
+          currency: "CNY",
+          platformFeeBps: 0,
+          developerReceivableCents: 19900,
+        },
+        roleTokenPricing: {
+          inputTokenCentsPerMillion: 120,
+          outputTokenCentsPerMillion: 360,
+          currency: "CNY",
+          developerReceivableBps: 10000,
+          platformFeeBps: 0,
+        },
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe("Dijie role product metadata", () => {
+  it("normalizes a valid role product metadata payload", () => {
+    expect(normalizeDijieRoleProductMetadataFromProduct(productWithRole())).toMatchObject({
+      ok: true,
+      value: {
+        kind: "role_product",
+        protocolVersion: "2026-05",
+        roleListingId: "prod_role_researcher",
+        packageId: "pkg_researcher",
+        packageVersion: "1.0.0",
+        developerRef: "dev_001",
+        listingStatus: "published",
+        reviewState: "approved",
+        capabilities: ["资料收集", "简报生成"],
+        pricing: {
+          kind: "one_time_authorization",
+          authorizationFeeCents: 19900,
+          platformFeeBps: 0,
+          developerReceivableCents: 19900,
+        },
+        roleTokenPricing: {
+          inputTokenCentsPerMillion: 120,
+          outputTokenCentsPerMillion: 360,
+          developerReceivableBps: 10000,
+          platformFeeBps: 0,
+        },
+      },
+    });
+  });
+
+  it("rejects role products without developer token pricing", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({ roleTokenPricing: undefined }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: [
+        "metadata.dijieRole.roleTokenPricing must define CNY input/output token cents per million with platformFeeBps=0 and developerReceivableBps=10000.",
+      ],
+    });
+  });
+
+  it("rejects role token pricing platform cuts", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({
+          roleTokenPricing: {
+            inputTokenCentsPerMillion: 120,
+            outputTokenCentsPerMillion: 360,
+            currency: "CNY",
+            developerReceivableBps: 9500,
+            platformFeeBps: 500,
+          },
+        }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: [
+        "metadata.dijieRole.roleTokenPricing must define CNY input/output token cents per million with platformFeeBps=0 and developerReceivableBps=10000.",
+      ],
+    });
+  });
+
+  it("rejects role products without package identity fields", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({ packageId: undefined, packageVersion: undefined }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: [
+        "metadata.dijieRole.packageId is required.",
+        "metadata.dijieRole.packageVersion is required.",
+      ],
+    });
+  });
+
+  it("rejects marketplace platform cuts", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({
+          pricing: {
+            kind: "one_time_authorization",
+            authorizationFeeCents: 19900,
+            currency: "CNY",
+            platformFeeBps: 1000,
+            developerReceivableCents: 17910,
+          },
+        }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: ["metadata.dijieRole.pricing must be one_time_authorization in CNY with platformFeeBps=0."],
+    });
+  });
+
+  it("requires explicit review state and listing status in role metadata", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({ listingStatus: undefined, reviewState: undefined }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: [
+        "metadata.dijieRole.listingStatus is required.",
+        "metadata.dijieRole.reviewState is required.",
+      ],
+    });
+  });
+
+  it("rejects non-CNY authorization and role token pricing", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({
+          pricing: {
+            kind: "one_time_authorization",
+            authorizationFeeCents: 19900,
+            currency: "USD",
+            platformFeeBps: 0,
+            developerReceivableCents: 19900,
+          },
+          roleTokenPricing: {
+            inputTokenCentsPerMillion: 120,
+            outputTokenCentsPerMillion: 360,
+            currency: "USD",
+            developerReceivableBps: 10000,
+            platformFeeBps: 0,
+          },
+        }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: [
+        "metadata.dijieRole.pricing must be one_time_authorization in CNY with platformFeeBps=0.",
+        "metadata.dijieRole.roleTokenPricing must define CNY input/output token cents per million with platformFeeBps=0 and developerReceivableBps=10000.",
+      ],
+    });
+  });
+
+  it("rejects legacy product-level pricing outside metadata.dijieRole.pricing", () => {
+    const product = productWithRole({ pricing: undefined });
+    const result = normalizeDijieRoleProductMetadataFromProduct({
+      ...product,
+      metadata: {
+        ...product.metadata,
+        dijie_pricing: {
+          kind: "one_time_authorization",
+          authorizationFeeCents: 19900,
+          currency: "CNY",
+          platformFeeBps: 0,
+          developerReceivableCents: 19900,
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      issues: ["metadata.dijieRole.pricing must be one_time_authorization in CNY with platformFeeBps=0."],
+    });
+  });
+
+  it("rejects local absolute entrypoints", () => {
+    const result = normalizeDijieRoleProductMetadataFromProduct(
+      productWithRole({
+        manifestSummary: {
+          entrypoint: "/Users/weizuo/private/role_package/manifest.json",
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContain(
+        "metadata.dijieRole.manifestSummary.entrypoint must not be a local absolute path.",
+      );
+      expect(result.issues).toContain("metadata.dijieRole must not contain local absolute paths.");
+    }
+  });
+
+  it("rejects secret or token field names in role metadata", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({
+          providerAuth: "raw-secret",
+          providerKey: "raw-provider-key",
+          cloudBearer: "cloud-bearer",
+          rawExecutionToken: "raw-token",
+        }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: ["metadata.dijieRole must not contain secret, token, or provider auth field names."],
+    });
+  });
+
+  it("rejects private execution and developer-mode context fields in role metadata", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({
+          executionId: "exec_123",
+          entitlementId: "order_group_123",
+          deviceId: "device_123",
+          workspaceRef: "workspace_123",
+          localGatewayId: "gateway_123",
+          roleBuildBrief: "Internal developer-mode prompt summary.",
+          modeStage: "developer-role-builder",
+          developerModePrompt: "Create a role from the user's private chat.",
+          conversation: "private developer conversation",
+          messages: ["user described private business context"],
+          orderTotalCents: 19900,
+          walletBalanceCents: 5000,
+        }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: [
+        "metadata.dijieRole must not contain execution, entitlement, device, workspace, order, wallet, mode stage, prompt, or chat context field names.",
+      ],
+    });
+  });
+
+  it("exposes privacy-only validation for product create and update guards", () => {
+    expect(
+      findDijieRoleMetadataPrivacyIssues({
+        kind: "role_product",
+        entitlement: "ent_123",
+        execution: "exec_123",
+        history: "private chat transcript",
+        modeStage: "intake",
+        prompt: "private developer-mode prompt",
+        workspace: "workspace_123",
+        workspaceRef: "/Users/alice/private/workspace",
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        "metadata.dijieRole must not contain local absolute paths.",
+        "metadata.dijieRole must not contain execution, entitlement, device, workspace, order, wallet, mode stage, prompt, or chat context field names.",
+      ]),
+    );
+  });
+
+  it("rejects nested local absolute paths outside the manifest entrypoint", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({
+          reviewMaterials: {
+            sampleOutputPath: "file:///Users/weizuo/private/output.json",
+          },
+        }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: ["metadata.dijieRole must not contain local absolute paths."],
+    });
+  });
+
+  it("rejects private execution ids or provider secret values hidden in public-looking fields", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({
+          description:
+            "Public listing text accidentally includes exec_123 and sk-testsecretvalue1234567890.",
+        }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: ["metadata.dijieRole must not contain private execution ids, raw tokens, or provider secrets."],
+    });
+  });
+
+  it("rejects product-level metadata outside the dijieRole namespace", () => {
+    const product = productWithRole();
+    const result = normalizeDijieRoleProductMetadataFromProduct({
+      ...product,
+      metadata: {
+        dijie: product.metadata.dijieRole,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContain("metadata.dijieRole.kind must be role_product.");
+    }
+  });
+
+  it("rejects role products that request privileged scopes", () => {
+    expect(
+      normalizeDijieRoleProductMetadataFromProduct(
+        productWithRole({
+          scopes: ["role.execute", "audit.write", "operator.write"],
+        }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      issues: ["metadata.dijieRole.scopes may only include role.execute and audit.write."],
+    });
+  });
+});

--- a/apps/api/src/lib/dijie/role-product-metadata.ts
+++ b/apps/api/src/lib/dijie/role-product-metadata.ts
@@ -1,0 +1,408 @@
+import {
+  normalizeOneTimeAuthorizationPricing,
+  normalizeRoleTokenPricing,
+  type DijieExecutionTokenPricing,
+  type DijieRoleTokenPricing,
+} from "./execution-token";
+
+export type DijieRoleListingStatus =
+  | "draft"
+  | "proposed"
+  | "published"
+  | "delisted"
+  | "archived";
+
+export type DijieRoleReviewState = "draft" | "submitted" | "approved" | "rejected";
+
+export type DijieRoleManifestSummary = {
+  entrypoint?: string;
+  tools?: string[];
+  permissions?: string[];
+  sandbox?: "readonly" | "workspace-write" | "networked" | "custom";
+  inputs?: string[];
+  outputs?: string[];
+  secretsRequired?: string[];
+};
+
+export type DijieRoleProductMetadata = {
+  kind: "role_product";
+  protocolVersion: string;
+  roleListingId?: string;
+  packageId: string;
+  packageVersion: string;
+  developerRef: string;
+  listingOwnerRef: string;
+  billingBeneficiaryRef: string;
+  listingStatus: DijieRoleListingStatus;
+  reviewState: DijieRoleReviewState;
+  title?: string;
+  subtitle?: string;
+  description?: string;
+  capabilities: string[];
+  manifestSummary: DijieRoleManifestSummary;
+  pricing: DijieExecutionTokenPricing;
+  roleTokenPricing: DijieRoleTokenPricing;
+  scopes: string[];
+};
+
+export type DijieRoleProductMetadataResult =
+  | { ok: true; value: DijieRoleProductMetadata }
+  | { ok: false; issues: string[] };
+
+type UnknownRecord = Record<string, unknown>;
+
+const DEFAULT_PROTOCOL_VERSION = "2026-05";
+const DEFAULT_SCOPES = ["role.execute", "audit.write"];
+const ALLOWED_SCOPES = new Set(DEFAULT_SCOPES);
+const LISTING_STATUSES = new Set<DijieRoleListingStatus>([
+  "draft",
+  "proposed",
+  "published",
+  "delisted",
+  "archived",
+]);
+const REVIEW_STATES = new Set<DijieRoleReviewState>([
+  "draft",
+  "submitted",
+  "approved",
+  "rejected",
+]);
+const SENSITIVE_KEY_PATTERN =
+  /(api[_-]?key|secret|provider[_-]?(auth|key)|access[_-]?token|refresh[_-]?token|bearer|cloud[_-]?bearer|raw[_-]?(execution[_-]?)?token|execution[_-]?token)/i;
+const PRIVATE_CLOUD_BRIDGE_FIELD_NAMES = new Set([
+  "actorid",
+  "actorcontext",
+  "chat",
+  "chats",
+  "conversation",
+  "conversations",
+  "customerid",
+  "developerbuildcontext",
+  "developermodecontext",
+  "deviceid",
+  "entitlement",
+  "entitlementid",
+  "execution",
+  "executionid",
+  "history",
+  "localgatewayid",
+  "message",
+  "messages",
+  "modestage",
+  "order",
+  "ordergroupid",
+  "orderid",
+  "prompt",
+  "prompts",
+  "rolebuildbrief",
+  "buildbrief",
+  "sessionid",
+  "wallet",
+  "walletid",
+  "workspace",
+  "workspaceref",
+]);
+const PRIVATE_CLOUD_BRIDGE_KEY_PATTERN =
+  /(chat|conversation|message)[_-]?(history|log|transcript)/i;
+const PRIVATE_CLOUD_BRIDGE_VALUE_PATTERN =
+  /\b(?:exec|cus|ent|ord|ordgrp|wallet|device|workspace|gateway|audit|settlement)_[A-Za-z0-9][A-Za-z0-9_-]*\b/i;
+const PROVIDER_SECRET_VALUE_PATTERN =
+  /\b(?:sk-[A-Za-z0-9][A-Za-z0-9_-]{12,}|sk-ant-[A-Za-z0-9_-]{12,}|AIza[0-9A-Za-z_-]{20,}|Bearer\s+[A-Za-z0-9._~+/=-]{12,})\b/i;
+
+function asRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function stringField(record: UnknownRecord, field: string): string | undefined {
+  const value = record[field];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function roleMetadataFromProduct(product: UnknownRecord): UnknownRecord {
+  const productMetadata = asRecord(product.metadata);
+  return asRecord(productMetadata.dijieRole);
+}
+
+function pricingFromRoleMetadata(role: UnknownRecord): DijieExecutionTokenPricing | undefined {
+  return normalizeOneTimeAuthorizationPricing(role.pricing);
+}
+
+function roleTokenPricingFromRoleMetadata(role: UnknownRecord): DijieRoleTokenPricing | undefined {
+  return normalizeRoleTokenPricing(role.roleTokenPricing ?? role.role_token_pricing);
+}
+
+function listingStatusFromRole(role: UnknownRecord): DijieRoleListingStatus | undefined {
+  const raw = stringField(role, "listingStatus") ?? stringField(role, "listing_status");
+  const normalized = raw?.toLowerCase();
+  return normalized && LISTING_STATUSES.has(normalized as DijieRoleListingStatus)
+    ? (normalized as DijieRoleListingStatus)
+    : undefined;
+}
+
+function reviewStateFromRole(role: UnknownRecord): DijieRoleReviewState | undefined {
+  const raw = stringField(role, "reviewState") ?? stringField(role, "review_state");
+  const normalized = raw?.toLowerCase();
+  return normalized && REVIEW_STATES.has(normalized as DijieRoleReviewState)
+    ? (normalized as DijieRoleReviewState)
+    : undefined;
+}
+
+function manifestSummaryFromRole(role: UnknownRecord): DijieRoleManifestSummary {
+  const manifest = asRecord(role.manifestSummary ?? role.manifest_summary);
+  const sandbox = stringField(manifest, "sandbox");
+  return {
+    ...(stringField(manifest, "entrypoint") ? { entrypoint: stringField(manifest, "entrypoint") } : {}),
+    ...(stringArray(manifest.tools).length > 0 ? { tools: stringArray(manifest.tools) } : {}),
+    ...(stringArray(manifest.permissions).length > 0
+      ? { permissions: stringArray(manifest.permissions) }
+      : {}),
+    ...(sandbox === "readonly" ||
+    sandbox === "workspace-write" ||
+    sandbox === "networked" ||
+    sandbox === "custom"
+      ? { sandbox }
+      : {}),
+    ...(stringArray(manifest.inputs).length > 0 ? { inputs: stringArray(manifest.inputs) } : {}),
+    ...(stringArray(manifest.outputs).length > 0 ? { outputs: stringArray(manifest.outputs) } : {}),
+    ...(stringArray(manifest.secretsRequired ?? manifest.secrets_required).length > 0
+      ? { secretsRequired: stringArray(manifest.secretsRequired ?? manifest.secrets_required) }
+      : {}),
+  };
+}
+
+function containsLocalAbsolutePath(value: string): boolean {
+  const normalized = value.trim().replace(/\\/g, "/");
+  return (
+    normalized.startsWith("/") ||
+    /^[A-Za-z]:\//.test(normalized) ||
+    normalized.startsWith("file://") ||
+    /(?:^|[\s"'(])\/(?:Users|home|private|var|tmp|Volumes)\//u.test(normalized)
+  );
+}
+
+function containsLocalAbsolutePathValue(value: unknown): boolean {
+  if (typeof value === "string") {
+    return containsLocalAbsolutePath(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsLocalAbsolutePathValue);
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  return Object.values(value as UnknownRecord).some(containsLocalAbsolutePathValue);
+}
+
+function containsSensitiveFieldName(value: unknown): boolean {
+  if (typeof value === "string") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsSensitiveFieldName);
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return Object.entries(value as UnknownRecord).some(
+    ([key, entry]) =>
+      !["secretsRequired", "secrets_required"].includes(key) &&
+      (SENSITIVE_KEY_PATTERN.test(key) || containsSensitiveFieldName(entry)),
+  );
+}
+
+function containsPrivateCloudBridgeFieldName(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsPrivateCloudBridgeFieldName);
+  }
+
+  return Object.entries(value as UnknownRecord).some(([key, entry]) => {
+    const normalizedKey = key.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+
+    return (
+      PRIVATE_CLOUD_BRIDGE_FIELD_NAMES.has(normalizedKey) ||
+      normalizedKey.startsWith("order") ||
+      normalizedKey.includes("wallet") ||
+      normalizedKey.endsWith("prompt") ||
+      normalizedKey.endsWith("prompts") ||
+      PRIVATE_CLOUD_BRIDGE_KEY_PATTERN.test(key) ||
+      containsPrivateCloudBridgeFieldName(entry)
+    );
+  });
+}
+
+function containsPrivateCloudBridgeValue(value: unknown): boolean {
+  if (typeof value === "string") {
+    return (
+      PRIVATE_CLOUD_BRIDGE_VALUE_PATTERN.test(value) ||
+      PROVIDER_SECRET_VALUE_PATTERN.test(value)
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsPrivateCloudBridgeValue);
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return Object.values(value as UnknownRecord).some(containsPrivateCloudBridgeValue);
+}
+
+export function findDijieRoleMetadataPrivacyIssues(roleInput: unknown): string[] {
+  const role = asRecord(roleInput);
+  const issues: string[] = [];
+  const hasPrivateCloudBridgeFieldName = containsPrivateCloudBridgeFieldName(role);
+
+  if (containsLocalAbsolutePathValue(role)) {
+    issues.push("metadata.dijieRole must not contain local absolute paths.");
+  }
+  if (containsSensitiveFieldName(role)) {
+    issues.push("metadata.dijieRole must not contain secret, token, or provider auth field names.");
+  }
+  if (hasPrivateCloudBridgeFieldName) {
+    issues.push(
+      "metadata.dijieRole must not contain execution, entitlement, device, workspace, order, wallet, mode stage, prompt, or chat context field names.",
+    );
+  }
+  if (!hasPrivateCloudBridgeFieldName && containsPrivateCloudBridgeValue(role)) {
+    issues.push(
+      "metadata.dijieRole must not contain private execution ids, raw tokens, or provider secrets.",
+    );
+  }
+
+  return issues;
+}
+
+export function normalizeDijieRoleProductMetadataFromProduct(
+  productInput: unknown,
+): DijieRoleProductMetadataResult {
+  const product = asRecord(productInput);
+  const role = roleMetadataFromProduct(product);
+  const issues: string[] = [];
+
+  const pricing = pricingFromRoleMetadata(role);
+  const roleTokenPricing = roleTokenPricingFromRoleMetadata(role);
+  const listingStatus = listingStatusFromRole(role);
+  const reviewState = reviewStateFromRole(role);
+  const manifestSummary = manifestSummaryFromRole(role);
+  const packageId = stringField(role, "packageId") ?? stringField(role, "package_id");
+  const packageVersion = stringField(role, "packageVersion") ?? stringField(role, "package_version") ?? stringField(role, "version");
+  const developerRef =
+    stringField(role, "developerRef") ??
+    stringField(role, "developer_ref") ??
+    stringField(role, "developerId") ??
+    stringField(role, "developer_id") ??
+    stringField(asRecord(product.seller), "id");
+  const listingOwnerRef =
+    stringField(role, "listingOwnerRef") ??
+    stringField(role, "listing_owner_ref") ??
+    stringField(asRecord(product.seller), "id") ??
+    developerRef;
+  const billingBeneficiaryRef =
+    stringField(role, "billingBeneficiaryRef") ??
+    stringField(role, "billing_beneficiary_ref") ??
+    developerRef;
+  const protocolVersion =
+    stringField(role, "protocolVersion") ??
+    stringField(role, "protocol_version") ??
+    DEFAULT_PROTOCOL_VERSION;
+  const capabilities = stringArray(role.capabilities);
+  const scopes = stringArray(role.scopes).length > 0 ? stringArray(role.scopes) : DEFAULT_SCOPES;
+
+  if (stringField(role, "kind") !== "role_product") {
+    issues.push("metadata.dijieRole.kind must be role_product.");
+  }
+  if (!packageId) {
+    issues.push("metadata.dijieRole.packageId is required.");
+  }
+  if (!packageVersion) {
+    issues.push("metadata.dijieRole.packageVersion is required.");
+  }
+  if (!developerRef) {
+    issues.push("metadata.dijieRole.developerRef is required.");
+  }
+  if (!listingOwnerRef) {
+    issues.push("metadata.dijieRole.listingOwnerRef is required.");
+  }
+  if (!billingBeneficiaryRef) {
+    issues.push("metadata.dijieRole.billingBeneficiaryRef is required.");
+  }
+  if (!listingStatus) {
+    issues.push("metadata.dijieRole.listingStatus is required.");
+  }
+  if (!reviewState) {
+    issues.push("metadata.dijieRole.reviewState is required.");
+  }
+  if (!pricing) {
+    issues.push("metadata.dijieRole.pricing must be one_time_authorization in CNY with platformFeeBps=0.");
+  }
+  if (!roleTokenPricing) {
+    issues.push(
+      "metadata.dijieRole.roleTokenPricing must define CNY input/output token cents per million with platformFeeBps=0 and developerReceivableBps=10000.",
+    );
+  }
+  if (scopes.some((scope) => !ALLOWED_SCOPES.has(scope))) {
+    issues.push("metadata.dijieRole.scopes may only include role.execute and audit.write.");
+  }
+  if (manifestSummary.entrypoint && containsLocalAbsolutePath(manifestSummary.entrypoint)) {
+    issues.push("metadata.dijieRole.manifestSummary.entrypoint must not be a local absolute path.");
+  }
+  issues.push(...findDijieRoleMetadataPrivacyIssues(role));
+
+  if (
+    issues.length > 0 ||
+    !pricing ||
+    !roleTokenPricing ||
+    !listingStatus ||
+    !reviewState ||
+    !packageId ||
+    !packageVersion ||
+    !developerRef ||
+    !listingOwnerRef ||
+    !billingBeneficiaryRef
+  ) {
+    return { ok: false, issues };
+  }
+
+  return {
+    ok: true,
+    value: {
+      kind: "role_product",
+      protocolVersion,
+      roleListingId: stringField(role, "roleListingId") ?? stringField(role, "role_listing_id") ?? stringField(product, "id"),
+      packageId,
+      packageVersion,
+      developerRef,
+      listingOwnerRef,
+      billingBeneficiaryRef,
+      listingStatus,
+      reviewState,
+      title: stringField(role, "title"),
+      subtitle: stringField(role, "subtitle"),
+      description: stringField(role, "description"),
+      capabilities,
+      manifestSummary,
+      pricing,
+      roleTokenPricing,
+      scopes,
+    },
+  };
+}
+
+export function isPublicDijieRoleProduct(metadata: DijieRoleProductMetadata): boolean {
+  return metadata.listingStatus === "published" && metadata.reviewState === "approved";
+}

--- a/apps/api/src/modules/README.md
+++ b/apps/api/src/modules/README.md
@@ -1,5 +1,7 @@
 # Custom Module
 
+迭界AI岗位商场是云端业务系统，不是 OpenClaw 插件。本文件里的 plugin 只指 Medusa/Mercur 内部扩展机制。
+
 A module is a package of reusable functionalities. It can be integrated into your Medusa application without affecting the overall system. You can create a module as part of a plugin.
 
 > Learn more about modules in [this documentation](https://docs.medusajs.com/learn/fundamentals/modules).

--- a/apps/api/src/modules/dijie-audit/index.ts
+++ b/apps/api/src/modules/dijie-audit/index.ts
@@ -1,0 +1,7 @@
+import { Module } from "@medusajs/framework/utils";
+import { DIJIE_AUDIT_MODULE } from "../../lib/dijie/audit-store";
+import DijieAuditModuleService from "./service";
+
+export default Module(DIJIE_AUDIT_MODULE, {
+  service: DijieAuditModuleService,
+});

--- a/apps/api/src/modules/dijie-audit/migrations/Migration20260531000000.ts
+++ b/apps/api/src/modules/dijie-audit/migrations/Migration20260531000000.ts
@@ -1,0 +1,20 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260531000000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "dijie_audit_record" ("id" text not null, "execution_id" text not null, "actor_id" text not null, "role_listing_id" text not null, "package_id" text not null, "package_version" text not null, "developer_ref" text not null, "listing_owner_ref" text not null, "billing_beneficiary_ref" text not null, "entitlement_id" text not null, "device_id" text not null, "workspace_ref" text not null, "local_gateway_id" text not null, "status" text check ("status" in ('completed', 'failed', 'cancelled', 'timed_out')) not null, "execution_token_issued_at" timestamptz not null, "execution_token_expires_at" timestamptz not null, "received_at" timestamptz not null, "pricing" jsonb not null, "role_token_pricing" jsonb not null, "role_usage_ledger" jsonb null, "model_proxy_usage" jsonb null, "tool_usage" jsonb not null, "changed_files" jsonb not null, "artifacts" jsonb not null, "error_summary" text null, "payload" jsonb not null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "dijie_audit_record_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_execution_id" ON "dijie_audit_record" ("execution_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_actor_id" ON "dijie_audit_record" ("actor_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_role_listing_id" ON "dijie_audit_record" ("role_listing_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_package_id" ON "dijie_audit_record" ("package_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_developer_ref" ON "dijie_audit_record" ("developer_ref") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_listing_owner_ref" ON "dijie_audit_record" ("listing_owner_ref") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_billing_beneficiary_ref" ON "dijie_audit_record" ("billing_beneficiary_ref") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_entitlement_id" ON "dijie_audit_record" ("entitlement_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_dijie_audit_record_deleted_at" ON "dijie_audit_record" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "dijie_audit_record" cascade;`);
+  }
+}

--- a/apps/api/src/modules/dijie-audit/models/dijie-audit-record.ts
+++ b/apps/api/src/modules/dijie-audit/models/dijie-audit-record.ts
@@ -1,0 +1,32 @@
+import { model } from "@medusajs/framework/utils";
+
+const DijieAuditRecord = model.define("dijie_audit_record", {
+  id: model.id({ prefix: "djaudit" }).primaryKey(),
+  execution_id: model.text().searchable(),
+  actor_id: model.text().searchable(),
+  role_listing_id: model.text().searchable(),
+  package_id: model.text().searchable(),
+  package_version: model.text(),
+  developer_ref: model.text().searchable(),
+  listing_owner_ref: model.text().searchable(),
+  billing_beneficiary_ref: model.text().searchable(),
+  entitlement_id: model.text().searchable(),
+  device_id: model.text(),
+  workspace_ref: model.text(),
+  local_gateway_id: model.text(),
+  status: model.enum(["completed", "failed", "cancelled", "timed_out"]),
+  execution_token_issued_at: model.dateTime(),
+  execution_token_expires_at: model.dateTime(),
+  received_at: model.dateTime(),
+  pricing: model.json(),
+  role_token_pricing: model.json(),
+  role_usage_ledger: model.json().nullable(),
+  model_proxy_usage: model.json().nullable(),
+  tool_usage: model.json(),
+  changed_files: model.json(),
+  artifacts: model.json(),
+  error_summary: model.text().nullable(),
+  payload: model.json(),
+});
+
+export default DijieAuditRecord;

--- a/apps/api/src/modules/dijie-audit/models/index.ts
+++ b/apps/api/src/modules/dijie-audit/models/index.ts
@@ -1,0 +1,1 @@
+export { default as DijieAuditRecord } from "./dijie-audit-record";

--- a/apps/api/src/modules/dijie-audit/service.ts
+++ b/apps/api/src/modules/dijie-audit/service.ts
@@ -1,0 +1,34 @@
+import { MedusaService } from "@medusajs/framework/utils";
+import {
+  recordDijieAuditSummaryWithRepository,
+  retrieveDijieAuditRecordByExecutionIdWithRepository,
+  type DijieAuditRecordRepository,
+  type DijieAuditRecordLookupRepository,
+  type DijieAuditRecordStore,
+  type DijieAuditExecutionRecordReader,
+} from "../../lib/dijie/audit-store";
+import type { DijieAuditRecord as DijieAuditRecordPayload } from "../../lib/dijie/audit-summary";
+import { DijieAuditRecord } from "./models";
+
+class DijieAuditModuleService
+  extends MedusaService({
+    DijieAuditRecord,
+  })
+  implements DijieAuditRecordStore, DijieAuditExecutionRecordReader
+{
+  async recordDijieAuditSummary(record: DijieAuditRecordPayload) {
+    return recordDijieAuditSummaryWithRepository(
+      this as unknown as DijieAuditRecordRepository,
+      record,
+    );
+  }
+
+  async retrieveDijieAuditRecordByExecutionId(executionId: string) {
+    return retrieveDijieAuditRecordByExecutionIdWithRepository(
+      this as unknown as DijieAuditRecordLookupRepository,
+      executionId,
+    );
+  }
+}
+
+export default DijieAuditModuleService;

--- a/apps/vendor/index.html
+++ b/apps/vendor/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/public/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mercur Vendor Hub</title>
+    <title>迭界AI岗位商场开发者中心</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/vendor/vite.config.ts
+++ b/apps/vendor/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => {
       react(),
       mercurDashboardPlugin({
         medusaConfigPath: '../api/medusa-config.ts',
+        name: '迭界AI岗位商场',
         ...(backendUrl ? { backendUrl } : {}),
         components: {
           StoreSetup: 'components/store-setup/store-setup',

--- a/docs/dijie/human-closed-loop-runbook.md
+++ b/docs/dijie/human-closed-loop-runbook.md
@@ -1,0 +1,353 @@
+# 迭界AI真人闭环验收 Runbook
+
+本 runbook 用来验收“岗位 Token 计费 + 真人闭环前置协议”的第一段真实业务链路。它不是自动化测试替代品；目标是让真人用真实账号走完创建、审核、购买、授权、本地执行、审计上传和审计读取，并留下可复查证据。
+
+正式运行本 runbook 前，先完成 OpenClaw 本地端预备清单：`openclaw-base/docs/aics/developer-package-smoke-preflight.md`。该清单只用于 PR/HOTL gate 通过前的准备工作，不能替代正式真人 smoke 证据。
+
+## Scope
+
+本轮必须证明：
+
+- vendor 能创建带 `roleTokenPricing` 的岗位商品。
+- admin 只能审核通过合法岗位定价：`currency = CNY`、输入/输出 Token 单价非负、`platformFeeBps = 0`、`developerReceivableBps = 10000`。
+- buyer 购买或授权后，云端能从真实订单事实推导 `/dijie/my-roles` 和 `/dijie/execution-token`。
+- OpenClaw 本地端用 execution token 执行岗位，生成 `AuditSummary.modelProxyUsage`。
+- 云端 `/dijie/audit` 持久化审计记录，并派生 `role_usage` 开发者应收账。
+- `GET /dijie/executions/:executionId` 只返回安全计费摘要，不返回 raw token、cloud bearer、provider key、本地绝对路径或模型原始请求/响应。
+
+不在本轮验收：
+
+- 钱包和开发者收益页。
+- 正式 entitlement 表。
+- 平台抽成策略。
+- 终端用户免手填 cloud bearer 的正式账号桥。
+
+## Preconditions
+
+### Cloud / marketplace
+
+准备一套可丢弃的测试账号：
+
+- vendor/developer 账号：用于创建岗位商品。
+- admin 账号：用于审核岗位商品。
+- buyer/customer 账号：用于购买并执行岗位。
+
+云端 API 需要启用 execution token 签发和审计验签：
+
+```bash
+DIJIE_EXECUTION_TOKEN_ISSUER_ENABLED=true
+DIJIE_ENTITLEMENT_VERIFY_URL=<cloud-base-url>/dijie/entitlements/verify
+DIJIE_ENTITLEMENT_VERIFY_BEARER=<internal bridge bearer>
+DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM=<ed25519 private key pem>
+DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM=<ed25519 public key pem>
+DIJIE_EXECUTION_TOKEN_TTL_SECONDS=300
+DIJIE_INTERNAL_BRIDGE_BEARER=<internal bridge bearer>
+```
+
+The `dijieAuditRecordStore` Medusa module must be registered. If it is missing, `/dijie/audit` must return 503 and the local run must not report full success.
+
+### OpenClaw local runtime
+
+The AICS/OpenClaw plugin needs the matching public key and cloud URLs:
+
+```json
+{
+  "aics": {
+    "allowWrites": true,
+    "executionTokenPublicKeyPem": "<same ed25519 public key pem>",
+    "cloudBaseUrl": "<cloud-base-url>",
+    "cloudAuditUploadEnabled": true,
+    "cloudAuditUploadRequired": true
+  }
+}
+```
+
+The local runtime must have either OpenClaw-native `runEmbeddedAgent` available or an explicit temporary `localExecutorCommand`. Missing execution engine config is a correct failure, not a pass.
+
+Do not paste production credentials into screenshots, docs, commits, role packages, `AuditSummary`, or `RoleResult`. The development-only cloud bearer is request-only evidence and must never be persisted.
+
+## Evidence Sheet
+
+Record these ids during the run:
+
+```text
+cloudBaseUrl:
+vendor account:
+admin account:
+buyer actor/customer id:
+roleListingId/product id:
+packageId:
+packageVersion:
+developerRef:
+listingOwnerRef:
+billingBeneficiaryRef:
+authorization price:
+role token input cents per million:
+role token output cents per million:
+order id or order_group id:
+entitlementId used:
+deviceId:
+workspaceRef:
+localGatewayId:
+executionId:
+auditRecordId:
+developerReceivableCents from role_usage:
+```
+
+## Step 1: Vendor Creates Role Listing
+
+Use the vendor UI to create a role product with:
+
+- one-time authorization price in CNY
+- input Token price in cents per million
+- output Token price in cents per million
+- package identity: `packageId` and `packageVersion`
+- developer, listing owner, and billing beneficiary refs
+
+Expected result:
+
+- The product metadata includes `metadata.dijieRole.kind = "role_product"`.
+- The product metadata contains only public listing metadata; it does not contain `modeStage`, role-builder prompts, chat history, `RoleBuildBrief`, workspace refs, execution ids, raw tokens, or provider secrets.
+- `metadata.dijieRole.pricing.kind = "one_time_authorization"`.
+- `metadata.dijieRole.pricing.platformFeeBps = 0`.
+- `metadata.dijieRole.pricing.developerReceivableBps = 10000`.
+- `metadata.dijieRole.roleTokenPricing.currency = "CNY"`.
+- `metadata.dijieRole.roleTokenPricing.inputTokenCentsPerMillion` is a non-negative integer.
+- `metadata.dijieRole.roleTokenPricing.outputTokenCentsPerMillion` is a non-negative integer.
+- `metadata.dijieRole.roleTokenPricing.platformFeeBps = 0`.
+- `metadata.dijieRole.roleTokenPricing.developerReceivableBps = 10000`.
+
+Failure checks:
+
+- Try leaving one Token price blank or negative. The listing must not be accepted as a valid executable role.
+- Try changing platform fee away from zero through any available surface. Admin review must block publication.
+
+## Step 2: Admin Reviews Listing
+
+Use the admin UI product detail page to review the role section.
+
+Expected result:
+
+- The page displays authorization price and role Token prices.
+- The page blocks approval if currency is not `CNY`.
+- The page blocks approval if either Token price is negative or missing.
+- The page blocks approval if platform fee is not zero.
+- The page blocks approval if developer receivable is not 10000 bps.
+- Once approved and published, `GET /dijie/roles` includes the listing.
+
+Evidence:
+
+```bash
+curl '<cloud-base-url>/dijie/roles'
+```
+
+Confirm the role projection includes `pricing` and `roleTokenPricing`, but no secrets, raw package auth, or local absolute paths.
+
+## Step 3: Buyer Purchases Or Authorizes Role
+
+Use the buyer account to purchase the approved role listing through the normal marketplace checkout path.
+
+Expected result:
+
+- The order belongs to the buyer customer.
+- The order is paid.
+- The order line item references the approved role listing.
+- Canceled or unpaid orders do not create an installed role.
+
+Evidence:
+
+Call the installed roles endpoint with the buyer's cloud bearer:
+
+```bash
+curl '<cloud-base-url>/dijie/my-roles?workspaceRef=<workspaceRef>&deviceId=<deviceId>' \
+  -H 'Authorization: Bearer <buyer-cloud-access-token>'
+```
+
+Expected response:
+
+- `ok: true`
+- one role with `entitlementId`
+- nested `role.roleListingId`
+- nested `role.roleTokenPricing`
+- no fake role card when the order is missing, unpaid, canceled, or owned by another customer
+
+Use the returned `entitlementId` in later steps. In the current implementation it may be an `order_group.id` or `order.id`.
+
+## Step 4: Request Execution Token
+
+From OpenClaw AICS UI or the Gateway method `dijie.executionToken.request`, request an execution token with:
+
+```text
+roleListingId=<approved product id>
+entitlementId=<order_group id or order id>
+deviceId=<local device id>
+workspaceRef=<local workspace ref>
+localGatewayId=<local gateway id>
+cloud_access_token=<buyer cloud bearer>
+```
+
+Equivalent API evidence:
+
+```bash
+curl '<cloud-base-url>/dijie/execution-token' \
+  -H 'Authorization: Bearer <buyer-cloud-access-token>' \
+  -H 'Content-Type: application/json' \
+  --data '{
+    "roleListingId": "<roleListingId>",
+    "entitlementId": "<entitlementId>",
+    "deviceId": "<deviceId>",
+    "workspaceRef": "<workspaceRef>",
+    "localGatewayId": "<localGatewayId>"
+  }'
+```
+
+Expected response:
+
+- `ok: true`
+- `grant.executionId`
+- `grant.token`
+- `grant.pricing.kind = "one_time_authorization"`
+- `grant.pricing.platformFeeBps = 0`
+- `grant.pricing.developerReceivableBps = 10000`
+- `grant.roleTokenPricing.currency = "CNY"`
+- `grant.roleTokenPricing.platformFeeBps = 0`
+- `grant.roleTokenPricing.developerReceivableBps = 10000`
+- `grant.scopes` includes `role.execute` and `audit.write`
+
+Failure checks:
+
+- Wrong buyer bearer returns 401 or 403.
+- Wrong `entitlementId` returns 403.
+- Missing product `roleTokenPricing` returns a hard failure.
+- Unpaid or canceled order returns a hard failure.
+- Missing issuer env returns 503.
+
+## Step 5: Run The Local Role
+
+In OpenClaw, run the role builder through the existing main-system flow, not a second chat box. Developer mode is the current role, work identity, and process stage inside the same primary conversation surface. For the development bridge this may be done from the AICS diagnostics page, but the natural-language entry remains OpenClaw's primary conversation surface.
+
+Required confirmed run fields:
+
+```text
+request_zh=<user role build request>
+confirm_brief=true
+role_build_brief_json=<confirmed brief>
+execution_token=<grant.token>
+role_listing_id=<grant.roleListingId>
+entitlement_id=<grant.entitlementId>
+device_id=<grant.deviceId>
+workspace_ref=<grant.workspaceRef>
+local_gateway_id=<grant.localGatewayId>
+```
+
+Expected local result:
+
+- Preflight verifies the Ed25519 signature.
+- Preflight rejects expired tokens.
+- Preflight rejects missing or invalid `roleTokenPricing`.
+- Preflight rejects context mismatch for role listing, entitlement, device, workspace, or local gateway.
+- The local executor produces `RoleResult` and `AuditSummary`.
+- `AuditSummary.modelProxyUsage` is present.
+- If audit upload is required, cloud audit failure makes the local run fail explicitly.
+
+## Step 6: Verify Audit Upload And Billing Summary
+
+Successful audit upload returns:
+
+- `ok: true`
+- `executionId`
+- `auditRecordId`
+- `billingSummary.source = "role_usage"`
+- `billingSummary.platformReceivableCents = 0`
+- `billingSummary.developerReceivableCents` equals Token usage multiplied by the role Token price snapshot
+- `billingSummary.developerRef`
+- `billingSummary.billingBeneficiaryRef`
+
+Failure checks:
+
+- Remove `modelProxyUsage` from the summary. `/dijie/audit` must return 400.
+- Remove `roleTokenPricing` from the token claims. `/dijie/audit` must return 401 or 400 depending on where validation fails.
+- Disable audit store. `/dijie/audit` must return 503.
+- Make the store throw. `/dijie/audit` must return 502.
+
+## Step 7: Read Safe Execution Summary
+
+Read the execution with the same buyer cloud bearer:
+
+```bash
+curl '<cloud-base-url>/dijie/executions/<executionId>' \
+  -H 'Authorization: Bearer <buyer-cloud-access-token>'
+```
+
+Expected response:
+
+- `ok: true`
+- `execution.executionId`
+- `execution.actorId`
+- `execution.roleListingId`
+- `execution.entitlementId`
+- `execution.status`
+- `execution.pricing`
+- `execution.modelProxyUsage`
+- `execution.toolUsage`
+- `execution.changedFiles`
+- `execution.artifacts`
+- `execution.receivedAt`
+
+The response must not include:
+
+- raw execution token
+- cloud bearer
+- provider key or provider auth
+- model raw request or raw response
+- raw stdout or stderr
+- local absolute paths
+- full persisted payload
+
+Failure checks:
+
+- Another buyer's bearer returns 403.
+- Missing bearer returns 401.
+- Unknown execution returns 404.
+- Missing audit store/read source returns 503.
+
+## Pass Criteria
+
+The run passes only when all of these are true:
+
+- A real vendor-created role listing with valid `roleTokenPricing` was approved.
+- A real buyer purchase or authorization produced `/dijie/my-roles`.
+- `/dijie/execution-token` minted a token from real buyer entitlement facts.
+- OpenClaw preflight accepted the token and rejected at least one intentional mismatch.
+- Local execution produced `AuditSummary.modelProxyUsage`.
+- `/dijie/audit` persisted the record and returned `role_usage` billing summary.
+- `GET /dijie/executions/:executionId` returned the safe projection.
+- No step used fake success or mock installed roles.
+- No screenshot, log, audit record, artifact, or response leaked bearer tokens, execution tokens, provider credentials, or local absolute paths.
+
+## Stop Conditions
+
+Stop the run and fix the product before continuing if:
+
+- A missing `roleTokenPricing` can still be approved or executed.
+- A buyer without a paid order can receive an execution token.
+- OpenClaw reports success when required audit upload fails.
+- Developer Token receivable is zero when model usage is non-zero.
+- Platform receivable is non-zero for `role_usage`.
+- The safe execution endpoint returns raw token, cloud bearer, provider auth, raw model payload, or local absolute paths.
+
+## After The Run
+
+Do not start wallet or developer earnings UI until this evidence exists:
+
+```text
+roleListingId:
+entitlementId:
+executionId:
+auditRecordId:
+role_usage developerReceivableCents:
+safe execution read verified by buyer:
+cross-buyer read rejected:
+```
+
+Once the evidence is captured, the next product slice is the developer revenue read model: aggregate authorization fee plus role Token usage into a developer-facing earnings page without changing the zero-platform-fee rule.

--- a/docs/dijie/local-execution-bridge.md
+++ b/docs/dijie/local-execution-bridge.md
@@ -1,0 +1,324 @@
+# 迭界AI本地执行桥
+
+## Product Boundary
+
+迭界AI云端使用 Mercur/Medusa 作为账号、岗位商场、订单、一次授权、审核和开发者中心的业务实现基础。OpenClaw fork 不是外接插件，也不是被削成纯 SaaS 后端；它改名和迁移业务规则后就是迭界AI主系统本体，保留原有对话、编程、workspace、session、Gateway、工具调用、文件读写、测试和 artifact 生成能力。
+
+云端不直接操作本地文件，本地端不直接修改订单、钱包、授权或审核状态。两边通过短期执行授权和审计摘要连接。
+
+## Adaptation Boundary
+
+开发边界定死：OpenClaw 侧和 Mercur/Medusa 商城侧都必须在原有能力基础上改编，不允许硬性直接植入一套平行功能。只有原框架真的没有的能力，才考虑新增模块；新增模块前必须先和用户确认。
+
+OpenClaw 侧原则：
+
+```text
+原有主对话框 -> 继续作为唯一自然语言入口；模式只是同一聊天框里的当前角色、工作身份和流程阶段
+原有 session / workspace -> 继续承载上下文和本地执行
+原有 Gateway -> 继续作为唯一执行和 RPC 入口
+原有 tools / model / provider auth -> 继续作为运行能力
+原有 logs / usage / status -> 优先接入迭界AI状态和审计信息
+```
+
+禁止为了迭界AI再造第二套聊天入口、第二套执行入口、第二套 workspace/runtime。OpenClaw 没有的业务能力才新增，例如 `AicsActorContext`、岗位商场授权、execution token、RolePackage/RoleResult 协议、审计桥、计费治理规则。
+
+Mercur/Medusa 侧原则：
+
+```text
+原有 customer / seller / developer 账号 -> 改编为迭界AI买家和开发者身份
+原有 product / listing / order -> 改编为岗位 listing 和一次授权订单
+原有 admin / review 能力 -> 改编为岗位包审核和平台治理
+原有 module / service 模式 -> 改编为 entitlement、audit、payout 记录
+```
+
+禁止绕过商城原有商业事实源另造影子商城、影子订单、影子账号。除非原框架没有合适设施，或者复用会破坏权限、审计、账本、生命周期边界，否则默认必须先改编原有能力。
+
+## Development Operating Model
+
+后续推进这个方向时，规划阶段和开发阶段都默认用三智能体模式。不是先由主智能体单独规划再分发，而是规划时就分成三路评审和拆分，开发时再三路执行。
+
+三智能体规划：
+
+```text
+规划智能体 A：OpenClaw fork / 迭界AI主系统规划
+-> 本地 App、Control UI、Gateway、device/session/workspace runtime
+-> 本地执行、模型/运行身份、UI 失败状态风险
+
+规划智能体 B：Mercur/Medusa fork / 迭界AI岗位商场规划
+-> 账号、订单、entitlement、一次授权费、审计读写
+-> 商业事实、auth、审核、listing 生命周期风险
+
+规划智能体 C：集成 / 协议 / 安全规划
+-> API contracts、ActorContext、token claims、RoleResult/AuditSummary
+-> secret 泄露、跨系统事实归属、失败关闭语义
+```
+
+三智能体开发：
+
+```text
+子智能体 A：OpenClaw fork / 迭界AI主系统
+-> 本地 App、Control UI、Gateway、device/session/workspace runtime
+-> 本地执行、OpenClaw-native runEmbeddedAgent、RoleResult/AuditSummary
+-> 页面失败状态、本地 validation/smoke 展示
+
+子智能体 B：Mercur/Medusa fork / 迭界AI岗位商场
+-> 账号、订单、entitlement、一次授权费
+-> execution token 签发、audit 上传、audit read model
+-> 开发者中心、审核、listing 生命周期
+
+子智能体 C 或主智能体：controller / reviewer / integrator
+-> 拆任务、保持边界、审核两边代码、跑关键测试
+-> 检查没有假成功、没有 secret 泄露、没有跨系统直接写库
+-> 最后用业务语言说明现在系统能做什么
+```
+
+主智能体不能在没有覆盖三路角色时声称已经三智能体规划或三智能体开发。如果系统子智能体数量限制导致无法同时派满三路，必须明确说明，并优先复用已有子智能体；主智能体必须显式承担缺失的集成/协议/安全角色，不能悄悄省略。
+
+写入边界固定：
+
+- OpenClaw 侧子智能体不修改 Mercur/Medusa 仓库。
+- Mercur/Medusa 侧子智能体不修改 OpenClaw 仓库。
+- 集成 / 协议 / 安全智能体只在确认归属后修改共享文档或协议 schema。
+- 主智能体可以在审核后补 integration docs 或小范围 glue 修复，但必须说明修改文件和验证结果。
+
+每次汇报按这个顺序：
+
+```text
+改完以后业务上能做什么
+两个仓库分别改了什么
+真实测试 / smoke 结果
+还缺哪个真人页面闭环
+```
+
+## First Pricing Rule
+
+第一版岗位侧只收一次授权费，平台不抽岗位分成：
+
+- 开发者为岗位 listing 设置授权价格。
+- 开发者为岗位 listing 设置模型用量单价：`metadata.dijieRole.roleTokenPricing.inputTokenCentsPerMillion` 和 `outputTokenCentsPerMillion`，单位为分/百万 Token。
+- 第一版岗位商品币种固定为 `CNY`，一次授权费和岗位 Token 单价都必须是非负整数分值，`platformFeeBps = 0`，`developerReceivableBps = 10000`。
+- 用户第一次购买/授权岗位时付款。
+- 岗位授权费 100% 归开发者，`platformFeeBps = 0`。
+- 平台收入来自用户直接使用迭界AI主系统时产生的 token、模型、工具和执行用量计费，不从岗位费用里再抽成。
+- 用户进入某个岗位执行上下文后，该岗位运行产生的模型 Token 费用归岗位开发者所有，不能归入平台主系统收入。
+- 用户后续运行该岗位不按运行时长额外计费；岗位运行的可计费资源先按模型 Token 账处理，后续若增加其他岗位用量类型也必须归岗位开发者。
+- 运行时仍需要资源限制，例如单次最长运行时间、并发数、最大 artifact 大小和最大模型代理调用量。这些限制用于保护系统，不作为隐藏计费。
+
+## Bridge Flow
+
+```text
+用户登录迭界AI云端
+-> 购买/授权岗位
+-> 迭界AI主系统本地 App 绑定同一账号和设备
+-> 本地 Gateway 请求 execution token
+-> 云端校验账号、entitlement、listing 状态、设备绑定和资源限制
+-> 云端签发短期 execution token
+-> 迭界AI主系统 runtime 在 workspace 中执行
+-> 本地生成 RoleResult 和 AuditSummary
+-> 云端记录审计摘要、artifact metadata 和执行状态
+```
+
+真人验收步骤见 [迭界AI真人闭环验收 Runbook](./human-closed-loop-runbook.md)。该 runbook 用来记录真实账号、真实岗位商品、真实订单授权、本地执行、审计上传和安全审计读取的证据。
+
+## Current OpenClaw UI Bridge
+
+迭界AI主系统页面当前只作为桥接状态和审计调试面板，不作为第二套岗位生成对话框。用户自然语言入口必须继续使用 OpenClaw 原本主对话框；所谓使用者模式、开发者模式，只能表达同一聊天框下当前角色、工作身份和流程阶段，不能暗示为另一套聊天入口、另一套会话实体或另一套聊天产品。
+
+岗位包生成的正式前端流程是对话优先：开发者在主对话里只补充业务逻辑和业务事实，直到主系统明确岗位要解决什么业务问题、给谁用、业务流程如何判断、希望完成什么结果。输入、输出、业务规则、验收标准、包结构、协议映射、验证材料、定价意图和审核资料都由主系统内置资料包和开发者模式流程处理。主系统再把业务逻辑沉淀成内部 `RoleBuildBrief`，用隔离 workspace 生成 `role_package/`。这个 `role_package/` 必须是可审核、可下载、可上传到开发者中心的完整岗位程序包，不是单纯的商品描述或 listing 占位。
+
+同一个主系统前端有两个用户模式：`使用者模式` 和 `开发者模式`。使用者模式用于购买、安装和运行已有岗位；开发者模式由明确的模式切换、命令或开发者中心入口唤醒。进入开发者模式后，不是打开新的聊天产品，而是让原主对话进入岗位开发的当前工作身份和流程阶段：它只向开发者追问业务逻辑，平台内置资料包负责岗位包结构、协议、验收、验证和上传标准，并交付下载/上传到开发者中心的动作。
+
+开发者模式必须切换上下文、权限、文案和可用动作。它可以读取本次开发者提供的需求、素材、公开协议和隔离 workspace；不能把使用者模式里的普通工作上下文、已购买岗位运行历史、主系统私有记忆或密钥当成岗位包生成输入。
+
+开发者模式必须内置指南提示词和资料包，但这些都是本地主系统的私有过程材料。开发者只需要捋清业务逻辑；execution token、Gateway、RoleResult、AuditSummary、entitlement、审计上传、Token 计费、结算和开发者中心上传协议都由主系统资料包和云端桥处理，不能变成开发者必须学习或手填的接口知识。
+
+开发者模式流程也不能把平台后端状态当成提示词材料。`executionId`、`actorId`、`entitlementId`、订单/钱包事实、结算快照、审核状态、cloud bearer 和 raw token 只能在平台桥、审计构建器、结算派生器和云端 API 内部流转。岗位开发流程只接收开发者提供的业务材料、公开岗位包协议/模板和隔离 workspace。
+
+在开发者模式内部，开发者只表达业务逻辑。输入、输出、业务规则、异常处理、验收标准、测试样例、岗位包结构、协议映射、验证材料和上传标准都是平台职责，已经内置在开发者模式流程和资料包里；不能要求内部开发者逐项填写、定义或确认这些标准。对于不用迭界AI开发者模式、选择用其他软件自行开发岗位包的外部开发者，这些维度可以作为公开平台标准和交付规范提供。
+
+开发者中心的表单只承接“已有岗位包”的上架资料：岗位包 ID、版本、清单入口、授权价、岗位 Token 单价、审核资料和发布状态。它不能反过来成为主系统里的岗位生成入口。
+
+## Cloud Developer Center Boundary
+
+Mercur/Medusa 云端仍是岗位商场、使用者中心和开发者中心的事实源，但第一版开发者中心不做完整云端 AI 助手，也不新增岗位生成聊天框。云端只管理账号、开发者身份、product/listing、订单授权、审核状态、执行授权、审计摘要和结算派生。
+
+内部开发者在 OpenClaw/迭界AI主系统的开发者模式里只表达业务逻辑。输入、输出、业务规则、异常处理、验收标准、测试样例、岗位包结构、协议映射、验证材料和上传标准由本地主系统内置资料包和开发者模式流程自动处理成内部 `RoleBuildBrief` 和 `role_package/`。开发者中心不能要求内部开发者把这些维度逐项手填成商品表单字段，也不能保存开发者模式的原始提示词、对话历史、`modeStage` 或私有 workspace 上下文。
+
+开发者中心表单的上架边界固定为：
+
+- 岗位包身份：`packageId`、`packageVersion` 和清单入口，例如 `role_package/manifest.json`。
+- 商场展示资料：标题、副标题、描述、能力摘要、图片、分类和销售渠道。
+- 商业规则：一次授权费、岗位 Token 输入/输出单价、`CNY`、平台抽成为 0、开发者应收为 10000 bps。
+- 审核生命周期：草稿、待审核、审核通过后发布、拒绝或下架。
+
+对不用迭界AI开发者模式、选择用其他软件自行开发岗位包的外部开发者，输入、输出、业务规则、异常处理、验收标准和测试样例可以作为公开岗位包交付规范；这些规范应进入岗位包清单、包内文档或审核材料，而不是变成云端生成助手或 per-user 执行事实。
+
+`metadata.dijieRole` 只能保存可公开 listing metadata 和审核/结算需要的稳定快照。它不能保存 `RoleBuildBrief`、开发者模式 prompt、聊天记录、`modeStage`、`executionId`、`actorId`、`entitlementId`、订单/钱包事实、`deviceId`、`workspaceRef`、`localGatewayId`、cloud bearer、raw execution token、provider auth 或 secret 原文。这些字段只允许在本地主系统开发者模式流程、平台桥、execution token、审计构建器、结算派生器和云端 API 内部按需流转。
+
+```text
+填写 roleListingId / entitlementId / deviceId / workspaceRef / localGatewayId
+-> 填入临时 cloud access token
+-> 点击 获取执行授权
+-> Gateway 调用 dijie.executionToken.request
+-> 本地 extension 请求 POST /dijie/execution-token
+-> 页面拿到短期 execution token
+-> 填入或回填 executionId
+-> 点击 查询审计记录
+-> Gateway 调用 dijie.executionAudit.read
+-> 本地 extension 请求 GET /dijie/executions/:executionId
+```
+
+`cloud access token` 只是开发期过渡输入，用来证明本地端可以通过云端账号授权拿到短期执行 token。它不能写入审计结果、role package、RoleResult、日志或本地持久配置。后续正式账号打通后，页面应由正常登录态换取 execution token，但仍然必须失败关闭：没有云端认证、没有 entitlement、listing 未发布、设备或 workspace 不匹配时，都不能进入本地执行。
+
+正式产品流程禁止把 `cloud access token` 做成终端客户手填字段。它只是开发诊断输入；上线形态必须由统一账号/session 桥自动换取短期云端访问，并且只能作为请求凭证使用。它不能进入 `RoleResult`、`AuditSummary`、岗位包、本地配置、执行日志或可持久化 UI state。
+
+## Billing Ledgers
+
+第一版把平台收入和岗位开发者收入拆成三条账本语义，后续落数据库时必须保持拆分：
+
+- `UsageLedger / main_system_usage`：用户直接使用迭界AI主系统产生的模型 token、工具执行、runtime 资源、下载和安装。收入归平台。
+- `UsageLedger / role_usage`：用户使用某个岗位时产生的模型 Token 用量。它由审计摘要中的模型用量乘以 `roleTokenPricing` 快照派生，`platformReceivableCents = 0`，`developerReceivableCents = Token费用`，收入归岗位开发者。
+- `MarketplaceOrderLedger`：岗位商场购买/授权事实。`platformFeeBps = 0`，`platformFeeCents = 0`。
+- `DeveloperPayoutLedger`：开发者应收。岗位授权费和岗位运行 Token 费用都必须进入开发者应收，不允许用平台抽成减少开发者应收。
+
+当前 `apps/api/src/lib/dijie/ledgers.ts` 是纯业务规则层，还没有写入数据库。它先用于保护分账边界：主系统计费归平台；岗位购买/授权费归开发者；岗位运行中产生的模型 Token 费用也归开发者；重复运行岗位不变成运行时长计费。
+
+## Current Role Marketplace Read Endpoints
+
+`GET /dijie/roles` 是岗位商场公开岗位商品列表。它从 Medusa/Mercur 的真实 `product` facts 读取，只返回具备迭界AI岗位 metadata、审核通过、已上架、带岗位包身份、以及 `one_time_authorization` 定价的 product。普通商品、未审核 product、未上架 product、缺少一次授权费或缺少岗位包 identity 的 product 不会被投影成岗位。
+
+当前岗位商品判定统一走 `apps/api/src/lib/dijie/role-product-metadata.ts`：
+
+- `metadata.dijieRole.kind = "role_product"`
+- `metadata.dijieRole.protocolVersion` 必填，默认目标版本为 `2026-05`
+- `metadata.dijieRole.packageId` 必填
+- `metadata.dijieRole.packageVersion` 必填
+- `metadata.dijieRole.developerRef` 必填
+- `metadata.dijieRole.listingOwnerRef` 必填，可从 seller 或 developerRef 派生
+- `metadata.dijieRole.billingBeneficiaryRef` 必填，可从 developerRef 派生
+- `metadata.dijieRole.listingStatus = "published"`
+- `metadata.dijieRole.reviewState = "approved"`
+- `metadata.dijieRole.pricing.kind = "one_time_authorization"`
+- `metadata.dijieRole.pricing.currency = "CNY"`
+- `metadata.dijieRole.pricing.platformFeeBps = 0`
+- `metadata.dijieRole.pricing.developerReceivableBps = 10000`
+- `metadata.dijieRole.pricing.developerReceivableCents = authorizationFeeCents`
+- `metadata.dijieRole.roleTokenPricing.currency = "CNY"`
+- `metadata.dijieRole.roleTokenPricing.inputTokenCentsPerMillion` 必须是非负整数
+- `metadata.dijieRole.roleTokenPricing.outputTokenCentsPerMillion` 必须是非负整数
+- `metadata.dijieRole.roleTokenPricing.platformFeeBps = 0`
+- `metadata.dijieRole.roleTokenPricing.developerReceivableBps = 10000`
+- `metadata.dijieRole.scopes` 只能包含 `role.execute` 和 `audit.write`
+
+`manifestSummary.entrypoint` 不能是本地绝对路径，`metadata.dijieRole` 任意层级都不能保存本地绝对路径。metadata 不能包含 secret、token、provider auth、provider key、cloud bearer、raw execution token 字段名。`secretsRequired` 只能保存 secret 名称，不能保存 secret 原文。
+
+`metadata.dijieRole` 也不能保存 prompt、开发者模式 prompt、`RoleBuildBrief`、`modeStage`、chat/conversation/message history、`executionId`、`actorId`、`entitlementId`、`deviceId`、`workspaceRef`、`localGatewayId`、订单事实或钱包事实。开发者中心和 admin review 只能读取这些严格 listing metadata；如果开发者提交了上述字段，即使商品被误改成 published，公开 listing、entitlement verifier 和执行入口也必须因 parser 校验失败而拒绝。
+
+Admin 审核页必须在发布前校验一次授权费和 `roleTokenPricing`：价格为非负整数、币种为 `CNY`、平台抽成为 0、开发者应收为 10000 bps。校验失败时只能停留在待审核状态，不能把 listing 发布。
+
+`POST /dijie/entitlements/verify` 与 `GET /dijie/roles` 使用同一个严格 parser。也就是说，不能出现“公开岗位列表不显示，但 verifier 仍然把普通商品当成可执行岗位”的旁路。
+
+`GET /dijie/my-roles` 是本地迭界AI主系统同步“我的岗位”的最小入口。它要求已认证 customer actor，并从真实 `order_group` / `order` / line item 与 product facts 推导已安装岗位：
+
+- 订单必须属于当前 customer。
+- 订单必须已付款，取消或未付款订单不产生岗位授权。
+- line item 必须能匹配对应岗位 product。
+- 响应返回 `entitlementId`、`orderId`、`authorizedAt` 和嵌套的 `role` 安全投影。
+
+当前版本不新增 entitlement 表，也不返回假岗位卡片。OpenClaw 侧的 `dijie.marketplace.roles.list` 默认读取 `/dijie/my-roles`；云端不可达、未登录、响应结构不包含 roles 时，本地主系统必须失败提示，不能 fallback 成同步成功。
+
+## Current Execution Token Endpoint
+
+`POST /dijie/execution-token` 已接入失败关闭的短期执行授权签发路径。它要求已认证 customer、必填执行字段，并且必须配置：
+
+- `DIJIE_EXECUTION_TOKEN_ISSUER_ENABLED=true`
+- `DIJIE_ENTITLEMENT_VERIFY_URL`
+- `DIJIE_ENTITLEMENT_VERIFY_BEARER`，当 verifier 使用内部接口时传递
+- `DIJIE_EXECUTION_TOKEN_PRIVATE_KEY_PEM`，用于云端 Ed25519 私钥签名
+
+云端会先调用 entitlement verifier 校验岗位授权、listing 状态、设备、本地 Gateway 和 workspace 关系。只有 verifier 返回 `ok: true`、岗位包身份、开发者/上架/结算归属，以及 `one_time_authorization` 价格时，才会签发 30 到 900 秒的 Ed25519 execution token。本地端后续只能用公钥验证 token，不能持有云端签名私钥。
+
+这个接口不能 fallback 成成功，不能返回假 token，也不能接受 runtime-duration / metered pricing。设备绑定、listing 状态和资源限制的真实 verifier 仍是下一步需要接入的云端业务实现。
+
+execution token 必须固化以下业务快照，后续审计、结算、争议处理都按 token 当时快照处理，不能按当前 product/listing 反查覆盖历史：
+
+- `roleListingId`
+- `packageId`
+- `packageVersion`
+- `developerRef`
+- `listingOwnerRef`
+- `billingBeneficiaryRef`
+- `entitlementId`
+- `pricing`
+- `scopes`
+
+## Current Entitlement Verifier
+
+`POST /dijie/entitlements/verify` 是云端内部 verifier。它要求 `DIJIE_INTERNAL_BRIDGE_BEARER`，并用 Mercur/Medusa 的 marketplace facts 判断一次授权是否成立：
+
+- `roleListingId` 对应的 product 必须存在。
+- product metadata 必须在 `metadata.dijieRole` 内显式声明可执行 listing 状态和审核状态：`listingStatus = "published"` 且 `reviewState = "approved"`。
+- product metadata 必须在 `metadata.dijieRole.pricing` 内显式声明 `one_time_authorization` 一次授权费；product-level 旧价格字段不能作为执行授权依据。
+- product metadata 必须能给出 `packageId`、`packageVersion`、`developerRef`、`listingOwnerRef`、`billingBeneficiaryRef`。
+- `entitlementId` 当前先映射为 `order_group.id` 或 `order.id`。
+- 对应订单必须属于 `actorId` 这个 customer。
+- 订单必须已付款，并且 line item 必须包含这个 `roleListingId`。
+
+第一版不新增 entitlement 表，先从真实订单和 product listing metadata 推导授权。后续可以把这个 verifier 的结果落成正式 entitlement record，但不能绕过订单和审核事实。
+
+协议里的 `entitlementId` 表示“授权引用”，不是固定数据库表名。当前它可引用 `order_group.id` 或 `order.id`；未来引入正式 entitlement 表时，必须保留旧订单引用用于审计和兼容，不能重写历史执行记录。
+
+## Current Audit Upload Endpoint
+
+`POST /dijie/audit` 是本地执行端上传 `AuditSummary` / `RoleResult` 的云端入口。它要求：
+
+- `Authorization: Bearer <execution token>`
+- `DIJIE_EXECUTION_TOKEN_PUBLIC_KEY_PEM`，用于验证云端签发的 Ed25519 execution token
+- execution token 必须包含 `audit.write` scope
+- 上传的 `executionId`、`roleListingId`、`entitlementId`、`deviceId`、`workspaceRef`、`localGatewayId` 必须和 execution token 完全一致
+- `result.executionId`、`result.roleListingId`、`result.status` 必须和外层 audit summary 一致
+- 必须注册真实 `dijieAuditRecordStore` Medusa module，或者兼容旧名 `dijieAuditSink` 且暴露 `recordDijieAuditSummary()` 方法的真实 store
+
+当前 endpoint 只负责验签、验 scope、验字段一致性，然后调用 `apps/api/src/modules/dijie-audit` 的 `DijieAuditModuleService` 持久化审计记录。该 module 定义 `dijie_audit_record` 表，保存 `executionId`、actor、listing、entitlement、设备、workspace、本地 Gateway、状态、execution token issued/expires 时间、pricing snapshot、role token pricing snapshot、model/tool usage、changed files、artifact metadata、error summary 和完整 payload。
+
+安全计费摘要只允许保存派生后的用量和金额：输入/输出 Token 数、对应的 `roleTokenPricing` 快照、`role_usage` 的平台应收 0、开发者应收金额、执行状态和必要争议字段。它不能保存模型原始请求/响应、provider key、用户本地主对话全文、raw stdout/stderr、raw execution token、cloud bearer 或本地绝对路径。
+
+这里的完整 payload 仍必须是已脱敏 payload。禁止入库 cloud bearer、raw execution token、provider key、provider auth profile、模型原始请求/响应、主对话完整历史、raw stdout/stderr、本地绝对路径或 secret 原文。
+
+授权和审计入库时必须固化 `packageId` / `packageVersion` / `developerRef` / `listingOwnerRef` / `billingBeneficiaryRef` / `pricingSnapshot`。开发者结算和争议处理必须依据当时的快照，不能只按当前 listing owner 反查。
+
+没有审计 store 时返回 503，不会假装保存成功；store 写入失败时返回 502。这个 store 是第一版云端执行审计 read model 的落点。`GET /dijie/executions/:executionId` 只能返回安全投影，不能暴露执行 ID 以外的内部执行事实、本地私有路径、模型密钥或 provider auth。
+
+## Current Execution Audit Read Endpoint
+
+`GET /dijie/executions/:executionId` 是本地 OpenClaw Gateway 和开发者中心查看执行结果的最小 read endpoint。OpenClaw 侧通过正常云端 customer session/bearer（开发期称为 `cloud bearer`）查询该 endpoint；这个 bearer 只用于请求鉴权，不能写入审计记录、RoleResult、artifact metadata、本地日志或 role package。该 endpoint 要求已认证 customer actor，且只允许 `actorId` 与审计记录 `actor_id` 完全一致的调用者读取。它优先从 `dijieAuditRecordStore` module service 的 `retrieveDijieAuditRecordByExecutionId()` 读取；如果 module service 不在当前 scope 中暴露 read 方法，会尝试用 Medusa query graph 读取 `dijie_audit_record` read model。
+
+成功响应只返回安全投影：
+
+- `roleListingId`
+- `packageId`
+- `packageVersion`
+- `developerRef`
+- `listingOwnerRef`
+- `billingBeneficiaryRef`
+- `status`
+- `pricing`
+- `roleTokenPricing`
+- `billingSummary`，只包含 `role_usage` 派生用量、单价、币种、平台应收 0 和开发者应收金额
+- `toolUsage`
+- `modelProxyUsage`
+- `changedFiles`
+- `artifacts`
+- `errorSummary`
+- `receivedAt`
+
+该 endpoint 的响应不回显 `executionId`、`actorId`、`entitlementId`、`deviceId`、`workspaceRef`、`localGatewayId`、订单/钱包事实、完整 `payload`、execution token issued/expires 时间、raw token、cloud bearer、raw secrets、模型 provider key、provider auth 或本地绝对路径。`changedFiles` 如果收到本地绝对路径，只保留文件名或相对路径形态；artifact 字符串字段和 `errorSummary` 在返回前会再做出口脱敏，避免把用户机器路径或认证材料暴露给云端 UI / OpenClaw Gateway。
+
+错误语义：
+
+- 缺少已认证 actor 返回 401。
+- 缺少 `executionId` path parameter 返回 400。
+- 没有可用的 audit module/store/query read source 返回 503，失败关闭。
+- 读取 store/query 失败返回 502。
+- 找不到对应 execution audit record 返回 404。
+- execution audit record 属于其他 actor 返回 403。

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -122,7 +122,7 @@
     "close": "Close",
     "showMore": "Show more",
     "continue": "Continue",
-    "continueWithEmail": "Continue with Email",
+    "continueWithEmail": "登录",
     "idCopiedToClipboard": "ID copied to clipboard",
     "addReason": "Add Reason",
     "addNote": "Add Note",
@@ -149,10 +149,10 @@
   },
   "app": {
     "search": {
-      "label": "Search",
-      "title": "Search",
-      "description": "Search your entire store, including orders, products, customers, and more.",
-      "allAreas": "All areas",
+      "label": "搜索",
+      "title": "搜索",
+      "description": "搜索迭界AI岗位商场中的授权订单、岗位商品、开发者和更多内容。",
+      "allAreas": "全部范围",
       "navigation": "Navigation",
       "openResult": "Open result",
       "showMore": "Show more",
@@ -163,17 +163,17 @@
       "emptySearchMessage": "Enter a keyword or phrase to explore.",
       "loadMore": "Load {{count}} more",
       "groups": {
-        "all": "All areas",
+        "all": "全部范围",
         "customer": "Customers",
-        "seller": "Sellers",
+        "seller": "开发者",
         "customerGroup": "Customer Groups",
-        "product": "Products",
+        "product": "岗位商品",
         "productVariant": "Product Variants",
         "inventory": "Inventory",
         "reservation": "Reservations",
         "category": "Categories",
         "collection": "Collections",
-        "order": "Orders",
+        "order": "授权订单",
         "promotion": "Promotions",
         "campaign": "Campaigns",
         "priceList": "Price Lists",
@@ -198,8 +198,8 @@
       "commandShortcut": "Commands",
       "then": "then",
       "navigation": {
-        "goToOrders": "Orders",
-        "goToProducts": "Products",
+        "goToOrders": "授权订单",
+        "goToProducts": "岗位商品",
         "goToCollections": "Collections",
         "goToCategories": "Categories",
         "goToCustomers": "Customers",
@@ -209,12 +209,12 @@
         "goToPriceLists": "Price Lists",
         "goToPromotions": "Promotions",
         "goToCampaigns": "Campaigns",
-        "goToSellers": "Sellers",
-        "goToPayouts": "Payouts"
+        "goToSellers": "开发者",
+        "goToPayouts": "结算"
       },
       "settings": {
         "goToSettings": "Settings",
-        "goToStore": "Store",
+        "goToStore": "迭界AI岗位商场",
         "goToUsers": "Users",
         "goToRegions": "Regions",
         "goToTaxRegions": "Tax Regions",
@@ -242,8 +242,8 @@
         }
       },
       "store": {
-        "label": "Store",
-        "storeSettings": "Store settings"
+        "label": "迭界AI岗位商场",
+        "storeSettings": "商场设置"
       },
       "actions": {
         "logout": "Log out"
@@ -258,10 +258,10 @@
         "extensions": "Extensions"
       },
       "main": {
-        "store": "Store",
-        "marketplace": "Marketplace",
-        "storeSettings": "Store settings",
-        "marketplaceSettings": "Marketplace settings"
+        "store": "迭界AI岗位商场",
+        "marketplace": "迭界AI岗位商场",
+        "storeSettings": "商场设置",
+        "marketplaceSettings": "商场设置"
       },
       "settings": {
         "header": "Settings",
@@ -405,20 +405,20 @@
     "availableIn": "Available in <0>{{x}}</0> of <1>{{y}}</1> sales channels"
   },
   "products": {
-    "domain": "Products",
-    "associatedStore": "Associated Store",
+    "domain": "岗位商品",
+    "associatedStore": "关联开发者",
     "additionalAttributes": "Additional Attributes",
     "list": {
-      "noRecordsMessage": "Create your first product to start selling."
+      "noRecordsMessage": "创建第一个岗位商品后即可开始上架授权。"
     },
     "edit": {
-      "header": "Edit Product",
-      "description": "Edit the product details.",
-      "successToast": "Product {{title}} was successfully updated."
+      "header": "编辑岗位商品",
+      "description": "编辑岗位商品详情。",
+      "successToast": "岗位商品 {{title}} 更新成功。"
     },
     "create": {
-      "title": "Create Product",
-      "description": "Create a new product.",
+      "title": "创建岗位商品",
+      "description": "创建新的岗位商品。",
       "header": "General",
       "tabs": {
         "details": "Details",
@@ -1061,7 +1061,7 @@
         "creditLineDescription": "Refund amount as store credit"
       }
     },
-    "domain": "Orders",
+    "domain": "授权订单",
     "claim": "Claim",
     "exchange": "Exchange",
     "return": "Return",
@@ -1069,7 +1069,7 @@
     "orderCanceled": "Order canceled successfully",
     "onDateFromSalesChannel": "{{date}} from {{salesChannel}}",
     "list": {
-      "noRecordsMessage": "Your orders will show up here."
+      "noRecordsMessage": "授权订单会显示在这里。"
     },
     "status": {
       "not_paid": "Not paid",
@@ -1515,15 +1515,15 @@
       "returnableQuantity": "Returnable quantity",
       "groupId": "Group ID",
       "orderIds": "Order IDs",
-      "vendor": "Vendor",
-      "vendorsCount_one": "{{count}} vendor",
-      "vendorsCount_other": "{{count}} vendors"
+      "vendor": "开发者",
+      "vendorsCount_one": "{{count}} 个开发者",
+      "vendorsCount_other": "{{count}} 个开发者"
     }
   },
   "payouts": {
-    "domain": "Payouts",
+    "domain": "结算",
     "list": {
-      "empty": "No payouts found"
+      "empty": "暂无结算记录"
     },
     "status": {
       "paid": "Paid",
@@ -2506,10 +2506,10 @@
     "invite": "Invite"
   },
   "marketplace": {
-    "domain": "Marketplace",
-    "manageMarketplaceDetails": "Manage your marketplace's details",
+    "domain": "迭界AI岗位商场",
+    "manageMarketplaceDetails": "管理迭界AI岗位商场资料",
     "edit": {
-      "header": "Edit Marketplace"
+      "header": "编辑迭界AI岗位商场"
     }
   },
   "store": {
@@ -3031,10 +3031,10 @@
     }
   },
   "login": {
-    "forgotPassword": "Forgot password? - <0>Reset</0>",
-    "title": "Welcome to {{name}}",
-    "hint": "Sign in to access the admin hub",
-    "sessionExpired": "Session expired"
+    "forgotPassword": "忘记密码？<0>重置</0>",
+    "title": "{{name}}",
+    "hint": "平台运营后台：审核岗位、管理授权订单和执行审计。",
+    "sessionExpired": "登录已过期"
   },
   "invite": {
     "title": "Welcome to Mercur Admin Panel",
@@ -3242,8 +3242,8 @@
     "inventoryItem": "Inventory item",
     "requiredQuantity": "Required quantity",
     "description": "Description",
-    "email": "Email",
-    "password": "Password",
+    "email": "邮箱",
+    "password": "密码",
     "repeatPassword": "Repeat Password",
     "confirmPassword": "Confirm Password",
     "newPassword": "New Password",
@@ -3314,9 +3314,9 @@
     "phone": "Phone",
     "metadata": "Metadata",
     "selectCountry": "Select country",
-    "products": "Products",
+    "products": "岗位商品",
     "variants": "Variants",
-    "orders": "Orders",
+    "orders": "授权订单",
     "account": "Account",
     "total": "Order Total",
     "paidTotal": "Paid Total",
@@ -3428,11 +3428,11 @@
     }
   },
   "requests": {
-    "domain": "Requests",
-    "seller": "Seller",
-    "product": "Product",
+    "domain": "审核请求",
+    "seller": "开发者",
+    "product": "岗位商品",
     "review-remove": "Review Remove",
-    "return": "Order Return",
+    "return": "授权订单退回",
     "product-collection": "Product Collection",
     "product-category": "Product Category",
     "product-tag": "Product Tag",
@@ -3440,7 +3440,7 @@
     "product-update": "Product Update"
   },
   "stores": {
-    "domain": "Stores",
+    "domain": "开发者",
     "handleTooltip": "The handle is used as the URL slug for the store. Leave empty to auto-generate from the name.",
     "fields": {
       "name": "Name",
@@ -3456,7 +3456,7 @@
       "city": "City",
       "province": "Province",
       "country_code": "Country Code",
-      "seller": "Seller",
+      "seller": "开发者",
       "premium": "Featured"
     },
     "status": {

--- a/packages/admin/src/i18n/translations/zhCN.json
+++ b/packages/admin/src/i18n/translations/zhCN.json
@@ -147,8 +147,8 @@
     "search": {
       "label": "搜索",
       "title": "搜索",
-      "description": "搜索整个商店,包括订单、产品、客户等。",
-      "allAreas": "所有区域",
+      "description": "搜索迭界AI岗位商场中的授权订单、岗位商品、开发者和更多内容。",
+      "allAreas": "全部范围",
       "navigation": "导航",
       "openResult": "打开结果",
       "showMore": "显示更多",
@@ -159,16 +159,16 @@
       "emptySearchMessage": "输入关键词或短语以开始探索。",
       "loadMore": "加载更多 {{count}} 项",
       "groups": {
-        "all": "所有区域",
+        "all": "全部范围",
         "customer": "客户",
         "customerGroup": "客户组",
-        "product": "产品",
+        "product": "岗位商品",
         "productVariant": "产品变体",
         "inventory": "库存",
         "reservation": "预订",
         "category": "分类",
         "collection": "系列",
-        "order": "订单",
+        "order": "授权订单",
         "promotion": "促销",
         "campaign": "活动",
         "priceList": "价格表",
@@ -193,8 +193,8 @@
       "commandShortcut": "命令",
       "then": "然后",
       "navigation": {
-        "goToOrders": "订单",
-        "goToProducts": "产品",
+        "goToOrders": "授权订单",
+        "goToProducts": "岗位商品",
         "goToCollections": "系列",
         "goToCategories": "分类",
         "goToCustomers": "客户",
@@ -207,7 +207,7 @@
       },
       "settings": {
         "goToSettings": "设置",
-        "goToStore": "商店",
+        "goToStore": "迭界AI岗位商场",
         "goToUsers": "用户",
         "goToRegions": "地区",
         "goToTaxRegions": "税收地区",
@@ -235,8 +235,8 @@
         }
       },
       "store": {
-        "label": "商店",
-        "storeSettings": "商店设置"
+        "label": "迭界AI岗位商场",
+        "storeSettings": "商场设置"
       },
       "actions": {
         "logout": "退出登录"
@@ -251,8 +251,8 @@
         "extensions": "扩展"
       },
       "main": {
-        "store": "商店",
-        "storeSettings": "商店设置"
+        "store": "迭界AI岗位商场",
+        "storeSettings": "商场设置"
       },
       "settings": {
         "header": "设置",
@@ -396,18 +396,18 @@
     "availableIn": "在 <1>{{y}}</1> 个销售渠道中的 <0>{{x}}</0> 个可用"
   },
   "products": {
-    "domain": "产品",
+    "domain": "岗位商品",
     "additionalAttributes": "附加属性",
     "list": {
-      "noRecordsMessage": "创建您的第一个产品以开始销售。"
+      "noRecordsMessage": "创建第一个岗位商品后即可开始上架授权。"
     },
     "edit": {
-      "header": "编辑产品",
-      "description": "编辑产品详情。",
-      "successToast": "产品 {{title}} 更新成功。"
+      "header": "编辑岗位商品",
+      "description": "编辑岗位商品详情。",
+      "successToast": "岗位商品 {{title}} 更新成功。"
     },
     "create": {
-      "title": "创建产品",
+      "title": "创建岗位商品",
       "description": "创建新产品。",
       "header": "常规",
       "tabs": {
@@ -1011,7 +1011,7 @@
     }
   },
   "orders": {
-    "domain": "订单",
+    "domain": "授权订单",
     "claim": "索赔",
     "exchange": "换货",
     "return": "退货",
@@ -1019,7 +1019,7 @@
     "orderCanceled": "订单取消成功！",
     "onDateFromSalesChannel": "{{date}} 来自 {{salesChannel}}",
     "list": {
-      "noRecordsMessage": "您的订单将显示在这里。"
+      "noRecordsMessage": "授权订单会显示在这里。"
     },
     "status": {
       "not_paid": "未支付",
@@ -2692,8 +2692,8 @@
   },
   "login": {
     "forgotPassword": "忘记密码？ - <0>重置</0>",
-    "title": "欢迎使用Medusa",
-    "hint": "登录以访问账户区域"
+    "title": "迭界AI岗位商场",
+    "hint": "平台运营后台：审核岗位、管理授权订单和执行审计。"
   },
   "invite": {
     "title": "欢迎使用Medusa",
@@ -2939,9 +2939,9 @@
     "phone": "电话",
     "metadata": "元数据",
     "selectCountry": "选择国家",
-    "products": "产品",
+    "products": "岗位商品",
     "variants": "变体",
-    "orders": "订单",
+    "orders": "授权订单",
     "account": "账户",
     "total": "订单总额",
     "paidTotal": "已收金额",

--- a/packages/admin/src/pages/products/product-detail/components/product-role-review-section/index.ts
+++ b/packages/admin/src/pages/products/product-detail/components/product-role-review-section/index.ts
@@ -1,0 +1,4 @@
+export {
+  ProductRoleReviewSection,
+  createPublicDijieRoleMetadata,
+} from "./product-role-review-section"

--- a/packages/admin/src/pages/products/product-detail/components/product-role-review-section/product-role-review-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-role-review-section/product-role-review-section.tsx
@@ -1,0 +1,499 @@
+import { CheckCircle } from "@medusajs/icons"
+import { Button, Container, Heading, StatusBadge, Text, toast, usePrompt } from "@medusajs/ui"
+import { HttpTypes } from "@medusajs/types"
+
+import { SectionRow } from "../../../../../components/common/section"
+import { useUpdateProduct } from "../../../../../hooks/api/products"
+
+type RoleReviewState = "draft" | "submitted" | "approved" | "rejected"
+type RoleListingStatus = "draft" | "proposed" | "published" | "rejected"
+
+type DijieRoleMetadata = Record<string, unknown> & {
+  reviewState?: RoleReviewState
+  review_state?: RoleReviewState
+  listingStatus?: RoleListingStatus
+  listing_status?: RoleListingStatus
+  packageId?: string
+  package_id?: string
+  packageVersion?: string
+  package_version?: string
+  authorizationFeeCents?: number
+  pricing?: {
+    kind?: string
+    authorizationFeeCents?: number
+    authorization_fee_cents?: number
+    amountCents?: number
+    amount_cents?: number
+    currency?: string
+    platformFeeBps?: number
+    platform_fee_bps?: number
+    developerReceivableBps?: number
+    developer_receivable_bps?: number
+    developerReceivableCents?: number
+    developer_receivable_cents?: number
+  }
+  roleTokenPricing?: {
+    currency?: string
+    inputTokenCentsPerMillion?: number
+    input_token_cents_per_million?: number
+    inputCentsPerMillion?: number
+    input_cents_per_million?: number
+    outputTokenCentsPerMillion?: number
+    output_token_cents_per_million?: number
+    outputCentsPerMillion?: number
+    output_cents_per_million?: number
+    platformFeeBps?: number
+    platform_fee_bps?: number
+    developerReceivableBps?: number
+    developer_receivable_bps?: number
+  }
+}
+
+const REVIEW_STATE_LABELS: Record<string, string> = {
+  draft: "草稿",
+  submitted: "待审核",
+  approved: "已通过",
+  rejected: "未通过",
+}
+
+const LISTING_STATUS_LABELS: Record<string, string> = {
+  draft: "草稿",
+  proposed: "待发布",
+  published: "已发布",
+  rejected: "未发布",
+}
+
+const statusColor = (value?: string) => {
+  switch (value) {
+    case "approved":
+    case "published":
+      return "green"
+    case "submitted":
+    case "proposed":
+      return "orange"
+    case "rejected":
+      return "red"
+    default:
+      return "grey"
+  }
+}
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+const getRoleMetadata = (product: HttpTypes.AdminProduct) => {
+  const metadata = asRecord(product.metadata)
+  const role = asRecord(metadata.dijieRole)
+
+  return Object.keys(role).length ? (role as DijieRoleMetadata) : null
+}
+
+const getReviewState = (role: DijieRoleMetadata) => {
+  return role.reviewState ?? role.review_state ?? "draft"
+}
+
+const getListingStatus = (role: DijieRoleMetadata) => {
+  return role.listingStatus ?? role.listing_status ?? "draft"
+}
+
+const getPackageVersion = (role: DijieRoleMetadata) => {
+  return role.packageVersion ?? role.package_version ?? "-"
+}
+
+const getPackageId = (role: DijieRoleMetadata) => {
+  return role.packageId ?? role.package_id ?? "-"
+}
+
+const readNumber = (...values: unknown[]) => {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
+const isNonNegativeInteger = (value: unknown) => {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+}
+
+const readString = (...values: unknown[]) => {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim()
+    }
+  }
+
+  return undefined
+}
+
+const readStringArray = (value: unknown) => {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim()).map((item) => item.trim())
+    : []
+}
+
+const definedRecord = (record: Record<string, unknown>) => {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined)
+  )
+}
+
+export const createPublicDijieRoleMetadata = (
+  role: DijieRoleMetadata,
+  overrides: Partial<Pick<DijieRoleMetadata, "reviewState" | "listingStatus">> = {}
+) => {
+  const pricing = asRecord(role.pricing)
+  const roleTokenPricing = getRoleTokenPricing(role)
+  const manifestSummary = asRecord(role.manifestSummary)
+  const entrypoint = readString(manifestSummary.entrypoint)
+  const publicManifestSummary = definedRecord({
+    ...(entrypoint ? { entrypoint } : {}),
+    tools: readStringArray(manifestSummary.tools),
+    permissions: readStringArray(manifestSummary.permissions),
+    sandbox: readString(manifestSummary.sandbox),
+    inputs: readStringArray(manifestSummary.inputs),
+    outputs: readStringArray(manifestSummary.outputs),
+  })
+
+  return definedRecord({
+    kind: "role_product",
+    protocolVersion: readString(role.protocolVersion, (role as Record<string, unknown>).protocol_version) ?? "2026-05",
+    roleListingId: readString(role.roleListingId, (role as Record<string, unknown>).role_listing_id),
+    packageId: readString(role.packageId, role.package_id),
+    packageVersion: readString(role.packageVersion, role.package_version),
+    developerRef: readString(role.developerRef, (role as Record<string, unknown>).developer_ref),
+    listingOwnerRef: readString(role.listingOwnerRef, (role as Record<string, unknown>).listing_owner_ref),
+    billingBeneficiaryRef: readString(
+      role.billingBeneficiaryRef,
+      (role as Record<string, unknown>).billing_beneficiary_ref
+    ),
+    listingStatus: overrides.listingStatus ?? getListingStatus(role),
+    reviewState: overrides.reviewState ?? getReviewState(role),
+    title: readString(role.title),
+    subtitle: readString(role.subtitle),
+    description: readString(role.description),
+    capabilities: readStringArray(role.capabilities),
+    pricing: definedRecord({
+      kind: readString(pricing.kind) ?? "one_time_authorization",
+      authorizationFeeCents: readNumber(
+        pricing.authorizationFeeCents,
+        pricing.authorization_fee_cents,
+        pricing.amountCents,
+        pricing.amount_cents,
+        role.authorizationFeeCents
+      ),
+      currency: readString(pricing.currency) ?? "CNY",
+      platformFeeBps: readNumber(pricing.platformFeeBps, pricing.platform_fee_bps),
+      developerReceivableBps: readNumber(
+        pricing.developerReceivableBps,
+        pricing.developer_receivable_bps
+      ),
+      developerReceivableCents: readNumber(
+        pricing.developerReceivableCents,
+        pricing.developer_receivable_cents
+      ),
+    }),
+    roleTokenPricing: definedRecord({
+      currency: readString(roleTokenPricing.currency) ?? "CNY",
+      inputTokenCentsPerMillion: readNumber(
+        roleTokenPricing.inputTokenCentsPerMillion,
+        roleTokenPricing.input_token_cents_per_million,
+        roleTokenPricing.inputCentsPerMillion,
+        roleTokenPricing.input_cents_per_million
+      ),
+      outputTokenCentsPerMillion: readNumber(
+        roleTokenPricing.outputTokenCentsPerMillion,
+        roleTokenPricing.output_token_cents_per_million,
+        roleTokenPricing.outputCentsPerMillion,
+        roleTokenPricing.output_cents_per_million
+      ),
+      platformFeeBps: readNumber(roleTokenPricing.platformFeeBps, roleTokenPricing.platform_fee_bps),
+      developerReceivableBps: readNumber(
+        roleTokenPricing.developerReceivableBps,
+        roleTokenPricing.developer_receivable_bps
+      ),
+    }),
+    scopes: readStringArray(role.scopes),
+    ...(Object.keys(publicManifestSummary).length ? { manifestSummary: publicManifestSummary } : {}),
+  }) as DijieRoleMetadata
+}
+
+const formatAuthorizationFee = (role: DijieRoleMetadata) => {
+  const amount =
+    role.pricing?.authorizationFeeCents ??
+    role.pricing?.authorization_fee_cents ??
+    role.pricing?.amountCents ??
+    role.pricing?.amount_cents ??
+    role.authorizationFeeCents
+
+  if (typeof amount !== "number" || !Number.isFinite(amount)) {
+    return "-"
+  }
+
+  const currency = role.pricing?.currency ?? "CNY"
+  const displayAmount = (amount / 100).toFixed(2)
+
+  return currency === "CNY" ? `¥${displayAmount}` : `${displayAmount} ${currency}`
+}
+
+const getRoleTokenPricing = (role: DijieRoleMetadata) => {
+  return asRecord(
+    role.roleTokenPricing ?? (role as Record<string, unknown>).role_token_pricing
+  )
+}
+
+const formatCentsPerMillion = (value: unknown, currency: unknown) => {
+  if (!isNonNegativeInteger(value)) {
+    return "-"
+  }
+
+  if (currency === "CNY") {
+    return `${value} 分/百万`
+  }
+
+  return typeof currency === "string" ? `${value} ${currency}/百万` : "-"
+}
+
+const validateRolePricing = (role: DijieRoleMetadata) => {
+  const errors: string[] = []
+  const pricing = asRecord(role.pricing)
+  const roleTokenPricing = getRoleTokenPricing(role)
+
+  const authorizationFeeCents = readNumber(
+    pricing.authorizationFeeCents,
+    pricing.authorization_fee_cents,
+    pricing.amountCents,
+    pricing.amount_cents,
+    role.authorizationFeeCents
+  )
+  const authorizationCurrency = pricing.currency ?? "CNY"
+  const authorizationPlatformFeeBps = readNumber(
+    pricing.platformFeeBps,
+    pricing.platform_fee_bps
+  )
+  const authorizationDeveloperReceivableBps = readNumber(
+    pricing.developerReceivableBps,
+    pricing.developer_receivable_bps
+  )
+  const authorizationDeveloperReceivableCents = readNumber(
+    pricing.developerReceivableCents,
+    pricing.developer_receivable_cents
+  )
+
+  if (pricing.kind !== "one_time_authorization") {
+    errors.push("一次授权费必须使用 one_time_authorization 定价。")
+  }
+  if (!isNonNegativeInteger(authorizationFeeCents)) {
+    errors.push("一次授权费必须是非负整数分。")
+  }
+  if (authorizationCurrency !== "CNY") {
+    errors.push("一次授权费币种必须是 CNY。")
+  }
+  if (authorizationPlatformFeeBps !== 0) {
+    errors.push("一次授权费平台抽成必须为 0。")
+  }
+  if (authorizationDeveloperReceivableBps !== 10000) {
+    errors.push("一次授权费开发者应收必须为 10000 bps。")
+  }
+  if (
+    authorizationDeveloperReceivableCents !== undefined &&
+    authorizationDeveloperReceivableCents !== authorizationFeeCents
+  ) {
+    errors.push("一次授权费开发者应收金额必须等于授权费。")
+  }
+
+  const tokenCurrency = roleTokenPricing.currency
+  const inputCentsPerMillion = readNumber(
+    roleTokenPricing.inputTokenCentsPerMillion,
+    roleTokenPricing.input_token_cents_per_million,
+    roleTokenPricing.inputCentsPerMillion,
+    roleTokenPricing.input_cents_per_million
+  )
+  const outputCentsPerMillion = readNumber(
+    roleTokenPricing.outputTokenCentsPerMillion,
+    roleTokenPricing.output_token_cents_per_million,
+    roleTokenPricing.outputCentsPerMillion,
+    roleTokenPricing.output_cents_per_million
+  )
+  const tokenPlatformFeeBps = readNumber(
+    roleTokenPricing.platformFeeBps,
+    roleTokenPricing.platform_fee_bps
+  )
+  const tokenDeveloperReceivableBps = readNumber(
+    roleTokenPricing.developerReceivableBps,
+    roleTokenPricing.developer_receivable_bps
+  )
+
+  if (!isNonNegativeInteger(inputCentsPerMillion)) {
+    errors.push("输入 Token 单价必须是非负整数。")
+  }
+  if (!isNonNegativeInteger(outputCentsPerMillion)) {
+    errors.push("输出 Token 单价必须是非负整数。")
+  }
+  if (tokenCurrency !== "CNY") {
+    errors.push("岗位 Token 单价币种必须是 CNY。")
+  }
+  if (tokenPlatformFeeBps !== 0) {
+    errors.push("岗位 Token 单价平台抽成必须为 0。")
+  }
+  if (tokenDeveloperReceivableBps !== 10000) {
+    errors.push("岗位 Token 单价开发者应收必须为 10000 bps。")
+  }
+
+  return errors
+}
+
+export const ProductRoleReviewSection = ({
+  product,
+}: {
+  product: HttpTypes.AdminProduct
+}) => {
+  const role = getRoleMetadata(product)
+  const prompt = usePrompt()
+  const { mutateAsync, isPending } = useUpdateProduct(product.id)
+
+  if (!role) {
+    return null
+  }
+
+  const reviewState = getReviewState(role)
+  const listingStatus = getListingStatus(role)
+  const canApprove = reviewState === "submitted" && listingStatus === "proposed"
+  const pricingErrors = validateRolePricing(role)
+  const roleTokenPricing = getRoleTokenPricing(role)
+  const tokenCurrency = roleTokenPricing.currency
+  const inputCentsPerMillion = readNumber(
+    roleTokenPricing.inputTokenCentsPerMillion,
+    roleTokenPricing.input_token_cents_per_million,
+    roleTokenPricing.inputCentsPerMillion,
+    roleTokenPricing.input_cents_per_million
+  )
+  const outputCentsPerMillion = readNumber(
+    roleTokenPricing.outputTokenCentsPerMillion,
+    roleTokenPricing.output_token_cents_per_million,
+    roleTokenPricing.outputCentsPerMillion,
+    roleTokenPricing.output_cents_per_million
+  )
+
+  const handleApprove = async () => {
+    if (pricingErrors.length > 0) {
+      toast.error("岗位商品价格配置不符合发布规则", {
+        description: pricingErrors.join(" "),
+      })
+      return
+    }
+
+    const confirmed = await prompt({
+      title: "确认通过审核？",
+      description: "通过后，这个岗位商品会发布到迭界AI岗位商场。",
+      confirmText: "通过并发布",
+      cancelText: "取消",
+    })
+
+    if (!confirmed) {
+      return
+    }
+
+    await mutateAsync(
+      {
+        status: "published" as HttpTypes.AdminProductStatus,
+        metadata: {
+          ...asRecord(product.metadata),
+          dijieRole: createPublicDijieRoleMetadata(role, {
+            reviewState: "approved",
+            listingStatus: "published",
+          }),
+        },
+      } as any,
+      {
+        onSuccess: () => {
+          toast.success("岗位商品已通过审核并发布")
+        },
+        onError: (e) => {
+          toast.error("岗位商品审核失败", {
+            description: e.message,
+          })
+        },
+      }
+    )
+  }
+
+  return (
+    <Container className="divide-y p-0" data-testid="product-role-review-section">
+      <div className="flex items-center justify-between gap-4 px-6 py-4">
+        <div className="flex flex-col gap-y-1">
+          <Heading level="h2">岗位商品审核</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            只审核公开 listing metadata；开发者模式是主系统同一聊天框内的工作阶段，不保存 modeStage、提示词、聊天记录或私有 workspace 上下文。
+          </Text>
+        </div>
+        {canApprove && (
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={handleApprove}
+            isLoading={isPending}
+            data-testid="product-role-review-approve-button"
+          >
+            <CheckCircle />
+            通过并发布
+          </Button>
+        )}
+      </div>
+      <SectionRow
+        title="审核状态"
+        value={
+          <StatusBadge color={statusColor(reviewState)}>
+            {REVIEW_STATE_LABELS[reviewState] ?? reviewState}
+          </StatusBadge>
+        }
+      />
+      <SectionRow
+        title="上架状态"
+        value={
+          <StatusBadge color={statusColor(listingStatus)}>
+            {LISTING_STATUS_LABELS[listingStatus] ?? listingStatus}
+          </StatusBadge>
+        }
+      />
+      <SectionRow title="岗位包" value={getPackageId(role)} />
+      <SectionRow title="版本" value={getPackageVersion(role)} />
+      <SectionRow title="一次授权费" value={formatAuthorizationFee(role)} />
+      <SectionRow
+        title="岗位 Token 单价"
+        value={
+          <div className="flex flex-col gap-y-1">
+            <Text size="small">
+              输入：{formatCentsPerMillion(inputCentsPerMillion, tokenCurrency)}
+            </Text>
+            <Text size="small">
+              输出：{formatCentsPerMillion(outputCentsPerMillion, tokenCurrency)}
+            </Text>
+          </div>
+        }
+      />
+      <SectionRow
+        title="价格校验"
+        value={
+          pricingErrors.length === 0 ? (
+            <StatusBadge color="green">可发布</StatusBadge>
+          ) : (
+            <div className="flex flex-col gap-y-1">
+              <StatusBadge color="red">不可发布</StatusBadge>
+              {pricingErrors.map((error) => (
+                <Text key={error} size="small" className="text-ui-fg-subtle">
+                  {error}
+                </Text>
+              ))}
+            </div>
+          )
+        }
+      />
+    </Container>
+  )
+}

--- a/packages/admin/src/pages/products/product-detail/product-detail.tsx
+++ b/packages/admin/src/pages/products/product-detail/product-detail.tsx
@@ -11,6 +11,10 @@ import { ProductGeneralSection } from "./components/product-general-section";
 import { ProductMediaSection } from "./components/product-media-section";
 import { ProductOptionSection } from "./components/product-option-section";
 import { ProductOrganizationSection } from "./components/product-organization-section";
+import {
+  ProductRoleReviewSection,
+  createPublicDijieRoleMetadata,
+} from "./components/product-role-review-section";
 import { ProductSalesChannelSection } from "./components/product-sales-channel-section";
 import { ProductSellerSection } from "./components/product-seller-section/product-seller-section";
 import { ProductShippingProfileSection } from "./components/product-shipping-profile-section";
@@ -20,6 +24,35 @@ import { PRODUCT_DETAIL_QUERY } from "../constants";
 
 type AdminProductWithSeller = HttpTypes.AdminProduct & {
   seller?: SellerDTO;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+};
+
+const hasDijieRoleMetadata = (product: AdminProductWithSeller) => {
+  return Object.keys(asRecord(asRecord(product.metadata).dijieRole)).length > 0;
+};
+
+const sanitizeProductForExtraData = (
+  product: AdminProductWithSeller,
+): AdminProductWithSeller => {
+  const metadata = asRecord(product.metadata);
+  const role = asRecord(metadata.dijieRole);
+
+  if (!Object.keys(role).length) {
+    return product;
+  }
+
+  return {
+    ...product,
+    metadata: {
+      ...metadata,
+      dijieRole: createPublicDijieRoleMetadata(role),
+    },
+  };
 };
 
 const Root = ({ children }: { children?: ReactNode }) => {
@@ -52,24 +85,28 @@ const Root = ({ children }: { children?: ReactNode }) => {
     throw error;
   }
 
+  const isDijieRoleProduct = hasDijieRoleMetadata(product);
+  const extraDataProduct = sanitizeProductForExtraData(product);
+
   return Children.count(children) > 0 ? (
     <TwoColumnPage
-      data={product}
+      data={extraDataProduct}
       showJSON
-      showMetadata
+      showMetadata={!isDijieRoleProduct}
       data-testid="product-detail-page"
     >
       {children}
     </TwoColumnPage>
   ) : (
     <TwoColumnPage
-      data={product}
+      data={extraDataProduct}
       showJSON
-      showMetadata
+      showMetadata={!isDijieRoleProduct}
       data-testid="product-detail-page"
     >
       <TwoColumnPage.Main data-testid="product-detail-main">
         <ProductGeneralSection product={product} />
+        <ProductRoleReviewSection product={product} />
         <ProductMediaSection product={product} />
         <ProductOptionSection product={product} />
         <ProductVariantSection product={product} />
@@ -89,6 +126,7 @@ export const ProductDetailPage = Object.assign(Root, {
   Main: TwoColumnPage.Main,
   Sidebar: TwoColumnPage.Sidebar,
   MainGeneralSection: ProductGeneralSection,
+  MainRoleReviewSection: ProductRoleReviewSection,
   MainMediaSection: ProductMediaSection,
   MainOptionSection: ProductOptionSection,
   MainVariantSection: ProductVariantSection,

--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -2,6 +2,10 @@
 
 ## System Overview
 
+For 迭界AI, Mercur/Medusa is the cloud role marketplace implementation base,
+not an OpenClaw plugin. The plugin wording below describes Medusa's internal
+extension mechanism only.
+
 `@mercurjs/core` is the Medusa.js plugin that turns a standard Medusa
 commerce server into a multi-vendor marketplace. It is published as a
 Medusa plugin (built with `medusa plugin:develop` / `tsc` into

--- a/packages/dashboard-sdk/src/virtual-modules.ts
+++ b/packages/dashboard-sdk/src/virtual-modules.ts
@@ -66,7 +66,7 @@ function loadComponentsModule(mercurConfig: BuiltMercurConfig, cwd: string): str
 
     Object.entries(components).forEach(([name, componentPath]) => {
         const resolvedPath = path.resolve(cwd, 'src', componentPath)
-        imports.push(`import _${name} from "${JSON.stringify(resolvedPath)}"`)
+        imports.push(`import _${name} from ${JSON.stringify(resolvedPath)}`)
         exports.push(`${name}: _${name}`)
     })
 

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -144,7 +144,7 @@
     "close": "Close",
     "showMore": "Show more",
     "continue": "Continue",
-    "continueWithEmail": "Continue with Email",
+    "continueWithEmail": "登录",
     "idCopiedToClipboard": "ID copied to clipboard",
     "editVariantImages": "Edit variant images",
     "editImages": "Edit images",
@@ -172,10 +172,10 @@
   },
   "app": {
     "search": {
-      "label": "Search",
-      "title": "Search",
-      "description": "Search your entire store, including orders, products, customers, and more.",
-      "allAreas": "All areas",
+      "label": "搜索",
+      "title": "搜索",
+      "description": "搜索开发者中心中的授权订单、岗位商品、结算和更多内容。",
+      "allAreas": "全部范围",
       "navigation": "Navigation",
       "openResult": "Open result",
       "showMore": "Show more",
@@ -186,16 +186,16 @@
       "emptySearchMessage": "Enter a keyword or phrase to explore.",
       "loadMore": "Load {{count}} more",
       "groups": {
-        "all": "All areas",
+        "all": "全部范围",
         "customer": "Customers",
         "customerGroup": "Customer Groups",
-        "product": "Products",
+        "product": "岗位商品",
         "productVariant": "Product Variants",
         "inventory": "Inventory",
         "reservation": "Reservations",
         "category": "Categories",
         "collection": "Collections",
-        "order": "Orders",
+        "order": "授权订单",
         "promotion": "Promotions",
         "campaign": "Campaigns",
         "priceList": "Price Lists",
@@ -220,8 +220,8 @@
       "commandShortcut": "Commands",
       "then": "then",
       "navigation": {
-        "goToOrders": "Orders",
-        "goToProducts": "Products",
+        "goToOrders": "授权订单",
+        "goToProducts": "岗位商品",
         "goToCollections": "Collections",
         "goToCategories": "Categories",
         "goToCustomers": "Customers",
@@ -245,7 +245,7 @@
         "goToWorkflows": "Workflows",
         "goToProfile": "Profile",
         "goToReturnReasons": "Return reasons",
-        "goToStore": "Store"
+        "goToStore": "开发者中心"
       }
     },
     "menus": {
@@ -262,10 +262,10 @@
         }
       },
       "store": {
-        "label": "Store",
-        "storeSettings": "Store settings",
-        "editStore": "Edit Store",
-        "switchStore": "Switch store"
+        "label": "开发者",
+        "storeSettings": "开发者中心设置",
+        "editStore": "编辑开发者资料",
+        "switchStore": "切换开发者"
       },
       "actions": {
         "logout": "Log out"
@@ -280,8 +280,8 @@
         "extensions": "Extensions"
       },
       "main": {
-        "store": "Seller",
-        "storeSettings": "Seller settings"
+        "store": "开发者中心",
+        "storeSettings": "开发者中心设置"
       },
       "settings": {
         "header": "Settings",
@@ -432,18 +432,18 @@
     "availableIn": "Available in <0>{{x}}</0> of <1>{{y}}</1> sales channels"
   },
   "seller": {
-    "domain": "Seller"
+    "domain": "开发者"
   },
   "products": {
-    "domain": "Products",
+    "domain": "岗位商品",
     "bulkDelete": {
-      "title": "Delete Products",
-      "description": "You are about to delete {{count}} products from catalog. This action cannot be undone.",
-      "success": "Successfully deleted {{count}} products.",
-      "error": "Failed to delete products."
+      "title": "删除岗位商品",
+      "description": "即将从目录中删除 {{count}} 个岗位商品。此操作无法撤销。",
+      "success": "已删除 {{count}} 个岗位商品。",
+      "error": "删除岗位商品失败。"
     },
     "list": {
-      "noRecordsMessage": "Create your first product to start selling."
+      "noRecordsMessage": "创建第一个岗位商品后即可开始上架授权。"
     },
     "edit": {
       "header": "Edit Product",
@@ -1207,7 +1207,7 @@
         "creditLineDescription": "Refund amount as store credit"
       }
     },
-    "domain": "Orders",
+    "domain": "授权订单",
     "claim": "Claim",
     "exchange": "Exchange",
     "return": "Return",
@@ -2605,9 +2605,9 @@
     }
   },
   "payouts": {
-    "domain": "Payouts",
-    "payout": "Payout",
-    "noRecords": "No payouts found",
+    "domain": "结算",
+    "payout": "结算",
+    "noRecords": "暂无结算记录",
     "status": {
       "pending": "Pending",
       "processing": "Processing",
@@ -2724,9 +2724,9 @@
     }
   },
   "store": {
-    "domain": "Seller",
-    "manageYourStoresDetails": "Manage your seller's details",
-    "editStore": "Edit seller",
+    "domain": "开发者",
+    "manageYourStoresDetails": "管理开发者资料",
+    "editStore": "编辑开发者资料",
     "handleTooltip": "The handle becomes the URL slug for your store. Leave empty to auto-generate from the name.",
     "validation": {
       "nameRequired": "Please enter a name",
@@ -3235,16 +3235,16 @@
     }
   },
   "login": {
-    "forgotPassword": "Forgot password? <0>Reset</0>",
-    "title": "Welcome back!",
-    "hint": "Log in to your vendor account.",
-    "submit": "Log in",
-    "sessionExpired": "Session expired",
-    "notSellerYet": "Not a seller yet? <0>Create an account</0>",
+    "forgotPassword": "忘记密码？<0>重置</0>",
+    "title": "迭界AI岗位商场",
+    "hint": "开发者登录后管理岗位包、上架授权和结算。",
+    "submit": "登录",
+    "sessionExpired": "登录已过期",
+    "notSellerYet": "还不是开发者？<0>申请入驻</0>",
     "validation": {
-      "emailRequired": "Please enter an email",
-      "emailInvalid": "Please enter a valid email",
-      "passwordRequired": "Please enter your password"
+      "emailRequired": "请输入邮箱",
+      "emailInvalid": "请输入有效邮箱",
+      "passwordRequired": "请输入密码"
     }
   },
   "register": {
@@ -3577,8 +3577,8 @@
     "inventoryItem": "Inventory item",
     "requiredQuantity": "Required quantity",
     "description": "Description",
-    "email": "Email",
-    "password": "Password",
+    "email": "邮箱",
+    "password": "密码",
     "repeatPassword": "Repeat Password",
     "confirmPassword": "Confirm Password",
     "newPassword": "New Password",
@@ -3650,9 +3650,9 @@
     "phone": "Phone",
     "metadata": "Metadata",
     "selectCountry": "Select",
-    "products": "Products",
+    "products": "岗位商品",
     "variants": "Variants",
-    "orders": "Orders",
+    "orders": "授权订单",
     "account": "Account",
     "total": "Order Total",
     "paidTotal": "Paid Total",

--- a/packages/vendor/src/i18n/translations/zhCN.json
+++ b/packages/vendor/src/i18n/translations/zhCN.json
@@ -147,8 +147,8 @@
     "search": {
       "label": "搜索",
       "title": "搜索",
-      "description": "搜索整个商店,包括订单、产品、客户等。",
-      "allAreas": "所有区域",
+      "description": "搜索开发者中心中的授权订单、岗位商品、结算和更多内容。",
+      "allAreas": "全部范围",
       "navigation": "导航",
       "openResult": "打开结果",
       "showMore": "显示更多",
@@ -159,16 +159,16 @@
       "emptySearchMessage": "输入关键词或短语以开始探索。",
       "loadMore": "加载更多 {{count}} 项",
       "groups": {
-        "all": "所有区域",
+        "all": "全部范围",
         "customer": "客户",
         "customerGroup": "客户组",
-        "product": "产品",
+        "product": "岗位商品",
         "productVariant": "产品变体",
         "inventory": "库存",
         "reservation": "预订",
         "category": "分类",
         "collection": "系列",
-        "order": "订单",
+        "order": "授权订单",
         "promotion": "促销",
         "campaign": "活动",
         "priceList": "价格表",
@@ -193,8 +193,8 @@
       "commandShortcut": "命令",
       "then": "然后",
       "navigation": {
-        "goToOrders": "订单",
-        "goToProducts": "产品",
+        "goToOrders": "授权订单",
+        "goToProducts": "岗位商品",
         "goToCollections": "系列",
         "goToCategories": "分类",
         "goToCustomers": "客户",
@@ -207,7 +207,7 @@
       },
       "settings": {
         "goToSettings": "设置",
-        "goToStore": "商店",
+        "goToStore": "开发者中心",
         "goToUsers": "用户",
         "goToRegions": "地区",
         "goToTaxRegions": "税收地区",
@@ -235,10 +235,10 @@
         }
       },
       "store": {
-        "label": "商店",
-        "storeSettings": "商店设置",
-        "editStore": "Edit Store",
-        "switchStore": "Switch store"
+        "label": "开发者",
+        "storeSettings": "开发者中心设置",
+        "editStore": "编辑开发者资料",
+        "switchStore": "切换开发者"
       },
       "actions": {
         "logout": "退出登录"
@@ -253,8 +253,8 @@
         "extensions": "扩展"
       },
       "main": {
-        "store": "商店",
-        "storeSettings": "商店设置"
+        "store": "开发者中心",
+        "storeSettings": "开发者中心设置"
       },
       "settings": {
         "header": "设置",
@@ -398,12 +398,12 @@
     "availableIn": "在 <1>{{y}}</1> 个销售渠道中的 <0>{{x}}</0> 个可用"
   },
   "products": {
-    "domain": "产品",
+    "domain": "岗位商品",
     "list": {
-      "noRecordsMessage": "创建您的第一个产品以开始销售。"
+      "noRecordsMessage": "创建第一个岗位商品后即可开始上架授权。"
     },
     "edit": {
-      "header": "编辑产品",
+      "header": "编辑岗位商品",
       "description": "编辑产品详情。",
       "successToast": "产品 {{title}} 更新成功。"
     },
@@ -1012,7 +1012,7 @@
     }
   },
   "orders": {
-    "domain": "订单",
+    "domain": "授权订单",
     "claim": "索赔",
     "exchange": "换货",
     "return": "退货",
@@ -2372,9 +2372,9 @@
     "invite": "邀请"
   },
   "store": {
-    "domain": "商店",
-    "manageYourStoresDetails": "管理您的商店详细信息",
-    "editStore": "编辑商店",
+    "domain": "开发者",
+    "manageYourStoresDetails": "管理开发者资料",
+    "editStore": "编辑开发者资料",
     "defaultCurrency": "默认货币",
     "defaultRegion": "默认地区",
     "defaultSalesChannel": "默认销售渠道",
@@ -2680,8 +2680,8 @@
   },
   "login": {
     "forgotPassword": "忘记密码？ - <0>重置</0>",
-    "title": "欢迎使用Medusa",
-    "hint": "登录以访问账户区域"
+    "title": "迭界AI岗位商场",
+    "hint": "开发者登录后管理岗位包、上架授权和结算。"
   },
   "invite": {
     "title": "欢迎使用Medusa",
@@ -2927,9 +2927,9 @@
     "phone": "电话",
     "metadata": "元数据",
     "selectCountry": "选择国家",
-    "products": "产品",
+    "products": "岗位商品",
     "variants": "变体",
-    "orders": "订单",
+    "orders": "授权订单",
     "account": "账户",
     "total": "订单总额",
     "paidTotal": "已收金额",

--- a/packages/vendor/src/pages/products/create/constants.ts
+++ b/packages/vendor/src/pages/products/create/constants.ts
@@ -64,6 +64,36 @@ export const ProductCreateBaseSchema = z.object({
   subtitle: z.string().optional(),
   handle: z.string().optional(),
   description: z.string().optional(),
+  role_package_id: z.string().min(1, "请输入岗位包 ID"),
+  role_package_version: z.string().min(1, "请输入岗位包版本"),
+  role_authorization_fee_yuan: z
+    .string()
+    .min(1, "请输入一次授权费")
+    .regex(/^\d+(\.\d{1,2})?$/, "请输入最多两位小数的金额"),
+  role_input_token_price_cents_per_million: z
+    .string()
+    .min(1, "请输入输入 Token 单价")
+    .regex(/^\d+$/, "请输入非负整数"),
+  role_output_token_price_cents_per_million: z
+    .string()
+    .min(1, "请输入输出 Token 单价")
+    .regex(/^\d+$/, "请输入非负整数"),
+  role_capabilities: z.string().optional(),
+  role_manifest_ref: z
+    .string()
+    .optional()
+    .refine((value) => {
+      if (!value) {
+        return true
+      }
+
+      return !(
+        value.startsWith("/") ||
+        value.startsWith("~") ||
+        /^[A-Za-z]:[\\/]/.test(value) ||
+        value.split(/[\\/]/).includes("..")
+      )
+    }, "请输入岗位包内相对路径"),
   discountable: z.boolean(),
   type_id: z.string().optional(),
   collection_id: z.string().optional(),
@@ -159,6 +189,13 @@ export const PRODUCT_CREATE_FORM_DEFAULTS: Partial<
   material: "",
   mid_code: "",
   origin_country: "",
+  role_authorization_fee_yuan: "",
+  role_capabilities: "资料处理, 自动化执行",
+  role_input_token_price_cents_per_million: "",
+  role_manifest_ref: "role_package/manifest.json",
+  role_output_token_price_cents_per_million: "",
+  role_package_id: "",
+  role_package_version: "0.1.0",
   subtitle: "",
   title: "",
   type_id: "",

--- a/packages/vendor/src/pages/products/create/product-create-details-form/components/product-create-details-general-section/product-create-general-section.tsx
+++ b/packages/vendor/src/pages/products/create/product-create-details-form/components/product-create-details-general-section/product-create-general-section.tsx
@@ -1,4 +1,4 @@
-import { Input, Textarea } from "@medusajs/ui"
+import { Input, Text, Textarea } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 
 import { Form } from "@components/common/form"
@@ -90,6 +90,139 @@ export const ProductCreateGeneralSection = () => {
                   {...field}
                   placeholder={t("products.fields.description.placeholder")}
                 />
+              </Form.Control>
+            </Form.Item>
+          )
+        }}
+      />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="md:col-span-2">
+          <Text size="small" className="text-ui-fg-subtle">
+            开发者中心只填写已有岗位包的公开上架资料；开发者模式是主系统同一聊天框内的工作阶段，业务逻辑由主系统处理，不在云端 metadata 保存 modeStage、提示词、聊天记录或私有 workspace 上下文。
+          </Text>
+        </div>
+        <Form.Field
+          control={form.control}
+          name="role_package_id"
+          render={({ field }) => {
+            return (
+              <Form.Item>
+                <Form.Label>岗位包 ID</Form.Label>
+                <Form.Control>
+                  <Input {...field} placeholder="pkg_customer_quality" />
+                </Form.Control>
+                <Form.ErrorMessage>
+                  {form.formState.errors.role_package_id?.message}
+                </Form.ErrorMessage>
+              </Form.Item>
+            )
+          }}
+        />
+        <Form.Field
+          control={form.control}
+          name="role_package_version"
+          render={({ field }) => {
+            return (
+              <Form.Item>
+                <Form.Label>岗位包版本</Form.Label>
+                <Form.Control>
+                  <Input {...field} placeholder="0.1.0" />
+                </Form.Control>
+                <Form.ErrorMessage>
+                  {form.formState.errors.role_package_version?.message}
+                </Form.ErrorMessage>
+              </Form.Item>
+            )
+          }}
+        />
+        <Form.Field
+          control={form.control}
+          name="role_authorization_fee_yuan"
+          render={({ field }) => {
+            return (
+              <Form.Item>
+                <Form.Label>一次授权费（元）</Form.Label>
+                <Form.Control>
+                  <Input {...field} inputMode="decimal" placeholder="299.00" />
+                </Form.Control>
+                <Form.ErrorMessage>
+                  {form.formState.errors.role_authorization_fee_yuan?.message}
+                </Form.ErrorMessage>
+              </Form.Item>
+            )
+          }}
+        />
+        <Form.Field
+          control={form.control}
+          name="role_input_token_price_cents_per_million"
+          render={({ field }) => {
+            return (
+              <Form.Item>
+                <Form.Label>输入 Token 单价（分/百万）</Form.Label>
+                <Form.Control>
+                  <Input
+                    {...field}
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    placeholder="0"
+                  />
+                </Form.Control>
+                <Form.ErrorMessage>
+                  {form.formState.errors.role_input_token_price_cents_per_million?.message}
+                </Form.ErrorMessage>
+              </Form.Item>
+            )
+          }}
+        />
+        <Form.Field
+          control={form.control}
+          name="role_output_token_price_cents_per_million"
+          render={({ field }) => {
+            return (
+              <Form.Item>
+                <Form.Label>输出 Token 单价（分/百万）</Form.Label>
+                <Form.Control>
+                  <Input
+                    {...field}
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    placeholder="0"
+                  />
+                </Form.Control>
+                <Form.ErrorMessage>
+                  {form.formState.errors.role_output_token_price_cents_per_million?.message}
+                </Form.ErrorMessage>
+              </Form.Item>
+            )
+          }}
+        />
+      </div>
+      <Form.Field
+        control={form.control}
+        name="role_manifest_ref"
+        render={({ field }) => {
+          return (
+            <Form.Item>
+              <Form.Label optional>岗位包清单</Form.Label>
+              <Form.Control>
+                <Input {...field} placeholder="role_package/manifest.json" />
+              </Form.Control>
+              <Form.ErrorMessage>
+                {form.formState.errors.role_manifest_ref?.message}
+              </Form.ErrorMessage>
+            </Form.Item>
+          )
+        }}
+      />
+      <Form.Field
+        control={form.control}
+        name="role_capabilities"
+        render={({ field }) => {
+          return (
+            <Form.Item>
+              <Form.Label optional>岗位能力</Form.Label>
+              <Form.Control>
+                <Textarea {...field} placeholder="资料处理, 自动化执行" />
               </Form.Control>
             </Form.Item>
           )

--- a/packages/vendor/src/pages/products/create/product-create-details-form/product-create-details-form.tsx
+++ b/packages/vendor/src/pages/products/create/product-create-details-form/product-create-details-form.tsx
@@ -34,7 +34,16 @@ const Root = ({ children }: { children?: ReactNode }) => {
 Root._tabMeta = {
   id: "details",
   labelKey: "products.create.tabs.details",
-  validationFields: ["title", "media"],
+  validationFields: [
+    "title",
+    "media",
+    "role_package_id",
+    "role_package_version",
+    "role_authorization_fee_yuan",
+    "role_input_token_price_cents_per_million",
+    "role_output_token_price_cents_per_million",
+    "role_manifest_ref",
+  ],
 } satisfies TabDefinition;
 
 const Header = () => {

--- a/packages/vendor/src/pages/products/create/product-create-form/product-create-form.tsx
+++ b/packages/vendor/src/pages/products/create/product-create-form/product-create-form.tsx
@@ -53,6 +53,8 @@ type UploadedMedia = HttpTypes.AdminFile & {
 
 const SAVE_DRAFT_BUTTON = "save-draft-button"
 const SEC_CAT_PRODUCT_KEY = "sec_cat_product_key"
+const DEFAULT_ROLE_SCOPES = ["role.execute", "audit.write"]
+const DIJIE_ROLE_PROTOCOL_VERSION = "2026-05"
 
 const TAB_ORDER: Tab[] = [
   Tab.DETAILS,
@@ -66,6 +68,25 @@ const isMovingForward = (currentTab: Tab, newTab: Tab): boolean => {
   const currentIndex = TAB_ORDER.indexOf(currentTab)
   const newIndex = TAB_ORDER.indexOf(newTab)
   return newIndex > currentIndex
+}
+
+const parseAuthorizationFeeCents = (value?: string) => {
+  const amount = Number(value || "0")
+
+  return Number.isFinite(amount) ? Math.round(amount * 100) : 0
+}
+
+const parseNonNegativeInteger = (value?: string) => {
+  const amount = Number(value || "0")
+
+  return Number.isSafeInteger(amount) && amount >= 0 ? amount : 0
+}
+
+const parseRoleCapabilities = (value?: string) => {
+  return (value || "")
+    .split(/[\n,]/)
+    .map((capability) => capability.trim())
+    .filter(Boolean)
 }
 
 type ProductCreateFormProps = {
@@ -290,7 +311,17 @@ export const ProductCreateForm = ({
     }
 
     const media = values.media || []
-    const { secondary_categories, ...rest } = values as any
+    const {
+      secondary_categories,
+      role_authorization_fee_yuan,
+      role_capabilities,
+      role_input_token_price_cents_per_million,
+      role_manifest_ref,
+      role_output_token_price_cents_per_million,
+      role_package_id,
+      role_package_version,
+      ...rest
+    } = values as any
     const secCatProductKey =
       Array.isArray(secondary_categories) &&
       secondary_categories.length > 0
@@ -701,9 +732,62 @@ export const ProductCreateForm = ({
             ],
       metadata: (() => {
         const existing = (finalPayload as any)?.metadata ?? undefined
-        if (!secCatProductKey) return existing
-        return {
+        const authorizationFeeCents = parseAuthorizationFeeCents(
+          role_authorization_fee_yuan
+        )
+        const inputCentsPerMillion = parseNonNegativeInteger(
+          role_input_token_price_cents_per_million
+        )
+        const outputCentsPerMillion = parseNonNegativeInteger(
+          role_output_token_price_cents_per_million
+        )
+        const roleManifestRef =
+          typeof role_manifest_ref === "string" &&
+          role_manifest_ref.trim()
+            ? role_manifest_ref.trim()
+            : undefined
+
+        const metadata = {
           ...(existing ?? {}),
+          dijieRole: {
+            kind: "role_product",
+            protocolVersion: DIJIE_ROLE_PROTOCOL_VERSION,
+            title: finalPayload.title,
+            subtitle: finalPayload.subtitle || undefined,
+            description: finalPayload.description || undefined,
+            packageId: role_package_id,
+            packageVersion: role_package_version,
+            listingStatus: isDraftSubmission ? "draft" : "proposed",
+            reviewState: isDraftSubmission ? "draft" : "submitted",
+            capabilities: parseRoleCapabilities(role_capabilities),
+            pricing: {
+              kind: "one_time_authorization",
+              authorizationFeeCents,
+              currency: "CNY",
+              platformFeeBps: 0,
+              developerReceivableBps: 10000,
+              developerReceivableCents: authorizationFeeCents,
+            },
+            roleTokenPricing: {
+              currency: "CNY",
+              inputTokenCentsPerMillion: inputCentsPerMillion,
+              outputTokenCentsPerMillion: outputCentsPerMillion,
+              platformFeeBps: 0,
+              developerReceivableBps: 10000,
+            },
+            scopes: DEFAULT_ROLE_SCOPES,
+            ...(roleManifestRef
+              ? {
+                  manifestSummary: {
+                    entrypoint: roleManifestRef,
+                  },
+                }
+              : {}),
+          },
+        }
+        if (!secCatProductKey) return metadata
+        return {
+          ...metadata,
           [SEC_CAT_PRODUCT_KEY]: secCatProductKey,
         }
       })(),
@@ -779,7 +863,16 @@ export const ProductCreateForm = ({
 
     switch (currentTab) {
       case Tab.DETAILS:
-        fieldsToValidate = ["title", "handle"]
+        fieldsToValidate = [
+          "title",
+          "handle",
+          "role_package_id",
+          "role_package_version",
+          "role_authorization_fee_yuan",
+          "role_input_token_price_cents_per_million",
+          "role_output_token_price_cents_per_million",
+          "role_manifest_ref",
+        ]
         break
       case Tab.ORGANIZE:
         fieldsToValidate = ["categories"]
@@ -904,7 +997,16 @@ export const ProductCreateForm = ({
 
                 switch (tab) {
                   case Tab.DETAILS:
-                    fieldsToValidate = ["title", "handle"]
+                    fieldsToValidate = [
+                      "title",
+                      "handle",
+                      "role_package_id",
+                      "role_package_version",
+                      "role_authorization_fee_yuan",
+                      "role_input_token_price_cents_per_million",
+                      "role_output_token_price_cents_per_million",
+                      "role_manifest_ref",
+                    ]
                     break
                   case Tab.ORGANIZE:
                     fieldsToValidate = ["categories"]


### PR DESCRIPTION
## Summary

Adds the cloud-side Dijie role marketplace, execution authorization, audit, and billing bridge needed by the local AICS execution flow.

## Changes

- Adds strict `metadata.dijieRole` parsing for role listings, one-time authorization pricing, role token pricing, package identity, and safe public projections.
- Adds `/dijie/roles`, `/dijie/my-roles`, `/dijie/entitlements/verify`, `/dijie/execution-token`, `/dijie/audit`, and `/dijie/executions/:executionId` cloud endpoints.
- Adds the `dijie-audit` module/read model and ledger rules that route main-system usage to the platform while routing developer role token usage and authorization fees to the developer with zero platform cut.
- Updates vendor product creation and admin product review surfaces to collect/show role authorization pricing and developer role token pricing.
- Documents the local execution bridge and human closed-loop smoke runbook.

## Testing

- `bun test apps/api/src/lib/dijie apps/api/src/api/dijie` — 82 passing tests.
- `git diff --check HEAD`.

## Checklist

- [ ] This pull request targets `new`.
- [x] I updated documentation, locales if the change requires it.
- [x] I added or adjusted tests that cover the change.

## Linked issues

Related [AICS-292], [AICS-293].

Notes for review:

- This PR intentionally keeps formal entitlement records, payout pages, and full developer/user center AI automation out of scope.
- Existing duplicate translation-key warnings in the vendor/admin builds are pre-existing and not introduced by this change.
- AICS-293 should run the real account/product/purchase/execution/audit smoke after this cloud PR and the OpenClaw local PR are reviewed.
