### PR TITLE
fix(vendor): update product edit request toast copy

### DIFF
--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -450,7 +450,7 @@
       "header": "Edit Product",
       "description": "Edit the product details.",
       "successToast": "Product {{title}} was successfully updated.",
-      "requestSuccessToast": "Product update request has been submitted successfully.",
+      "requestSuccessToast": "Product update was successfully requested. Once confirmed by the Admin, changes will appear on the storefront.",
       "duplicateRequestErrorToast": "You already have an active request. You can only have one at a time.",
       "attributes": {
         "addAttribute": "Add Attribute",
@@ -477,7 +477,7 @@
         "cancelDescription": "Are you sure you want to cancel this product update request? This action cannot be undone."
       },
       "toast": {
-        "canceledSuccessfully": "Product update request canceled"
+        "canceledSuccessfully": "Product update request was successfully canceled."
       }
     },
     "create": {


### PR DESCRIPTION
## Summary
- Update the **product update request** success toast to: _"Product update was successfully requested. Once confirmed by the Admin, changes will appear on the storefront."_ (`products.edit.requestSuccessToast`)
- Update the **cancel update request** toast to: _"Product update request was successfully canceled."_ (`products.edits.toast.canceledSuccessfully`)
- English is the canonical i18n source; only `packages/vendor/src/i18n/translations/en.json` changed.

## Linear
[MER-169](https://linear.app/rigbyjs/issue/MER-169)

## Test plan
- [ ] In the vendor panel, submit a product edit request → toast reads the new copy.
- [ ] Cancel an active product update request → toast reads the new copy.
- [x] `bun run build` (vendor package rebuilds cleanly)
- [x] `en.json` validates as JSON

> Note: `bun run lint` and the vendor i18n validation test (`store.validation.nameTooLong`) fail on the current `canary` baseline, unrelated to this change (verified identical with/without the diff). This PR touches only two string values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)