### PR TITLE
fix(vendor): allocate items checkboxes, prefill and false-success bug

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -6743,10 +6743,14 @@
               "properties": {
                 "quantityNotAllocated": {
                   "type": "string"
+                },
+                "noItemsSelected": {
+                  "type": "string"
                 }
               },
               "required": [
-                "quantityNotAllocated"
+                "quantityNotAllocated",
+                "noItemsSelected"
               ],
               "additionalProperties": false
             }

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1693,9 +1693,9 @@
     "allocateItems": {
       "action": "Allocate items",
       "title": "Allocate order items",
-      "locationDescription": "Choose which location you want to allocate from.",
+      "locationDescription": "Choose which location you want to allocate items from",
       "itemsToAllocate": "Items to allocate",
-      "itemsToAllocateDesc": "Select the number of items you wish to allocate",
+      "itemsToAllocateDesc": "Choose items and quantities to allocate",
       "search": "Search items",
       "consistsOf": "Consists of {{num}}x inventory items",
       "requires": "Requires {{num}} per variant",
@@ -1704,7 +1704,8 @@
         "error": "Failed to allocate following items: {{items}}"
       },
       "error": {
-        "quantityNotAllocated": "There are unallocated items."
+        "quantityNotAllocated": "There are unallocated items.",
+        "noItemsSelected": "Select at least one item to allocate."
       }
     },
     "shipment": {

--- a/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/constants.ts
+++ b/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/constants.ts
@@ -3,4 +3,7 @@ import { z } from "zod"
 export const AllocateItemsSchema = z.object({
   location_id: z.string(),
   quantity: z.record(z.string(), z.number().or(z.string())),
+  // Keyed by line item id. Defaults to selected; deselected items are
+  // excluded from the allocation payload.
+  selected: z.record(z.string(), z.boolean()),
 })

--- a/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/order-allocate-items-form.tsx
+++ b/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/order-allocate-items-form.tsx
@@ -15,13 +15,15 @@ import { ordersQueryKeys } from "@hooks/api/orders"
 import { useCreateReservationItem } from "@hooks/api/reservations"
 import { useStockLocations } from "@hooks/api/stock-locations"
 import { queryClient } from "@lib/query-client"
+import { getFulfillableQuantity } from "@lib/order-item"
 import { AllocateItemsSchema } from "./constants"
 import {
   OrderAllocateItemsItem,
   type OfferLinkRow,
   type OrderLineItemWithOffer,
 } from "./order-allocate-items-item"
-import type { HttpTypes } from "@medusajs/types"
+import { buildAllocationPayload } from "./utils"
+import type { HttpTypes, OrderLineItemDTO } from "@medusajs/types"
 
 type OrderAllocateItemsFormProps = {
   order: HttpTypes.AdminOrder
@@ -59,6 +61,7 @@ export function OrderAllocateItemsForm({ order }: OrderAllocateItemsFormProps) {
     defaultValues: {
       location_id: "",
       quantity: defaultAllocations(itemsToAllocate),
+      selected: defaultSelected(itemsToAllocate),
     },
     resolver: zodResolver(AllocateItemsSchema),
   })
@@ -67,25 +70,26 @@ export function OrderAllocateItemsForm({ order }: OrderAllocateItemsFormProps) {
 
   const handleSubmit = form.handleSubmit(async (data) => {
     try {
-      const payload = Object.entries(data.quantity)
-        .filter(([key]) => !key.endsWith("-"))
-        .map(([key, quantity]) => [...key.split("-"), quantity])
+      const result = buildAllocationPayload(data.quantity, data.selected)
 
-      if (payload.some((d) => d[2] === "")) {
+      if (!result.ok) {
         form.setError("root.quantityNotAllocated", {
           type: "manual",
-          message: t("orders.allocateItems.error.quantityNotAllocated"),
+          message:
+            result.reason === "no-items"
+              ? t("orders.allocateItems.error.noItemsSelected")
+              : t("orders.allocateItems.error.quantityNotAllocated"),
         })
 
         return
       }
 
-      const promises = payload.map(([itemId, inventoryId, quantity]) =>
+      const promises = result.items.map((item) =>
         allocateItems({
           location_id: data.location_id,
-          inventory_item_id: String(inventoryId),
-          line_item_id: String(itemId),
-          quantity: typeof quantity === 'string' ? Number(quantity) : quantity,
+          inventory_item_id: item.inventory_item_id,
+          line_item_id: item.line_item_id,
+          quantity: item.quantity,
         })
       )
 
@@ -109,6 +113,11 @@ export function OrderAllocateItemsForm({ order }: OrderAllocateItemsFormProps) {
       })
     }
   })
+
+  const onToggleSelected = (itemId: string, checked: boolean) => {
+    form.setValue(`selected.${itemId}` as `selected.${string}`, checked)
+    form.clearErrors("root.quantityNotAllocated")
+  }
 
   const onQuantityChange = (
     link: OfferLinkRow,
@@ -180,7 +189,10 @@ export function OrderAllocateItemsForm({ order }: OrderAllocateItemsFormProps) {
 
   useEffect(() => {
     if (selectedLocationId) {
-      form.setValue("quantity", defaultAllocations(itemsToAllocate))
+      form.setValue(
+        "quantity",
+        defaultAllocations(itemsToAllocate, selectedLocationId)
+      )
     }
   }, [
 	selectedLocationId,
@@ -270,7 +282,7 @@ export function OrderAllocateItemsForm({ order }: OrderAllocateItemsFormProps) {
                       </Alert>
                     )}
 
-                    <div className="flex flex-col gap-y-1">
+                    <div className="flex flex-col gap-y-2">
                       {filteredItems.map((item) => (
                         <OrderAllocateItemsItem
                           key={item.id}
@@ -278,6 +290,7 @@ export function OrderAllocateItemsForm({ order }: OrderAllocateItemsFormProps) {
                           item={item}
                           locationId={selectedLocationId}
                           onQuantityChange={onQuantityChange}
+                          onToggleSelected={onToggleSelected}
                         />
                       ))}
                     </div>
@@ -312,27 +325,74 @@ export function OrderAllocateItemsForm({ order }: OrderAllocateItemsFormProps) {
 const resolveInventoryItemId = (link: OfferLinkRow): string | null =>
   link.inventory_item?.id ?? link.inventory_item_id ?? null
 
-function defaultAllocations(items: OrderLineItemWithOffer[]) {
+// Clamp a desired quantity to what is actually available at the chosen
+// location so the prefill never proposes more than can be reserved. Until a
+// location is picked there is nothing to clamp against, so the raw value is
+// returned.
+const clampToAvailable = (
+  desired: number,
+  link: OfferLinkRow,
+  locationId?: string
+): number => {
+  if (!locationId) {
+    return desired
+  }
+
+  const level = link.inventory_item?.location_levels?.find(
+    (l) => l.location_id === locationId
+  )
+  const available = level?.available_quantity ?? Number.MAX_SAFE_INTEGER
+
+  return Math.max(0, Math.min(desired, available))
+}
+
+// Prefill each allocatable row with its outstanding (fulfillable) quantity so
+// the default state is a valid, one-click allocation. Kit roots keep the
+// trailing-dash aggregator key (UI only); child rows are scaled by the kit's
+// required quantity.
+function defaultAllocations(
+  items: OrderLineItemWithOffer[],
+  locationId?: string
+) {
   const ret: Record<string, string | number> = {}
 
   items.forEach((item) => {
     const links = item.offer?.inventory_item_link ?? []
     const hasInventoryKit = links.length > 1
-    const firstInventoryItemId = resolveInventoryItemId(links[0] ?? {})
-
-    ret[
-      hasInventoryKit
-        ? `${item.id}-`
-        : `${item.id}-${firstInventoryItemId ?? ""}`
-    ] = ""
+    const firstLink = links[0]
+    const firstInventoryItemId = resolveInventoryItemId(firstLink ?? {})
+    const fulfillable = getFulfillableQuantity(
+      item as unknown as OrderLineItemDTO
+    )
 
     if (hasInventoryKit) {
+      ret[`${item.id}-`] = fulfillable
       links.forEach((link) => {
         const id = resolveInventoryItemId(link)
-        if (id) ret[`${item.id}-${id}`] = ""
+        if (!id) return
+        const required = link.required_quantity ?? 1
+        ret[`${item.id}-${id}`] = clampToAvailable(
+          fulfillable * required,
+          link,
+          locationId
+        )
       })
+    } else {
+      ret[`${item.id}-${firstInventoryItemId ?? ""}`] = clampToAvailable(
+        fulfillable,
+        firstLink ?? {},
+        locationId
+      )
     }
   })
 
+  return ret
+}
+
+function defaultSelected(items: OrderLineItemWithOffer[]) {
+  const ret: Record<string, boolean> = {}
+  items.forEach((item) => {
+    ret[item.id] = true
+  })
   return ret
 }

--- a/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/order-allocate-items-item.tsx
+++ b/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/order-allocate-items-item.tsx
@@ -6,7 +6,7 @@ import {
   TriangleDownMini,
 } from "@medusajs/icons"
 import { UseFormReturn, useWatch } from "react-hook-form"
-import { Input, Text, clx } from "@medusajs/ui"
+import { Checkbox, Input, Text, clx } from "@medusajs/ui"
 import * as zod from "zod"
 import type { AdminOrderLineItem, OrderLineItemDTO } from "@medusajs/types"
 
@@ -55,6 +55,7 @@ type OrderEditItemProps = {
     value: number | null,
     isRoot?: boolean
   ) => void
+  onToggleSelected: (itemId: string, checked: boolean) => void
 }
 
 const resolveInventoryItemId = (link: OfferLinkRow): string | null =>
@@ -65,6 +66,7 @@ export function OrderAllocateItemsItem({
   form,
   locationId,
   onQuantityChange,
+  onToggleSelected,
 }: OrderEditItemProps) {
   const { t } = useTranslation()
   const inventoryLinks = item.offer?.inventory_item_link ?? []
@@ -75,6 +77,12 @@ export function OrderAllocateItemsItem({
     control: form.control,
     name: "quantity",
   })
+
+  const isSelected =
+    useWatch({
+      control: form.control,
+      name: `selected.${item.id}` as `selected.${string}`,
+    }) !== false
 
   const hasInventoryKit = inventoryLinks.length > 1
   const firstLink = inventoryLinks[0]
@@ -118,8 +126,18 @@ export function OrderAllocateItemsItem({
   )
 
   return (
-    <div className="bg-ui-bg-subtle shadow-elevation-card-rest my-2 min-w-[720px] divide-y divide-dashed rounded-xl">
+    <div
+      className={clx(
+        "bg-ui-bg-subtle shadow-elevation-card-rest min-w-[720px] divide-y divide-dashed rounded-xl",
+        !isSelected && "opacity-60"
+      )}
+    >
       <div className="flex items-center gap-x-3 p-3 text-sm">
+        <Checkbox
+          checked={isSelected}
+          onCheckedChange={(value) => onToggleSelected(item.id, value === true)}
+          data-testid={`allocate-item-${item.id}-checkbox`}
+        />
         <div className="flex flex-1 items-center">
           <div className="flex items-center gap-x-3">
             {hasQuantityError && (
@@ -127,18 +145,22 @@ export function OrderAllocateItemsItem({
             )}
             <Thumbnail src={item.thumbnail} />
             <div className="flex flex-col">
-              <div className="flex flex-row">
-                <Text className="txt-small flex" as="span" weight="plus">
+              <div className="flex flex-row items-center gap-x-1">
+                <Text size="small" weight="plus" as="span">
                   {item.product_title}
                 </Text>
                 {(item.offer?.sku ?? item.variant_sku) && (
-                  <span className="text-ui-fg-subtle">
-                    {" "}
+                  <Text
+                    size="small"
+                    weight="plus"
+                    as="span"
+                    className="text-ui-fg-subtle"
+                  >
                     ({item.offer?.sku ?? item.variant_sku})
-                  </span>
+                  </Text>
                 )}
                 {hasInventoryKit && (
-                  <Component className="text-ui-fg-muted ml-2 overflow-visible pt-[2px]" />
+                  <Component className="text-ui-fg-muted ml-1 overflow-visible" />
                 )}
               </div>
               <Text as="div" className="text-ui-fg-subtle txt-small">
@@ -217,7 +239,7 @@ export function OrderAllocateItemsItem({
                           className="bg-ui-bg-base txt-small w-[46px] rounded-lg text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                           type="number"
                           {...field}
-                          disabled={!locationId}
+                          disabled={!locationId || !isSelected}
                           onChange={(e) => {
                             const val =
                               e.target.value === ""
@@ -357,7 +379,7 @@ export function OrderAllocateItemsItem({
                                 className="bg-ui-bg-base txt-small w-[46px] rounded-lg text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
                                 type="number"
                                 {...field}
-                                disabled={!locationId}
+                                disabled={!locationId || !isSelected}
                                 onChange={(e) => {
                                   const val =
                                     e.target.value === ""

--- a/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/utils.spec.ts
+++ b/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/utils.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest"
+
+import { buildAllocationPayload } from "./utils"
+
+describe("buildAllocationPayload", () => {
+  // MER-187: the allocate form used to report success while reserving nothing
+  // whenever the resolved payload was empty.
+  test("returns no-items for an empty quantity map (false-success regression)", () => {
+    expect(buildAllocationPayload({}, {})).toEqual({
+      ok: false,
+      reason: "no-items",
+    })
+  })
+
+  test("returns no-items when every line item is deselected", () => {
+    expect(
+      buildAllocationPayload({ "li_1-iitem_1": 2 }, { li_1: false })
+    ).toEqual({ ok: false, reason: "no-items" })
+  })
+
+  test("treats an undefined selection as selected", () => {
+    const result = buildAllocationPayload({ "li_1-iitem_1": 2 }, {})
+
+    expect(result).toEqual({
+      ok: true,
+      items: [{ line_item_id: "li_1", inventory_item_id: "iitem_1", quantity: 2 }],
+    })
+  })
+
+  test("drops the kit root aggregator key but keeps its inventory rows", () => {
+    const result = buildAllocationPayload(
+      { "li_1-": 3, "li_1-iitem_1": 2, "li_1-iitem_2": 1 },
+      { li_1: true }
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      items: [
+        { line_item_id: "li_1", inventory_item_id: "iitem_1", quantity: 2 },
+        { line_item_id: "li_1", inventory_item_id: "iitem_2", quantity: 1 },
+      ],
+    })
+  })
+
+  test("rejects empty, zero, and non-numeric quantities", () => {
+    expect(buildAllocationPayload({ "li_1-iitem_1": "" }, {}).ok).toBe(false)
+    expect(buildAllocationPayload({ "li_1-iitem_1": 0 }, {}).ok).toBe(false)
+    expect(buildAllocationPayload({ "li_1-iitem_1": "abc" }, {}).ok).toBe(false)
+  })
+
+  test("excludes only the deselected line items", () => {
+    const result = buildAllocationPayload(
+      { "li_1-iitem_1": 2, "li_2-iitem_2": 5 },
+      { li_1: false, li_2: true }
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      items: [{ line_item_id: "li_2", inventory_item_id: "iitem_2", quantity: 5 }],
+    })
+  })
+
+  test("coerces numeric strings to numbers", () => {
+    expect(buildAllocationPayload({ "li_1-iitem_1": "3" }, {})).toEqual({
+      ok: true,
+      items: [{ line_item_id: "li_1", inventory_item_id: "iitem_1", quantity: 3 }],
+    })
+  })
+})

--- a/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/utils.ts
+++ b/packages/vendor/src/pages/orders/[id]/allocate-items/order-create-fulfillment-form/utils.ts
@@ -1,0 +1,70 @@
+export type AllocationQuantityMap = Record<string, number | string>
+export type AllocationSelectedMap = Record<string, boolean>
+
+export type AllocationLineInput = {
+  line_item_id: string
+  inventory_item_id: string
+  quantity: number
+}
+
+export type BuildAllocationResult =
+  | { ok: true; items: AllocationLineInput[] }
+  | { ok: false; reason: "no-items" | "invalid-quantity" }
+
+/**
+ * Turns the form's `quantity` / `selected` maps into the list of reservations
+ * to create.
+ *
+ * Quantity keys are `${lineItemId}-${inventoryItemId}`. Inventory kits also
+ * store a root aggregator under `${lineItemId}-` (trailing dash) that only
+ * drives the UI — it must never become a reservation, so it is dropped here.
+ *
+ * Regression guard (MER-187): the previous implementation built the payload
+ * inline and only bailed out when a quantity was an empty string. An empty
+ * payload (no rows, or every item deselected) slipped through `[].some(...)`,
+ * `Promise.all([])` resolved, and the form reported a successful allocation
+ * while nothing was reserved. Returning an explicit `ok: false` makes the
+ * caller surface an error instead of a false success.
+ */
+export function buildAllocationPayload(
+  quantity: AllocationQuantityMap,
+  selected: AllocationSelectedMap
+): BuildAllocationResult {
+  const rows = Object.entries(quantity)
+    .filter(([key]) => !key.endsWith("-"))
+    .map(([key, value]) => {
+      const separatorIndex = key.indexOf("-")
+      return {
+        lineItemId: key.slice(0, separatorIndex),
+        inventoryItemId: key.slice(separatorIndex + 1),
+        value,
+      }
+    })
+    // Default (undefined) is selected; only an explicit `false` deselects.
+    .filter((row) => selected[row.lineItemId] !== false)
+
+  if (rows.length === 0) {
+    return { ok: false, reason: "no-items" }
+  }
+
+  const items: AllocationLineInput[] = []
+
+  for (const row of rows) {
+    if (row.value === "" || row.value === null || row.value === undefined) {
+      return { ok: false, reason: "invalid-quantity" }
+    }
+
+    const quantityNumber = Number(row.value)
+    if (!Number.isFinite(quantityNumber) || quantityNumber <= 0) {
+      return { ok: false, reason: "invalid-quantity" }
+    }
+
+    items.push({
+      line_item_id: row.lineItemId,
+      inventory_item_id: row.inventoryItemId,
+      quantity: quantityNumber,
+    })
+  }
+
+  return { ok: true, items }
+}


### PR DESCRIPTION
## Summary
- Reworks the vendor order **Allocate items** modal to fix MER-187.
- **Checkboxes (selected by default):** each item row now has a checkbox; deselecting excludes the item (and its kit children) from the allocation payload, dims the card, and disables its inputs.
- **Prefill + one-click allocate:** rows default to their outstanding (fulfillable) quantity, clamped to the available stock at the chosen location.
- **False-success bug:** an empty payload (no rows, or every item deselected) previously slipped through `[].some(...)`, resolved `Promise.all([])`, and toasted *success* while reserving nothing. Payload building now lives in a pure, unit-tested helper (`buildAllocationPayload`) that returns an explicit failure, and key parsing uses `indexOf("-")` instead of `split("-")` for robustness.
- **Copy + UI:** location hint → "Choose which location you want to allocate items from"; items hint → "Choose items and quantities to allocate"; item name/SKU now share typography with spacing between them; inter-block spacing tightened to 8px.

## Linear
[MER-187](https://linear.app/rigbyjs/issue/MER-187/orders-allocate-items)

## Test plan
- [x] `buildAllocationPayload` unit tests (7) — empty/all-deselected → no success, kit-root key dropped, partial deselection, numeric coercion: `npx vitest run --dir packages/vendor/src/pages/orders`
- [x] `bun run build` (vendor) — ESM + DTS typecheck pass
- [x] `oxlint` clean on changed files
- [ ] Manual: open an order with allocatable items in the Vendor panel → **Allocate items**, pick a location, confirm quantities prefill, deselect one item, allocate, and verify the order shows the remaining items as **Allocated**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)