### PR TITLE
fix(products): clean up vendor edit-variant request block

### DIFF
--- a/integration-tests/http/product-edit/vendor/product-edit.spec.ts
+++ b/integration-tests/http/product-edit/vendor/product-edit.spec.ts
@@ -319,6 +319,99 @@ medusaIntegrationTestRunner({
           expect(add.details.variant.title).toBe("Variant A")
         })
       })
+
+      describe("POST /vendor/products/:id/variants/:variant_id (staging)", () => {
+        // Adds a variant (auto-confirmed in the test env) and returns its
+        // applied id so the update flow has a real variant to diff against.
+        const addVariant = async (
+          productId: string,
+          payload: Record<string, unknown>,
+        ): Promise<string> => {
+          await api.post(
+            `/vendor/products/${productId}/variants`,
+            payload,
+            sellerHeaders,
+          )
+          const got = await api.get(
+            `/vendor/products/${productId}`,
+            sellerHeaders,
+          )
+          const variant = (got.data.product.variants as Array<any>).find(
+            (v) => v.title === payload.title,
+          )
+          return variant.id as string
+        }
+
+        it("stages a VARIANT_UPDATE carrying the variant_id and only the changed fields", async () => {
+          const productId = await createVendorProduct("Variant Update Product")
+          const variantId = await addVariant(productId, {
+            title: "Variant A",
+            sku: "OLD-SKU",
+          })
+
+          const res = await api.post(
+            `/vendor/products/${productId}/variants/${variantId}`,
+            // title unchanged, sku changed
+            { title: "Variant A", sku: "NEW-SKU" },
+            sellerHeaders,
+          )
+
+          expect(res.status).toBe(202)
+          const update = (res.data.product_change.actions as Array<any>).find(
+            (a) => a.action === ProductChangeActionType.VARIANT_UPDATE,
+          )
+          expect(update).toBeDefined()
+          expect(update.details.variant_id).toBe(variantId)
+          // Only the field that actually changed is staged.
+          expect(Object.keys(update.details.fields)).toEqual(["sku"])
+          expect(update.details.fields.sku).toBe("NEW-SKU")
+          expect(update.details.previous_fields.sku).toBe("OLD-SKU")
+        })
+
+        it("never stages manage_inventory — it is not vendor-editable (MER-168)", async () => {
+          const productId = await createVendorProduct("Manage Inventory Product")
+          const variantId = await addVariant(productId, {
+            title: "Variant B",
+            sku: "SKU-B",
+          })
+
+          const res = await api.post(
+            `/vendor/products/${productId}/variants/${variantId}`,
+            // Client tries to flip manage_inventory alongside a real edit.
+            { sku: "SKU-B2", manage_inventory: true },
+            sellerHeaders,
+          )
+
+          expect(res.status).toBe(202)
+          const update = (res.data.product_change.actions as Array<any>).find(
+            (a) => a.action === ProductChangeActionType.VARIANT_UPDATE,
+          )
+          expect(update).toBeDefined()
+          expect(Object.keys(update.details.fields)).toEqual(["sku"])
+          expect(update.details.fields).not.toHaveProperty("manage_inventory")
+        })
+
+        it("stages no VARIANT_UPDATE action when nothing editable changed", async () => {
+          const productId = await createVendorProduct("No Change Product")
+          const variantId = await addVariant(productId, {
+            title: "Variant C",
+            sku: "SKU-C",
+          })
+
+          const res = await api.post(
+            `/vendor/products/${productId}/variants/${variantId}`,
+            // Same title + sku, plus a non-editable field.
+            { title: "Variant C", sku: "SKU-C", manage_inventory: true },
+            sellerHeaders,
+          )
+
+          expect(res.status).toBe(202)
+          const updates = (res.data.product_change.actions as Array<any>).filter(
+            (a) => a.action === ProductChangeActionType.VARIANT_UPDATE,
+          )
+          expect(updates).toHaveLength(0)
+        })
+      })
     })
   },
 })

