### PR TITLE
fix(products): delete draft products without an approval request

### DIFF
--- a/integration-tests/http/product-edit/vendor/product-edit-draft-delete.spec.ts
+++ b/integration-tests/http/product-edit/vendor/product-edit-draft-delete.spec.ts
@@ -1,0 +1,132 @@
+// Force the product-request approval queue ON for this suite. The
+// shared test env (`integration-tests/.env.test`) ships
+// `MEDUSA_FF_PRODUCT_REQUEST=false`; `loadEnv` (dotenv) does not
+// override an already-set value, so assigning it here — before the
+// test runner boots the Medusa app — flips the flag for this file only.
+process.env.MEDUSA_FF_PRODUCT_REQUEST = "true"
+
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  ProductChangeActionType,
+  ProductChangeStatus,
+  ProductStatus,
+} from "@mercurjs/types"
+
+import { createSellerUser } from "../../../helpers/create-seller-user"
+
+jest.setTimeout(60_000)
+
+/**
+ * MER-181 — a vendor must be able to delete a `draft` product they
+ * never submitted for review without it landing in the operator
+ * approval queue. This suite runs with `MEDUSA_FF_PRODUCT_REQUEST=true`
+ * (admin approval enabled) and asserts:
+ *
+ *  - deleting a `draft` product applies inline (product gone, change
+ *    CONFIRMED), bypassing the queue, and
+ *  - deleting a non-draft (`proposed`) product still stages a PENDING
+ *    change for the operator (product preserved).
+ */
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api }) => {
+    describe("Vendor DELETE /vendor/products/:id — draft bypass (MER-181)", () => {
+      let container: MedusaContainer
+      let sellerHeaders: { headers: Record<string, string> }
+
+      beforeAll(async () => {
+        container = getContainer()
+      })
+
+      beforeEach(async () => {
+        const a = await createSellerUser(container, {
+          email: "draft-delete-seller@test.com",
+          name: "Draft Delete Seller",
+        })
+        sellerHeaders = a.headers
+      })
+
+      const createVendorProduct = async (
+        title: string,
+        status: (typeof ProductStatus)[keyof typeof ProductStatus],
+      ): Promise<string> => {
+        const res = await api.post(
+          `/vendor/products`,
+          { title, status },
+          sellerHeaders,
+        )
+        expect(res.data.product.status).toBe(status)
+        return res.data.product.id
+      }
+
+      const findDeleteChange = async (productId: string) => {
+        const query = container.resolve(ContainerRegistrationKeys.QUERY)
+        const { data } = await query.graph({
+          entity: "product_change",
+          fields: ["id", "status", "product_id", "actions.*"],
+          filters: { product_id: productId },
+        })
+        return (
+          data as Array<{
+            id: string
+            status: string
+            actions: Array<{ action: string }>
+          }>
+        ).find((c) =>
+          c.actions.some(
+            (a) => a.action === ProductChangeActionType.PRODUCT_DELETE,
+          ),
+        )
+      }
+
+      it("deletes a draft product inline even when PRODUCT_REQUEST is enabled", async () => {
+        const productId = await createVendorProduct(
+          "Draft Disposable",
+          ProductStatus.DRAFT,
+        )
+
+        const res = await api.delete(
+          `/vendor/products/${productId}`,
+          sellerHeaders,
+        )
+        expect(res.status).toBe(202)
+
+        // The product is actually gone — the delete was applied, not queued.
+        const got = await api
+          .get(`/vendor/products/${productId}`, sellerHeaders)
+          .catch((e) => e.response)
+        expect(got.status).toBe(404)
+
+        // The staged change was force-confirmed, not left pending.
+        const deleteChange = await findDeleteChange(productId)
+        expect(deleteChange).toBeDefined()
+        expect(deleteChange!.status).toBe(ProductChangeStatus.CONFIRMED)
+      })
+
+      it("keeps a non-draft delete pending for admin approval when PRODUCT_REQUEST is enabled", async () => {
+        const productId = await createVendorProduct(
+          "Proposed Keepme",
+          ProductStatus.PROPOSED,
+        )
+
+        const res = await api.delete(
+          `/vendor/products/${productId}`,
+          sellerHeaders,
+        )
+        expect(res.status).toBe(202)
+
+        // The product survives — the delete is awaiting operator approval.
+        const got = await api.get(
+          `/vendor/products/${productId}`,
+          sellerHeaders,
+        )
+        expect(got.status).toBe(200)
+
+        const deleteChange = await findDeleteChange(productId)
+        expect(deleteChange).toBeDefined()
+        expect(deleteChange!.status).toBe(ProductChangeStatus.PENDING)
+      })
+    })
+  },
+})

--- a/packages/core/src/workflows/product-edit/workflows/auto-confirm-product-change.ts
+++ b/packages/core/src/workflows/product-edit/workflows/auto-confirm-product-change.ts
@@ -13,18 +13,24 @@ import { confirmProductChangeWorkflow } from "./confirm-product-change"
 export type AutoConfirmProductChangeWorkflowInput = {
   change_id: string
   confirmed_by?: string
+  /**
+   * Force inline confirmation even when `PRODUCT_REQUEST` is enabled.
+   * Used for changes that should never enter the approval queue — e.g.
+   * deleting a `draft` product the seller never submitted for review.
+   */
+  force?: boolean
 }
 
 export const autoConfirmProductChangeWorkflowId = "auto-confirm-product-change"
 
 /**
  * Runs `confirmProductChangeWorkflow` inline when the
- * `PRODUCT_REQUEST` feature flag is disabled. Lets the seller's edit
- * staging workflows always create a `ProductChange`; the change is
- * either left pending for admin approval (flag on) or auto-applied
- * (flag off). Marketplaces that don't need an approval queue toggle
- * `MEDUSA_FF_PRODUCT_REQUEST=false` and get direct-mutation UX without
- * the routes diverging.
+ * `PRODUCT_REQUEST` feature flag is disabled, or when the caller passes
+ * `force: true`. Lets the seller's edit staging workflows always create
+ * a `ProductChange`; the change is either left pending for admin
+ * approval (flag on) or auto-applied (flag off / forced). Marketplaces
+ * that don't need an approval queue toggle `MEDUSA_FF_PRODUCT_REQUEST=false`
+ * and get direct-mutation UX without the routes diverging.
  */
 export const autoConfirmProductChangeWorkflow: ReturnWorkflow<
   AutoConfirmProductChangeWorkflowInput,
