### PR TITLE
fix(vendor): align offers toast copy with design spec

### DIFF
--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -828,7 +828,7 @@
     "variant": {
       "edit": {
         "header": "Edit Variant",
-        "success": "Product variant edited successfully"
+        "success": "Offer variant was successfully updated."
       },
       "create": {
         "header": "Variant details"
@@ -869,7 +869,7 @@
       "edit": {
         "header": "Shipping Configuration",
         "toasts": {
-          "success": "Successfully updated the shipping profile for {{title}}."
+          "success": "Shipping configuration was successfully updated."
         }
       },
       "create": {
@@ -1058,7 +1058,7 @@
     "subtitle": "Manage your catalog listings",
     "create": {
       "header": "Create offer",
-      "successToast": "Offer created",
+      "successToast": "Offer was successfully published. Only offers with stock levels and prices set will be visible on the storefront.",
       "publish": "Publish",
       "tip": "Select all relevant products that match your inventory, then easily create offers for them by simply adding your stock levels and prices.",
       "addPrice": "Add price",
@@ -1085,18 +1085,18 @@
     "pricing": {
       "header": "Manage prices",
       "description": "Add, change, or remove prices on this offer's ladder.",
-      "successToast": "Prices updated",
+      "successToast": "Prices were successfully updated.",
       "empty": "No prices configured"
     },
     "inventory": {
       "header": "Manage inventory items",
       "description": "Attach, detach, or change the required quantity per item.",
-      "successToast": "Inventory items updated",
+      "successToast": "Stock levels were successfully updated.",
       "empty": "No inventory items attached"
     },
     "delete": {
       "description": "You are about to delete offer {{sku}}. This cannot be undone.",
-      "successToast": "Offer deleted"
+      "successToast": "Offer was successfully deleted."
     },
     "bulkDelete": {
       "description_one": "You are about to delete {{count}} offer. This cannot be undone.",

--- a/packages/vendor/src/pages/products/[id]/shipping-profile/product-organization-form/product-shipping-profile-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/shipping-profile/product-organization-form/product-shipping-profile-form.tsx
@@ -63,12 +63,8 @@ export const ProductShippingProfileForm = ({
           data.shipping_profile_id === "" ? null : data.shipping_profile_id,
       } as any,
       {
-        onSuccess: ({ product }) => {
-          toast.success(
-            t("products.shippingProfile.edit.toasts.success", {
-              title: product.title,
-            })
-          )
+        onSuccess: () => {
+          toast.success(t("products.shippingProfile.edit.toasts.success"))
           handleSuccess()
         },
         onError: (error) => {


### PR DESCRIPTION
## Summary
Aligns the success toast copy on the vendor **Offers** surface with the agreed design spec ([MER-179](https://linear.app/rigbyjs/issue/MER-179)). All changes are English i18n value updates in `packages/vendor/src/i18n/translations/en.json` plus one small form cleanup — no keys added/removed, no behavior change.

| # | Action | New toast |
|---|--------|-----------|
| 1 | Offer created | "Offer was successfully published. Only offers with stock levels and prices set will be visible on the storefront." |
| 2 | Offer deleted | "Offer was successfully deleted." |
| 3 | Offer prices updated | "Prices were successfully updated." |
| 4 | Offer stock levels updated | "Stock levels were successfully updated." |
| 5 | Offer variant details updated | "Offer variant was successfully updated." |
| 7 | Shipping configuration updated | "Shipping configuration was successfully updated." |

The shipping-profile toast previously interpolated `{{title}}`; the new copy drops it, so the now-unused arg was removed from `product-shipping-profile-form.tsx`.

### Not included (flagged)
Spec items **6 (offer variant price)** and **8 (offer variant inventory items)** are intentionally omitted: those edit forms do not exist in the vendor panel yet (no routes, and `products.variant.inventory` is an empty `{}` stub). They need their forms built before the copy can land.

## Linear
[MER-179](https://linear.app/rigbyjs/issue/MER-179)

## Test plan
- [x] `en.json` is valid JSON
- [x] Changed files lint clean (`oxlint`)
- [x] No i18n keys added/removed (translation key-validation unaffected)
- [ ] Manually: trigger each of the 6 flows in the vendor panel and confirm the toast text

> Note: `bun run lint`, `bun run build`, and the vendor translation spec each fail on **pre-existing** baseline issues on `canary` (repo-wide oxlint errors, an implicit-`any` in `settings/locations/location-list-page.tsx`, and a missing `store.validation.nameTooLong` key) — all untouched by and independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)