--- a/packages/admin/src/pages/products/product-detail/components/product-active-edit-section/product-active-edit-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-active-edit-section/product-active-edit-section.tsx
@@ -343,36 +343,61 @@ const VariantUpdateBlock = ({
 }) => {
   const { t } = useTranslation();
   const found = variantsById.get(variantId);
-  const title =
-    found?.title ||
-    found?.sku ||
-    variantId ||
-    t("fields.variant", { defaultValue: "Variant" });
+  const variantFallback = t("fields.variant", { defaultValue: "Variant" });
+  const title = found?.title || found?.sku || variantId || variantFallback;
+  // Only append the SKU when it adds information beyond the title.
+  const sku = found?.sku && title !== found.sku ? found.sku : undefined;
   const images = isImageList(found?.images) ? found?.images : undefined;
 
   return (
-    <div
-      className="flex flex-col gap-y-3"
-      data-testid={`product-active-edit-variant-${variantId}`}
-    >
-      <div className="flex items-center gap-3">
-        {images && images.length > 0 && <ImageStrip images={images} />}
-        <Text size="small" leading="compact" className="text-ui-fg-subtle">
-          <span className="font-medium text-ui-fg-base">
-            {t("products.edits.panel.variantUpdated", {
-              defaultValue: "Variant updated",
-            })}
-          </span>
-          {": "}
-          {title}
+    <>
+      <div
+        className="flex items-start gap-4 px-6 py-4"
+        data-testid={`product-active-edit-variant-${variantId}`}
+      >
+        <Text
+          size="small"
+          weight="plus"
+          leading="compact"
+          className="text-ui-fg-subtle w-[160px] shrink-0"
+        >
+          {variantFallback}
         </Text>
+        <div className="flex flex-1 items-center gap-2">
+          {images && images.length > 0 && <ImageStrip images={images} />}
+          <Text
+            size="small"
+            leading="compact"
+            className="text-ui-fg-base font-medium"
+          >
+            {title}
+          </Text>
+          {sku && (
+            <Text size="small" leading="compact" className="text-ui-fg-subtle">
+              {`· ${sku}`}
+            </Text>
+          )}
+        </div>
       </div>
-      <div className="flex flex-col gap-y-4 pl-1">
-        {diffs.map((diff, idx) => (
-          <FieldRow key={`${variantId}-${diff.field}-${idx}`} diff={diff} />
-        ))}
-      </div>
-    </div>
+
+      {diffs.length > 0 && (
+        <div className="flex items-start gap-4 px-6 py-4">
+          <Text
+            size="small"
+            weight="plus"
+            leading="compact"
+            className="text-ui-fg-subtle w-[160px] shrink-0"
+          >
+            {t("labels.updated")}
+          </Text>
+          <div className="flex flex-1 flex-col gap-y-4">
+            {diffs.map((diff, idx) => (
+              <FieldRow key={`${variantId}-${diff.field}-${idx}`} diff={diff} />
+            ))}
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 
@@ -562,30 +587,15 @@ export const ProductActiveEditSection = ({
             </div>
           )}
 
-          {variantsUpdated.size > 0 && (
-            <div className="flex items-start gap-4 px-6 py-4">
-              <Text
-                size="small"
-                weight="plus"
-                leading="compact"
-                className="text-ui-fg-subtle w-[160px] shrink-0"
-              >
-                {t("labels.updated")}
-              </Text>
-              <div className="flex flex-1 flex-col gap-y-6">
-                {Array.from(variantsUpdated.entries()).map(
-                  ([variantId, diffs]) => (
-                    <VariantUpdateBlock
-                      key={variantId}
-                      variantId={variantId}
-                      diffs={diffs}
-                      variantsById={variantsById}
-                    />
-                  ),
-                )}
-              </div>
-            </div>
-          )}
+          {variantsUpdated.size > 0 &&
+            Array.from(variantsUpdated.entries()).map(([variantId, diffs]) => (
+              <VariantUpdateBlock
+                key={variantId}
+                variantId={variantId}
+                diffs={diffs}
+                variantsById={variantsById}
+              />
+            ))}
 
           {added.length > 0 && (
             <div className="flex items-start gap-4 px-6 py-4">

--- a/packages/core/src/api/vendor/products/[id]/variants/[variant_id]/route.ts
+++ b/packages/core/src/api/vendor/products/[id]/variants/[variant_id]/route.ts
@@ -50,6 +50,12 @@ export const POST = async (
 
   const { attribute_values: _av, ...update } = req.validatedBody
 
+  // `manage_inventory` is a marketplace invariant pinned to `false` at
+  // variant creation (see `create-products` / variant create route); it
+  // is not vendor-editable, so we deliberately do NOT inject it here.
+  // Forcing it in re-staged a phantom no-op change on every edit, which
+  // polluted the request block (MER-168). The workflow diffs the rest of
+  // the payload and stages only the fields that actually changed.
   const { result } = await productEditUpdateVariantsWorkflow(req.scope).run({
     input: {
       product_id: productId,
@@ -58,7 +64,7 @@ export const POST = async (
         {
           type: "update",
           variant_id: variantId,
-          fields: { ...update, manage_inventory: false },
+          fields: update,
         },
       ],
     },

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-variants.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-variants.ts
@@ -46,6 +46,14 @@ export const productEditUpdateVariantsWorkflowId =
   "product-edit-update-variants"
 
 /**
+ * Variant fields that are not vendor-editable and must never be staged
+ * as part of a `VARIANT_UPDATE`. `manage_inventory` is a marketplace
+ * invariant pinned to `false` at variant creation — surfacing it in the
+ * request block (as a phantom `Off → On` row) was the core of MER-168.
+ */
+const NON_EDITABLE_VARIANT_FIELDS = new Set(["manage_inventory"])
+
+/**
  * Vendor "edit product variants" orchestrator. Translates each
  * `operations[]` entry into a `VARIANT_ADD` / `VARIANT_UPDATE` /
  * `VARIANT_REMOVE` action on a fresh `ProductChange` via
@@ -133,6 +141,29 @@ export const productEditUpdateVariantsWorkflow: ReturnWorkflow<
           currentVariantsById.set(v.id, v)
         }
 
+        // Mirror the product-level field diff (`product-edit-update-fields`):
+        // normalize relation/array shapes to ids/urls before comparing so an
+        // unchanged value never produces a spurious change row.
+        const normalize = (value: unknown): unknown => {
+          if (Array.isArray(value)) {
+            return value
+              .map((item) => {
+                if (item && typeof item === "object" && "id" in item) {
+                  return (item as { id: string }).id
+                }
+                if (item && typeof item === "object" && "url" in item) {
+                  return (item as { url: string }).url
+                }
+                return item
+              })
+              .sort()
+          }
+          return value ?? null
+        }
+
+        const isEqual = (a: unknown, b: unknown): boolean =>
+          JSON.stringify(normalize(a)) === JSON.stringify(normalize(b))
+
         for (const op of input.operations ?? []) {
           switch (op.type) {
             case "add":
@@ -144,16 +175,43 @@ export const productEditUpdateVariantsWorkflow: ReturnWorkflow<
               break
             case "update": {
               const current = currentVariantsById.get(op.variant_id) ?? {}
+              const changedFields: Record<string, unknown> = {}
               const previousFields: Record<string, unknown> = {}
-              for (const field of Object.keys(op.fields ?? {})) {
+
+              for (const [field, proposedValue] of Object.entries(
+                op.fields ?? {},
+              )) {
+                // Never stage fields the vendor can't edit (e.g.
+                // `manage_inventory`).
+                if (NON_EDITABLE_VARIANT_FIELDS.has(field)) continue
+
+                // `options` is a relation update (option-title → value
+                // pairs), not a scalar column we load for diffing. Forward
+                // it untouched when provided so the apply step can re-pair
+                // variant options; it carries no meaningful previous value.
+                if (field === "options") {
+                  if (proposedValue !== undefined) {
+                    changedFields.options = proposedValue
+                  }
+                  continue
+                }
+
+                // Skip fields that did not actually change.
+                if (isEqual(current[field], proposedValue)) continue
+
+                changedFields[field] = proposedValue
                 previousFields[field] = current[field] ?? null
               }
+
+              // Nothing editable changed — don't stage an empty action.
+              if (!Object.keys(changedFields).length) break
+
               acts.push({
                 product_id: input.product_id,
                 action: ProductChangeActionType.VARIANT_UPDATE,
                 details: {
                   variant_id: op.variant_id,
-                  fields: op.fields,
+                  fields: changedFields,
                   previous_fields: previousFields,
                 },
               })

--- a/packages/dashboard-shared/src/lib/product-change-diff.ts
+++ b/packages/dashboard-shared/src/lib/product-change-diff.ts
@@ -30,6 +30,14 @@ export const REFERENCE_FIELDS: ReferenceField[] = [
 export const isReferenceField = (field: string): field is ReferenceField =>
   (REFERENCE_FIELDS as string[]).includes(field)
 
+/**
+ * Variant fields that are not vendor-editable and must never surface in
+ * the request block. The staging workflow already strips these, but
+ * older pending changes may still carry them — keep the display defensive
+ * so non-editable rows (e.g. `manage_inventory`) never render (MER-168).
+ */
+export const NON_EDITABLE_VARIANT_FIELDS = new Set(["manage_inventory"])
+
 export const isImageList = (value: unknown): value is { url: string }[] =>
   Array.isArray(value) &&
   value.length > 0 &&
@@ -141,6 +149,7 @@ export const partitionProductChangeActions = (
             ? String(details.variant_id)
             : undefined
         for (const [field, value] of Object.entries(fields)) {
+          if (NON_EDITABLE_VARIANT_FIELDS.has(field)) continue
           updated.push({
             field,
             previous: previousFields[field],

--- a/packages/vendor/src/pages/products/[id]/_components/product-active-edit-section/product-active-edit-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-active-edit-section/product-active-edit-section.tsx
@@ -327,36 +327,61 @@ const VariantUpdateBlock = ({
 }) => {
   const { t } = useTranslation();
   const found = variantsById.get(variantId);
-  const title =
-    found?.title ||
-    found?.sku ||
-    variantId ||
-    t("fields.variant", { defaultValue: "Variant" });
+  const variantFallback = t("fields.variant", { defaultValue: "Variant" });
+  const title = found?.title || found?.sku || variantId || variantFallback;
+  // Only append the SKU when it adds information beyond the title.
+  const sku = found?.sku && title !== found.sku ? found.sku : undefined;
   const images = isImageList(found?.images) ? found?.images : undefined;
 
   return (
-    <div
-      className="flex flex-col gap-y-3"
-      data-testid={`product-active-edit-variant-${variantId}`}
-    >
-      <div className="flex items-center gap-3">
-        {images && images.length > 0 && <ImageStrip images={images} />}
-        <Text size="small" leading="compact" className="text-ui-fg-subtle">
-          <span className="font-medium text-ui-fg-base">
-            {t("products.edits.panel.variantUpdated", {
-              defaultValue: "Variant updated",
-            })}
-          </span>
-          {": "}
-          {title}
+    <>
+      <div
+        className="flex items-start gap-4 px-6 py-4"
+        data-testid={`product-active-edit-variant-${variantId}`}
+      >
+        <Text
+          size="small"
+          weight="plus"
+          leading="compact"
+          className="text-ui-fg-subtle w-[160px] shrink-0"
+        >
+          {variantFallback}
         </Text>
+        <div className="flex flex-1 items-center gap-2">
+          {images && images.length > 0 && <ImageStrip images={images} />}
+          <Text
+            size="small"
+            leading="compact"
+            className="text-ui-fg-base font-medium"
+          >
+            {title}
+          </Text>
+          {sku && (
+            <Text size="small" leading="compact" className="text-ui-fg-subtle">
+              {`· ${sku}`}
+            </Text>
+          )}
+        </div>
       </div>
-      <div className="flex flex-col gap-y-4 pl-1">
-        {diffs.map((diff, idx) => (
-          <FieldRow key={`${variantId}-${diff.field}-${idx}`} diff={diff} />
-        ))}
-      </div>
-    </div>
+
+      {diffs.length > 0 && (
+        <div className="flex items-start gap-4 px-6 py-4">
+          <Text
+            size="small"
+            weight="plus"
+            leading="compact"
+            className="text-ui-fg-subtle w-[160px] shrink-0"
+          >
+            {t("labels.updated")}
+          </Text>
+          <div className="flex flex-1 flex-col gap-y-4">
+            {diffs.map((diff, idx) => (
+              <FieldRow key={`${variantId}-${diff.field}-${idx}`} diff={diff} />
+            ))}
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 
@@ -496,30 +521,15 @@ export const ProductActiveEditSection = ({
             </div>
           )}
 
-          {variantsUpdated.size > 0 && (
-            <div className="flex items-start gap-4 px-6 py-4">
-              <Text
-                size="small"
-                weight="plus"
-                leading="compact"
-                className="text-ui-fg-subtle w-[160px] shrink-0"
-              >
-                {t("labels.updated")}
-              </Text>
-              <div className="flex flex-1 flex-col gap-y-6">
-                {Array.from(variantsUpdated.entries()).map(
-                  ([variantId, diffs]) => (
-                    <VariantUpdateBlock
-                      key={variantId}
-                      variantId={variantId}
-                      diffs={diffs}
-                      variantsById={variantsById}
-                    />
-                  ),
-                )}
-              </div>
-            </div>
-          )}
+          {variantsUpdated.size > 0 &&
+            Array.from(variantsUpdated.entries()).map(([variantId, diffs]) => (
+              <VariantUpdateBlock
+                key={variantId}
+                variantId={variantId}
+                diffs={diffs}
+                variantsById={variantsById}
+              />
+            ))}
 
           {added.length > 0 && (
             <div className="flex items-start gap-4 px-6 py-4">


### PR DESCRIPTION
## Summary
Fixes the vendor **"Product update request"** block for variant edits (MER-168):
- **Hides non-editable fields** — the route forced `manage_inventory: false` into every edit, surfacing a phantom `Off → On` row. `manage_inventory` is a marketplace invariant pinned at variant creation, so it's no longer injected here.
- **Shows only edited values** — `product-edit-update-variants` now diffs the payload against the current variant (mirroring the product-level `product-edit-update-fields` flow). Only changed fields are staged; `options` (a relation update) is forwarded untouched; an all-unchanged submit stages no action.
- **Shows the edited variant clearly** — the admin + vendor active-edit blocks now render a dedicated **Variant** identity row (thumbnail + `title · sku`) above the **Updated** diff rows, matching the design.
- Defensive: the shared diff partition also skips non-editable fields so older pending changes don't render them.

> Note: the linked Figma mock shows a `Manage inventory: Off → On` row, but the ticket text is explicit and repeated that Manage Inventory *cannot be edited* and is a bug in the block — so it's treated as an illustrative placeholder and filtered out.

## Linear
[MER-168](https://linear.app/rigbyjs/issue/MER-168)

## Test plan
- [x] `bun run build` (9/9 packages)
- [x] `bun run test:integration:http -- product-edit/vendor/product-edit` (14/14 passing, incl. 3 new variant-update staging tests)
- [ ] Manual: as a vendor, edit a variant's SKU only → request block shows the **Variant** row + a single **Updated → SKU** diff, no Manage inventory, no unchanged fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)