### PR TITLE
fix(vendor): MER-125 restore tip border on required variant attribute

### DIFF
--- a/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
@@ -398,7 +398,7 @@ const SelectedAttributes = ({
               {field.use_for_variants && (
                 <>
                   <div />
-                  <VariantAxisTip />
+                  <VariantAxisTip className="border-none" />
                 </>
               )}
             </div>
@@ -640,13 +640,13 @@ const RequiredAttributeField = ({
   );
 };
 
-const VariantAxisTip = () => {
+const VariantAxisTip = ({ className }: { className?: string }) => {
   const { t } = useTranslation();
 
   return (
     <InlineTip
       label={t("products.create.attributes.tip")}
-      className="border-none"
+      className={className}
     >
       {t("products.create.attributes.variantAxisTip")}
     </InlineTip>


### PR DESCRIPTION
## Summary

Follow-up to [MER-125](https://linear.app/rigbyjs/issue/MER-125/products-vendor-panel-product-creation-step-3-required-attributes) addressing the QA review feedback on canary's new attribute form.

`VariantAxisTip` was passing `className=\"border-none\"` to `InlineTip` for both call sites, stripping the default Medusa UI tip border on the required attribute view as well as the optional one. The optional case lives inside the bordered `<li>` so it intentionally has no border; the required case has no parent card, so removing the border made the tip blend into the form.

`VariantAxisTip` now accepts an optional `className`. The optional/user-created use site passes `className=\"border-none\"`; the required use site (`is_variant_axis`) omits it and inherits InlineTip's default border.

The Medusa-radio indicator concern from the QA's first comment item is already covered by canary's `RadioSelectItem` (`CircleMiniFilledSolid`), so no additional change is needed there.

## Test plan

- [ ] Vendor → Products → Create → Step 3: add a required `is_variant_axis` attribute (e.g. Size) — the \"Tip: This attribute will create variants\" notice shows a visible card border.
- [ ] Same step: add an optional attribute with \"use for variants\" enabled — the tip inside its bordered `<li>` still has no inner border (no double border).
- [ ] `bun run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)