### PR TITLE
fix(vendor): improve edit variant details form

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -3351,6 +3351,22 @@
         "variant": {
           "type": "object",
           "properties": {
+            "validation": {
+              "type": "object",
+              "properties": {
+                "titleRequired": {
+                  "type": "string"
+                },
+                "optionRequired": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "titleRequired",
+                "optionRequired"
+              ],
+              "additionalProperties": false
+            },
             "edit": {
               "type": "object",
               "properties": {
@@ -3359,11 +3375,15 @@
                 },
                 "success": {
                   "type": "string"
+                },
+                "attributesTooltip": {
+                  "type": "string"
                 }
               },
               "required": [
                 "header",
-                "success"
+                "success",
+                "attributesTooltip"
               ],
               "additionalProperties": false
             },
@@ -3399,6 +3419,7 @@
             }
           },
           "required": [
+            "validation",
             "edit",
             "create",
             "deleteWarning",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -826,9 +826,14 @@
       }
     },
     "variant": {
+      "validation": {
+        "titleRequired": "Please enter a title",
+        "optionRequired": "Please select a value"
+      },
       "edit": {
         "header": "Edit Variant",
-        "success": "Product variant edited successfully"
+        "success": "Product variant edited successfully",
+        "attributesTooltip": "These are default values used to describe the item. They are not defined by Marketplace."
       },
       "create": {
         "header": "Variant details"

--- a/packages/vendor/src/pages/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
+++ b/packages/vendor/src/pages/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
@@ -1,5 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Button, Divider, Heading, Input, toast } from "@medusajs/ui"
+import { InformationCircleSolid } from "@medusajs/icons"
+import { Button, Divider, Heading, Input, Tooltip, toast } from "@medusajs/ui"
+import i18next from "i18next"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { z } from "zod"
@@ -25,8 +27,7 @@ type ProductEditVariantFormProps = {
 }
 
 const ProductEditVariantSchema = z.object({
-  title: z.string().min(1),
-  material: z.string().optional(),
+  title: z.string().min(1, i18next.t("products.variant.validation.titleRequired")),
   sku: z.string().optional(),
   ean: z.string().optional(),
   upc: z.string().optional(),
@@ -38,7 +39,9 @@ const ProductEditVariantSchema = z.object({
   mid_code: z.string().optional(),
   hs_code: z.string().optional(),
   origin_country: z.string().optional(),
-  options: z.record(z.string()).optional(),
+  options: z
+    .record(z.string().min(1, i18next.t("products.variant.validation.optionRequired")))
+    .optional(),
 })
 
 export const ProductEditVariantForm = ({
@@ -72,7 +75,6 @@ export const ProductEditVariantForm = ({
   const form = useForm<z.infer<typeof ProductEditVariantSchema>>({
     defaultValues: {
       title: variant.title || "",
-      material: variant.material || "",
       sku: variant.sku || "",
       ean: variant.ean || "",
       upc: variant.upc || "",
@@ -158,21 +160,6 @@ export const ProductEditVariantForm = ({
                 return (
                   <Form.Item>
                     <Form.Label>{t("fields.title")}</Form.Label>
-                    <Form.Control>
-                      <Input {...field} />
-                    </Form.Control>
-                    <Form.ErrorMessage />
-                  </Form.Item>
-                )
-              }}
-            />
-            <Form.Field
-              control={form.control}
-              name="material"
-              render={({ field }) => {
-                return (
-                  <Form.Item>
-                    <Form.Label optional>{t("fields.material")}</Form.Label>
                     <Form.Control>
                       <Input {...field} />
                     </Form.Control>
@@ -280,7 +267,12 @@ export const ProductEditVariantForm = ({
           </div>
           <Divider />
           <div className="flex flex-col gap-y-4">
-            <Heading level="h2">{t("products.attributes")}</Heading>
+            <div className="flex items-center gap-x-1">
+              <Heading level="h2">{t("products.attributes")}</Heading>
+              <Tooltip content={t("products.variant.edit.attributesTooltip")}>
+                <InformationCircleSolid className="text-ui-fg-muted" />
+              </Tooltip>
+            </div>
             <Form.Field
               control={form.control}
               name="weight"

--- a/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/constants.spec.ts
+++ b/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/constants.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest"
+
+import { CreateProductVariantSchema } from "./constants"
+
+describe("CreateProductVariantSchema", () => {
+  test("rejects an empty title", () => {
+    const result = CreateProductVariantSchema.safeParse({
+      title: "",
+      sku: "",
+      options: {},
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.join(".") === "title")).toBe(
+        true
+      )
+    }
+  })
+
+  test("rejects an unselected variant option", () => {
+    const result = CreateProductVariantSchema.safeParse({
+      title: "XS / Green",
+      options: { size: "XS", color: "" },
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.path.join(".") === "options.color")
+      ).toBe(true)
+    }
+  })
+
+  test("accepts a valid payload with every option selected", () => {
+    const result = CreateProductVariantSchema.safeParse({
+      title: "XS / Green",
+      sku: "SKU-1",
+      options: { size: "XS", color: "Green" },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("accepts a variant with no options", () => {
+    const result = CreateProductVariantSchema.safeParse({
+      title: "Default variant",
+      options: {},
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/constants.ts
+++ b/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/constants.ts
@@ -1,9 +1,12 @@
+import i18next from "i18next"
 import { z } from "zod"
 
 export const CreateProductVariantSchema = z.object({
-  title: z.string().min(1),
+  title: z.string().min(1, i18next.t("products.variant.validation.titleRequired")),
   sku: z.string().optional(),
-  options: z.record(z.string()).optional(),
+  options: z
+    .record(z.string().min(1, i18next.t("products.variant.validation.optionRequired")))
+    .optional(),
 })
 
 export const CreateVariantDetailsSchema = CreateProductVariantSchema.pick({

--- a/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/create-product-variant-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/create-product-variant-form.tsx
@@ -37,20 +37,31 @@ export const CreateProductVariantForm = ({
 }: CreateProductVariantFormProps) => {
   const { handleSuccess } = useRouteModal()
 
+  const variantAttributes =
+    (
+      product as HttpTypes.AdminProduct & Pick<ProductDTO, "attributes">
+    ).attributes?.filter((a) => a.is_variant_axis) ?? []
+
+  // Seed every variant-axis option with an empty value so the required
+  // validation fires for untouched selects (an empty record would pass).
+  const defaultOptions = variantAttributes.reduce<Record<string, string>>(
+    (acc, attribute) => {
+      acc[attribute.handle ?? attribute.id] = ""
+      return acc
+    },
+    {}
+  )
+
   const form = useForm<CreateProductVariantSchemaType>({
     defaultValues: {
       ...CREATE_VARIANT_DEFAULTS,
+      options: defaultOptions,
       ...extraDefaults,
     } as CreateProductVariantSchemaType,
     resolver: zodResolver(schema ?? CreateProductVariantSchema),
   })
 
   const { mutateAsync, isPending } = useCreateProductVariant(product.id)
-
-  const variantAttributes =
-    (
-      product as HttpTypes.AdminProduct & Pick<ProductDTO, "attributes">
-    ).attributes?.filter((a) => a.is_variant_axis) ?? []
 
   const handleSubmit = form.handleSubmit(async (data) => {
     const { title, options } = data


### PR DESCRIPTION
## Summary
- Remove the default Medusa **Material** field from the vendor *Edit Variant* drawer.
- Add proper validation to variant detail forms: **Title** and every **variant-axis option** (Size, Color, …) are now required, with inline messages ("Please enter a title" / "Please select a value"). Applied to both the edit drawer and the create wizard; the create form now seeds option defaults so untouched selects are validated on Continue.
- Add an informational **tooltip** to the *Attributes* section heading: "These are default values used to describe the item. They are not defined by Marketplace."

Scoped to `@mercurjs/vendor` per the ticket. The validation Figma reference shows the create wizard while the material/tooltip references show the edit drawer, so validation is applied to both sibling forms (same fields, same gap), while material removal and the tooltip are edit-drawer–specific.

## Linear
[MER-138](https://linear.app/rigbyjs/issue/MER-138)

## Test plan
- [x] `bun run build` (all 9 packages compile)
- [x] New unit spec `create-product-variant-form/constants.spec.ts` (4 passing) covering title-required, option-required, and valid payloads
- [x] i18n schema/en.json keys in sync (only the pre-existing, unrelated `store.validation.nameTooLong` mismatch remains on `canary`)
- [ ] Manual: open a product variant → *Edit Variant*, confirm no Material field, empty title/option show errors, Attributes heading shows the tooltip
- [ ] Manual: create a variant, leave an option unselected → "Please select a value"

🤖 Generated with [Claude Code](https://claude.com/claude-code)