### PR TITLE
fix(products): variant-step search + option-value create error

### DIFF
--- a/docs/specs/SPEC-009-vendor-variant-media.md
+++ b/docs/specs/SPEC-009-vendor-variant-media.md
@@ -1,0 +1,127 @@
+---
+status: not_started
+canonical: false
+priority: 2
+area: vendor/products
+created: 2026-06-11
+last_updated: 2026-06-11
+---
+
+# SPEC-009 Vendor Variant Media (per-variant images)
+
+Split out of **MER-127** (*PRODUCTS — Vendor Panel — Product Creation —
+Step 4 — Variant*). That ticket bundled three items; the two contained
+bug fixes (variant-grid search, and the "Option value X does not exist"
+create error) shipped in the MER-127 PR. This spec owns the remaining,
+larger item: **selecting images per variant**, which needs new backend
+persistence and is therefore tracked as its own feature.
+
+## Decision (owner: framework author)
+
+- **Persistence model:** native Medusa variant images. Medusa 2.11.2+
+  ships a real `ProductVariantProductImage` link and a `variant.images`
+  relation; we wire those through rather than storing URLs in
+  `variant.metadata` (a stopgap that is not a first-class, queryable
+  relation).
+- **Media source / UX:** **upload per variant** — each variant gets its
+  own upload control (mirrors the product-level Media section, which is
+  upload-based), not a "pick from product media" selector.
+
+These two choices were confirmed with the framework author on
+2026-06-11.
+
+## Why this is not just a UI field
+
+The current vendor create flow has no path to persist variant images:
+
+- Frontend create schema `ProductCreateVariantSchema`
+  (`packages/vendor/src/pages/products/create/constants.ts`) has no
+  `media`/`images` field.
+- `normalizeVariants` / `normalizeProductFormValues`
+  (`packages/vendor/src/pages/products/create/utils.ts`) send only
+  `title` / `options` / `sku` / `variant_rank` per variant.
+- Vendor create validator `CreateProductVariant`
+  (`packages/core/src/api/vendor/products/validators.ts`) accepts no
+  variant `images`. `UpdateProductVariant` accepts a single
+  `thumbnail` only.
+- Medusa's own `CreateProductVariantDTO`
+  (`@medusajs/types` → `product/common.d.ts`) does **not** accept
+  `images` or `thumbnail` on create — the native variant-image relation
+  is only reachable via a post-create link step.
+
+So a real implementation spans validator → workflow → UI.
+
+## Source design
+
+Figma — *Mercur 2.0 — Vendor Panel B2C*
+(`figma.com/design/sYJoh84Owr5tomRjpxG0no`):
+
+- Variant grid with a **Media** column, per-variant thumbnails + an
+  add ("+") affordance — flow heading node `40009010:146111`; the
+  end-state is also visible in node `40009019:257392`.
+
+Confluence — *Products in Mercur Admin Panel*
+(`rigbysoftwarehouse.atlassian.net/wiki/spaces/ME/pages/512786471`):
+the variant **details page manages Details / Media / Price / Inventory
+items** — confirming variant Media is a documented, first-class
+per-variant section (not a Figma-only detail), so the same backend
+serves both the create wizard and the variant detail/edit surface.
+
+## User-Visible Behavior
+
+- In the product-create **Variants** step, each variant row exposes a
+  Media affordance. The vendor can upload one or more images for that
+  specific variant.
+- On submit, the uploaded files are stored and associated with the
+  correct variant via the native variant-image relation.
+- Opening the created product / variant shows the variant's images on
+  the variant detail page (and they round-trip through edit).
+
+## Scope
+
+In scope:
+- Backend: accept variant `images` on `POST /vendor/products` (and the
+  update path), and a workflow step that creates `ProductImage` rows
+  and links them to the right variant via `ProductVariantProductImage`.
+- Frontend (vendor create): variant `media` schema field, upload UI in
+  the Variants step, and normalization that uploads files and sends the
+  resulting urls per variant.
+- Round-trip on the vendor variant detail/edit surface (shares the
+  backend).
+
+Out of scope (here):
+- The MER-127 variant-grid **search** and the **option-value create
+  error** — both already shipped in the MER-127 PR.
+- Admin-side variant media (mirror later if needed).
+
+## Open questions
+
+- Single thumbnail vs. multiple images per variant. The Figma shows one
+  thumbnail per row; the variant detail "Media" section implies a full
+  gallery. Default to **multiple** (native relation supports it) and
+  surface the first as the variant thumbnail.
+- Whether per-variant uploads should be de-duplicated against
+  product-level media when the same file is used in both.
+- Coordinate with MER-136 / MER-137 (vendor product-details "create
+  variant" / "variant details"), which already have worktrees and touch
+  the same variant surface.
+
+## Verification
+
+1. `POST /vendor/products` with a variant carrying `images: [{ url }]`
+   persists the image and links it to that variant (integration test in
+   `integration-tests/http/product/vendor/`).
+2. `GET /vendor/products/:id` (and the variant detail) returns the
+   variant with its `images` populated.
+3. Vendor create UI: upload an image on a variant row, publish, reopen
+   the product — the image shows on the right variant only.
+4. `bun run lint` and `bun run build` pass.
+
+## Evidence
+
+_Not started._
+
+## Notes
+
+The MER-127 PR delivered the two contained fixes and referenced this
+spec for the deferred media work.

--- a/integration-tests/http/product/vendor/product.spec.ts
+++ b/integration-tests/http/product/vendor/product.spec.ts
@@ -185,6 +185,52 @@ medusaIntegrationTestRunner({
           ])
         })
 
