### PR TITLE
fix(vendor): category tooltip, validation copy and lock deselect on product create

### DIFF
--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -500,7 +500,7 @@
         "options": "Please create at least one option.",
         "uniqueSku": "SKU must be unique across variants",
         "primaryCategoryRequired": "Primary category is required",
-        "categoryRequired": "Please select category",
+        "categoryRequired": "Please select a category",
         "titleRequired": "Title is required",
         "handleInvalidFormat": "Handle must contain only lowercase letters, numbers, and hyphens",
         "handleMustContainLetter": "Handle must contain at least one letter",
@@ -822,7 +822,7 @@
       },
       "primaryCategory": {
         "label": "Primary Category",
-        "tooltip": "The primary category defines which attributes are available for this product. Attributes are created by the Admin when setting up the marketplace."
+        "tooltip": "Category could define attributes that apply to this product. Attributes are created by the Admin when setting up the marketplace."
       }
     },
     "variant": {

--- a/packages/vendor/src/pages/products/common/components/category-combobox/single-category-combobox.tsx
+++ b/packages/vendor/src/pages/products/common/components/category-combobox/single-category-combobox.tsx
@@ -131,9 +131,8 @@ export const SingleCategoryCombobox = forwardRef<
         e.preventDefault()
         e.stopPropagation()
 
-        if (value === option.value) {
-          onChange(null)
-        } else {
+        // A selected category can only be changed to another one, not deselected.
+        if (value !== option.value) {
           onChange(option.value)
           handleOpenChange(false)
         }


### PR DESCRIPTION
## Summary
- Update the primary-category **tooltip** in the vendor product create flow to: _"Category could define attributes that apply to this product. Attributes are created by the Admin when setting up the marketplace."_
- Update the **validation message** for an unselected category to: _"Please select a category"_.
- Prevent **deselecting** an already-selected category in the single-category combobox — a selected category can only be switched to another one, not cleared.

## Linear
[MER-180](https://linear.app/rigbyjs/issue/MER-180)

## Test plan
- [ ] Vendor panel → Products → Create → Step 2 (Organize): hover the Category label info icon and confirm the new tooltip copy.
- [ ] Try to continue past Step 2 without a category and confirm the error reads "Please select a category".
- [ ] Select a category, then click it again (mouse and Enter) — it stays selected; clicking a different category switches the selection.
- [x] \`bun run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)