@@ -35,7 +41,9 @@ export const autoConfirmProductChangeWorkflow: ReturnWorkflow<
   function (input: AutoConfirmProductChangeWorkflowInput) {
     when(
       { input },
-      () => !FeatureFlag.isFeatureEnabled(MercurFeatureFlags.PRODUCT_REQUEST),
+      ({ input }) =>
+        Boolean(input.force) ||
+        !FeatureFlag.isFeatureEnabled(MercurFeatureFlags.PRODUCT_REQUEST),
     ).then(() => {
       confirmProductChangeWorkflow.runAsStep({
         input: transform({ input }, ({ input }) => ({

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-delete-product.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-delete-product.ts
@@ -5,9 +5,11 @@ import {
   WorkflowResponse,
   type ReturnWorkflow,
 } from "@medusajs/framework/workflows-sdk"
+import { useQueryGraphStep } from "@medusajs/medusa/core-flows"
 import {
   ProductChangeActionType,
   ProductChangeDTO,
+  ProductStatus,
 } from "@mercurjs/types"
 
 import { validateNoPendingProductChangeStep } from "../steps"
@@ -27,6 +29,11 @@ export const productEditDeleteProductWorkflowId =
  * which dispatches through `autoConfirmProductChangeWorkflow` —
  * either leaves it pending for admin approval (flag on) or applies it
  * inline (flag off).
+ *
+ * **Drafts skip the queue.** A `draft` product was never submitted for
+ * review, so there is nothing for an operator to approve. The staged
+ * change is force-confirmed inline (via `auto_confirm`) regardless of
+ * the `PRODUCT_REQUEST` flag, so the seller can delete it immediately.
  */
 export const productEditDeleteProductWorkflow: ReturnWorkflow<
   ProductEditDeleteProductWorkflowInput,
@@ -41,10 +48,18 @@ export const productEditDeleteProductWorkflow: ReturnWorkflow<
       })),
     )
 
+    const { data: products } = useQueryGraphStep({
+      entity: "product",
+      fields: ["id", "status"],
+      filters: { id: input.product_id },
+      options: { throwIfKeyNotFound: true },
+    }).config({ name: "delete-load-product" })
+
     const change = stageProductChangeWorkflow.runAsStep({
-      input: transform({ input }, ({ input }) => ({
+      input: transform({ input, products }, ({ input, products }) => ({
         product_id: input.product_id,
         created_by: input.created_by,
+        auto_confirm: products[0]?.status === ProductStatus.DRAFT,
         actions: [
           {
             product_id: input.product_id,

--- a/packages/core/src/workflows/product-edit/workflows/stage-product-change.ts
+++ b/packages/core/src/workflows/product-edit/workflows/stage-product-change.ts
@@ -36,6 +36,12 @@ export type StageProductChangeWorkflowInput = {
   >
   internal_note?: string
   external_note?: string
+  /**
+   * Force inline confirmation regardless of the `PRODUCT_REQUEST`
+   * feature flag. Forwarded to `autoConfirmProductChangeWorkflow`.
+   * Used by `productEditDeleteProductWorkflow` for `draft` products.
+   */
+  auto_confirm?: boolean
 }
 
 export const stageProductChangeWorkflowId = "stage-product-change"
@@ -96,6 +102,7 @@ export const stageProductChangeWorkflow = createWorkflow(
       input: transform({ changes, input }, ({ changes, input }) => ({
         change_id: changes[0]?.id as string,
         confirmed_by: input.created_by,
+        force: input.auto_confirm,
       })),
     })
 


### PR DESCRIPTION
## Summary
- A vendor deleting a `draft` product they never submitted for review had the delete staged as a **PENDING** `ProductChange` requiring operator approval whenever `PRODUCT_REQUEST` is enabled — so they couldn't remove their own unsubmitted product.
- `productEditDeleteProductWorkflow` now loads the product status and **force-confirms the staged delete inline for `draft` products**, via a new `auto_confirm` flag threaded through `stageProductChangeWorkflow` → `autoConfirmProductChangeWorkflow`.
- Non-draft deletes (`proposed`/`published`) still enter the approval queue when the flag is on. The flag-off path is unchanged.

## Linear
[MER-181](https://linear.app/rigbyjs/issue/MER-181)

## Test plan
- [x] New spec `integration-tests/http/product-edit/vendor/product-edit-draft-delete.spec.ts` runs with `MEDUSA_FF_PRODUCT_REQUEST=true` and asserts:
  - deleting a `draft` product applies inline (product `404`, change `CONFIRMED`)
  - deleting a `proposed` product stays `PENDING` (product preserved) — proving the flag is genuinely on and only drafts bypass the queue
- [x] `bun run build`
- [x] `bun run test:integration:http -- product-edit` (3 suites, 18 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)