+        // MER-127: a variant may reference an option value that the
+        // synthesised options miss — e.g. a user-entered custom value on an
+        // existing attribute, which value-id resolution drops. Stock variant
+        // creation used to reject the product with "Option value L does not
+        // exist for option Size". The wrapper now unions variant-referenced
+        // values back into the product options so creation succeeds.
+        it("(A2) creates the product when a variant references a value missing from variant_attributes value_ids", async () => {
+          const size = await createGlobalAttribute({
+            name: "Size",
+            type: "multi_select",
+            is_variant_axis: true,
+            values: ["S", "M"],
+          })
+
+          const create = await api.post(
+            `/vendor/products`,
+            {
+              title: "Vendor Custom Value",
+              variants: [
+                { title: "Small", attribute_values: { Size: "S" } },
+                // "L" is not part of the resolved variant_attributes below.
+                { title: "Large", attribute_values: { Size: "L" } },
+              ],
+              variant_attributes: [
+                {
+                  attribute_id: size.attribute_id,
+                  value_ids: [size.byName.get("S")!],
+                },
+              ],
+            },
+            seller1Headers,
+          )
+          expect(create.status).toBe(201)
+
+          const sizeOption = create.data.product.options.find(
+            (o: any) => o.title === "Size",
+          )
+          expect(sizeOption).toBeDefined()
+          expect(sizeOption.values.map((v: any) => v.value).sort()).toEqual([
+            "L",
+            "S",
+          ])
+          // Both variants were created against the unioned option set.
+          expect(create.data.product.variants).toHaveLength(2)
+        })
+
         // --- Case B: inline custom variant-axis attribute ---
         it("(B) inline custom variant-axis: creates a product-scoped attribute, links values, hides it from the global catalogue", async () => {
           const create = await api.post(

--- a/packages/core/src/workflows/product/workflows/create-products.ts
+++ b/packages/core/src/workflows/product/workflows/create-products.ts
@@ -67,6 +67,60 @@ const DEFAULT_OPTION_TITLE = "Default option"
 const DEFAULT_OPTION_VALUE = "Default option value"
 
 /**
+ * Ensures every option value referenced by a variant exists on the
+ * corresponding product option.
+ *
+ * Product `options` are synthesised from `variant_attributes` (value
+ * ids → value names), but a variant's `options` map carries value
+ * *names* the UI generated from the raw selection. When a selected
+ * value can't be resolved to an id — e.g. a user-entered custom value
+ * on an existing attribute, which the value-id resolution drops — the
+ * synthesised option ends up missing that value while a variant still
+ * references it. Stock variant creation then rejects the product with
+ * "Option value X does not exist for option Y" (MER-127).
+ *
+ * Unioning the variant-referenced names back into the options keeps the
+ * product self-consistent so creation succeeds. Existing option titles
+ * are augmented in place; a title referenced only by a variant is
+ * appended (preserving first-seen order) so the same error can't slip
+ * through a different way.
+ */
+export const unionVariantOptionValues = (
+  options: ProductOptionInput[],
+  variants: Array<{ options?: Record<string, string> }>,
+): ProductOptionInput[] => {
+  const valuesByTitle = new Map<string, Set<string>>()
+  const order: string[] = []
+
+  const ensureTitle = (title: string) => {
+    if (!valuesByTitle.has(title)) {
+      valuesByTitle.set(title, new Set())
+      order.push(title)
+    }
+    return valuesByTitle.get(title)!
+  }
+
+  for (const option of options) {
+    const set = ensureTitle(option.title)
+    for (const value of option.values) set.add(value)
+  }
+
+  for (const variant of variants) {
+    const variantOptions = variant.options
+    if (!variantOptions) continue
+    for (const [title, value] of Object.entries(variantOptions)) {
+      if (value === undefined || value === null || value === "") continue
+      ensureTitle(title).add(value)
+    }
+  }
+
+  return order.map((title) => ({
+    title,
+    values: Array.from(valuesByTitle.get(title)!),
+  }))
+}
+
+/**
  * Marketplace wrapper over stock `createProductsWorkflow`.
  *
  * On top of stock it:
@@ -193,7 +247,7 @@ export const createProductsWorkflow: ReturnWorkflow<
 
           return {
             ...rest,
-            options,
+            options: unionVariantOptionValues(options, stockVariants),
             ...(stockVariants.length ? { variants: stockVariants } : {}),
           }
         }),

--- a/packages/vendor/src/pages/products/create/components/product-create-variants-form/product-create-variants-form.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-variants-form/product-create-variants-form.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react"
+import { Input } from "@medusajs/ui"
+import { useMemo, useState } from "react"
 import { useWatch } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 
@@ -11,8 +12,11 @@ import { ProductCreateVariantSchema } from "../../constants"
 import { ProductCreateSchemaType } from "../../types"
 
 const Root = () => {
+  const { t } = useTranslation()
   const form = useTabbedForm<ProductCreateSchemaType>()
   const { setCloseOnEscape } = useRouteModal()
+
+  const [search, setSearch] = useState("")
 
   const variants = useWatch({
     control: form.control,
@@ -48,6 +52,37 @@ const Root = () => {
     return ret
   }, [variants])
 
+  const filteredVariantData = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    if (!query) {
+      return variantData
+    }
+
+    return variantData.filter((variant) => {
+      const haystack = [
+        variant.title,
+        variant.sku,
+        ...Object.values(variant.options ?? {}),
+      ]
+
+      return haystack.some((value) => value?.toLowerCase().includes(query))
+    })
+  }, [variantData, search])
+
+  const headerContent = (
+    <Input
+      type="search"
+      size="small"
+      autoComplete="off"
+      value={search}
+      onChange={(event) => setSearch(event.target.value)}
+      placeholder={t(
+        "products.create.variants.productVariants.searchPlaceholder"
+      )}
+      data-testid="product-create-variants-search-input"
+    />
+  )
+
   return (
     <div
       className="flex size-full flex-col divide-y overflow-hidden"
@@ -56,9 +91,10 @@ const Root = () => {
       <div data-testid="product-create-variants-form-datagrid">
         <DataGrid
           columns={columns}
-          data={variantData}
+          data={filteredVariantData}
           state={form}
           onEditingChange={(editing) => setCloseOnEscape(!editing)}
+          headerContent={headerContent}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
Two contained fixes for the vendor Product Creation **Step 4 — Variants** (MER-127):

- **Missing search** — the variants `DataGrid` now has a search box (via the header slot) that filters rows by title / SKU / option values. Matches the Figma + the documented "you can search and filter them" behaviour.
- **"Option value X does not exist for option Y" on create** — a variant could reference an option value that the backend-synthesised product options dropped (e.g. a user-entered custom value on an existing attribute, which value-id resolution silently skips). New `unionVariantOptionValues` folds every variant-referenced value back into the product options so creation stays self-consistent.

The third MER-127 item — **select images per variant** — needs new backend persistence (Medusa's `CreateProductVariantDTO` accepts no variant images on create), so it's split out into **SPEC-009** (native variant images, upload-per-variant) per the framework author's call, corroborated by the Confluence Products spec.

## Linear
[MER-127](https://linear.app/rigbyjs/issue/MER-127)

## Test plan
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test:integration:http -- product/vendor/product.spec.ts` — new `(A2)` case (variant references a value missing from `variant_attributes` value_ids) passes; full suite green **except** two **pre-existing** cross-seller authorization failures (`seller cannot update another seller's product`, `rejects attaching to another seller's product`) that also fail on `canary` with my changes stashed — unrelated to this PR (flagged separately).
- [ ] Manual: open vendor product create → Attributes (add a variant axis) → Variants tab; confirm the search box filters rows and keeps focus while typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)