### PR TITLE
fix(vendor): MER-126 add tooltip + correct filter bar on attribute step

### DIFF
--- a/packages/vendor/src/hooks/table/filters/use-attribute-table-filters.tsx
+++ b/packages/vendor/src/hooks/table/filters/use-attribute-table-filters.tsx
@@ -1,33 +1,28 @@
+import { ProductAttributeDTO } from "@mercurjs/types"
+import { createDataTableFilterHelper } from "@medusajs/ui"
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import { Filter } from "../../../components/table/data-table"
+
+import { useDataTableDateFilters } from "@components/data-table/helpers/general/use-data-table-date-filters"
+
+const filterHelper = createDataTableFilterHelper<ProductAttributeDTO>()
 
 export const useAttributeTableFilters = () => {
   const { t } = useTranslation()
+  const dateFilters = useDataTableDateFilters()
 
-  const filterableFilter: Filter = {
-    key: "is_filterable",
-    label: t("attributes.fields.filterable"),
-    type: "select",
-    options: [
-      {
-        label: t("filters.radio.yes"),
-        value: "true",
-      },
-      {
-        label: t("filters.radio.no"),
-        value: "false",
-      },
+  return useMemo(
+    () => [
+      filterHelper.accessor("is_filterable", {
+        label: t("attributes.fields.filterable"),
+        type: "select",
+        options: [
+          { label: t("filters.radio.yes"), value: "true" },
+          { label: t("filters.radio.no"), value: "false" },
+        ],
+      }),
+      ...dateFilters,
     ],
-  }
-
-  const dateFilters: Filter[] = [
-    { label: t("fields.createdAt"), key: "created_at" },
-    { label: t("fields.updatedAt"), key: "updated_at" },
-  ].map((f) => ({
-    key: f.key,
-    label: f.label,
-    type: "date" as const,
-  }))
-
-  return [filterableFilter, ...dateFilters]
+    [t, dateFilters]
+  )
 }

--- a/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-add-attributes-modal.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-add-attributes-modal.tsx
@@ -302,8 +302,20 @@ const useColumns = () => {
       }),
       columnHelper.accessor("is_required", {
         header: t("attributes.fields.required"),
-        cell: (info: any) =>
-          info.getValue() ? t("filters.radio.yes") : t("filters.radio.no"),
+        cell: (info: any) => {
+          if (info.getValue()) {
+            return (
+              <Tooltip
+                content={t("products.create.attributes.requiredTooltip")}
+              >
+                <span className="cursor-help underline decoration-dotted underline-offset-2">
+                  {t("filters.radio.yes")}
+                </span>
+              </Tooltip>
+            );
+          }
+          return t("filters.radio.no");
+        },
         enableSorting: false,
       }),
       columnHelper.accessor("type", {


### PR DESCRIPTION
## Summary
- Adds a tooltip to the "Yes" cell of the **Required** column in the Step 3 "Add existing attributes" modal, matching the Figma design ("This attribute is required by the Marketplace and can't be deselected.").
- Migrates `useAttributeTableFilters` to `createDataTableFilterHelper`, fixing the filter format for Medusa UI's new `DataTable`. Combined with the existing `compact` prop, the toolbar collapses to the single **Add filter / Search / Sort** row used elsewhere in the panel.

Linear: [MER-126](https://linear.app/rigbyjs/issue/MER-126/products-vendor-panel-product-creation-step-3-select-existing)

## Test plan
- [ ] On product create wizard, open Step 3 (Attributes) → click "Add existing".
- [ ] Confirm the toolbar shows a single row with "Add filter" on the left and Search + Sort on the right (no second toolbar row).
- [ ] Confirm required attributes are preselected with a disabled checkbox and a subtle row highlight.
- [ ] Hover the underlined "Yes" in the Required column of a required attribute and confirm the tooltip appears.
- [ ] Confirm the \`is_filterable\` and date filters open from "Add filter" and apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)