### PR TITLE
fix(vendor): correct orders sort label and pre-select default sort

### DIFF
--- a/packages/vendor/src/components/table/data-table/data-table-order-by/data-table-order-by.tsx
+++ b/packages/vendor/src/components/table/data-table/data-table-order-by/data-table-order-by.tsx
@@ -33,11 +33,11 @@ const initState = (
   defaultKey?: string,
 ): SortState => {
   const param = prefix ? `${prefix}_order` : "order"
-  const sortParam = params.get(param)
+  const sortParam = params.get(param) ?? defaultKey
 
   if (!sortParam) {
     return {
-      key: defaultKey,
+      key: undefined,
       dir: SortDirection.ASC,
     }
   }

--- a/packages/vendor/src/hooks/table/query/use-order-table-query.tsx
+++ b/packages/vendor/src/hooks/table/query/use-order-table-query.tsx
@@ -39,7 +39,7 @@ export const useOrderTableQuery = ({
     request: request?.split(","),
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,
-    order: order ? order : "-created_at",
+    order: order ? order : "-display_id",
     q,
   };
 

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1872,7 +1872,7 @@
       }
     },
     "fields": {
-      "displayId": "Display ID",
+      "displayId": "Order ID",
       "refundableAmount": "Refundable amount",
       "returnableQuantity": "Returnable quantity"
     }

--- a/packages/vendor/src/pages/orders/_components/order-list-table/order-list-data-table.tsx
+++ b/packages/vendor/src/pages/orders/_components/order-list-table/order-list-data-table.tsx
@@ -73,6 +73,7 @@ export const OrderListDataTable = () => {
           label: t("fields.updatedAt"),
         },
       ]}
+      defaultOrderBy="-display_id"
       queryObject={raw}
       noRecords={{
         message: t("orders.list.noRecordsMessage"),


### PR DESCRIPTION
## Summary
- Rename the first orders sort option from **"Display ID"** to **"Order ID"** (vendor Orders list + customer detail orders section share the key).
- Pre-select the default sort option in the dropdown so it's no longer empty — defaults to **Order ID, Descending** per the design.
- Align the orders query default (`-created_at` → `-display_id`) so the highlighted option matches the list's actual order.

`DataTableOrderBy` now treats `defaultOrderBy` as a sort token, so a `-` prefix expresses a descending default. Fully backward compatible: existing `defaultOrderBy="title"` usages (products, offers) stay ascending; tables with no default stay unselected.

## Linear
[MER-186](https://linear.app/rigbyjs/issue/MER-186)

## Design
Matches the [Figma reference](https://www.figma.com/design/sYJoh84Owr5tomRjpxG0no/-Mercur-2.0----Vendor-Panel?node-id=40013324-305310) — sort menu shows "Order ID" selected with "Descending" by default.

## Test plan
- [ ] Open vendor Orders page → sort dropdown shows **Order ID** + **Descending** pre-selected; list is sorted newest-first.
- [ ] First sort option reads **"Order ID"** (not "Display ID").
- [ ] Products/Offers lists still default to **Title, Ascending** (no regression).
- [x] `bun run lint` (changed files clean; only pre-existing unrelated errors remain)
- [x] `bun run build` (9/9 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)