### PR TITLE
fix(products): show edited variant identity and diff variant options

### DIFF
--- a/integration-tests/http/product-edit/vendor/product-edit.spec.ts
+++ b/integration-tests/http/product-edit/vendor/product-edit.spec.ts
@@ -411,6 +411,115 @@ medusaIntegrationTestRunner({
           )
           expect(updates).toHaveLength(0)
         })
+
+        // Creates a product whose single variant sits on a variant axis, so
+        // the variant carries real Medusa `options`. Returns the applied
+        // variant id and its current `{ option_title: value }` map.
+        const createProductWithVariantOptions = async (
+          title: string,
+          tag: string,
+        ): Promise<{
+          productId: string
+          variantId: string
+          currentOptions: Record<string, string>
+        }> => {
+          const product = (
+            await api.post(
+              `/vendor/products`,
+              {
+                status: "published",
+                title,
+                variant_attributes: [
+                  {
+                    name: `Color${tag}`,
+                    type: "multi_select",
+                    values: ["Red", "Blue"],
+                    is_variant_axis: true,
+                  },
+                ],
+                variants: [
+                  {
+                    title: "Red Variant",
+                    sku: `OPT-${tag}`,
+                    attribute_values: { [`Color${tag}`]: "Red" },
+                  },
+                ],
+              },
+              sellerHeaders,
+            )
+          ).data.product
+
+          const variantId = product.variants[0].id as string
+
+          const query = container.resolve(ContainerRegistrationKeys.QUERY)
+          const {
+            data: [loaded],
+          } = await query.graph({
+            entity: "variant",
+            fields: ["id", "options.value", "options.option.title"],
+            filters: { id: variantId },
+          })
+
+          const currentOptions = (
+            (loaded.options ?? []) as Array<{
+              value?: string
+              option?: { title?: string }
+            }>
+          ).reduce<Record<string, string>>((acc, o) => {
+            if (o.option?.title) acc[o.option.title] = o.value ?? ""
+            return acc
+          }, {})
+
+          // Guard: the test only means something if the axis synthesized a
+          // real variant option to diff against.
+          expect(Object.keys(currentOptions).length).toBeGreaterThan(0)
+
+          return { productId: product.id, variantId, currentOptions }
+        }
+
+        it("does not stage options when the variant options are unchanged (MER-168)", async () => {
+          const { productId, variantId, currentOptions } =
+            await createProductWithVariantOptions("Options Unchanged", "U1")
+
+          const res = await api.post(
+            `/vendor/products/${productId}/variants/${variantId}`,
+            // The edit form always re-submits `options`; only the sku changed.
+            { title: "Red Variant", sku: "OPT-CHANGED", options: currentOptions },
+            sellerHeaders,
+          )
+
+          expect(res.status).toBe(202)
+          const update = (res.data.product_change.actions as Array<any>).find(
+            (a) => a.action === ProductChangeActionType.VARIANT_UPDATE,
+          )
+          expect(update).toBeDefined()
+          expect(Object.keys(update.details.fields)).toEqual(["sku"])
+          expect(update.details.fields).not.toHaveProperty("options")
+        })
+
+        it("stages options when an option value actually changed (MER-168)", async () => {
+          const { productId, variantId, currentOptions } =
+            await createProductWithVariantOptions("Options Changed", "C1")
+
+          const [optionTitle] = Object.keys(currentOptions)
+          const changedOptions = { ...currentOptions, [optionTitle]: "Blue" }
+
+          const res = await api.post(
+            `/vendor/products/${productId}/variants/${variantId}`,
+            { title: "Red Variant", options: changedOptions },
+            sellerHeaders,
+          )
+
+          expect(res.status).toBe(202)
+          const update = (res.data.product_change.actions as Array<any>).find(
+            (a) => a.action === ProductChangeActionType.VARIANT_UPDATE,
+          )
+          expect(update).toBeDefined()
+          expect(update.details.fields).toHaveProperty("options")
+          expect(update.details.fields.options[optionTitle]).toBe("Blue")
+          // The previous map is carried for the before/after render.
+          expect(update.details.previous_fields.options).toEqual(currentOptions)
+        })
       })
     })
   },

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-variants.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-variants.ts
@@ -120,6 +120,11 @@ export const productEditUpdateVariantsWorkflow: ReturnWorkflow<
         "material",
         "variant_rank",
         "metadata",
+        // Loaded so an unchanged `options` payload is diffed away rather
+        // than re-staged on every edit (MER-168). `options` arrives as a
+        // `{ [option_title]: value }` map; rebuild the same shape from these.
+        "options.value",
+        "options.option.title",
       ],
       filters: { id: variantIdsToLoad },
     }).config({ name: "pc-load-variants-for-diff" })
@@ -164,6 +169,45 @@ export const productEditUpdateVariantsWorkflow: ReturnWorkflow<
         const isEqual = (a: unknown, b: unknown): boolean =>
           JSON.stringify(normalize(a)) === JSON.stringify(normalize(b))
 
+        // Reduce a value to a stable `{ option_title: value }` map for
+        // comparison. The proposed payload is already that shape; the
+        // current variant carries `options: [{ value, option: { title } }]`.
+        const toOptionsMap = (value: unknown): Record<string, string> => {
+          const out: Record<string, string> = {}
+          if (Array.isArray(value)) {
+            for (const entry of value) {
+              const title = (entry as { option?: { title?: string } })?.option
+                ?.title
+              if (title) {
+                out[title] = String(
+                  (entry as { value?: unknown })?.value ?? "",
+                )
+              }
+            }
+          } else if (value && typeof value === "object") {
+            for (const [k, v] of Object.entries(
+              value as Record<string, unknown>,
+            )) {
+              out[k] = String(v ?? "")
+            }
+          }
+          return out
+        }
+
+        // Order-independent equality for the options map.
+        const optionsEqual = (
+          a: Record<string, string>,
+          b: Record<string, string>,
+        ): boolean => {
+          const stable = (m: Record<string, string>) =>
+            JSON.stringify(
+              Object.keys(m)
+                .sort()
+                .map((k) => [k, m[k]]),
+            )
+          return stable(a) === stable(b)
+        }
+
         for (const op of input.operations ?? []) {
           switch (op.type) {
             case "add":
@@ -186,13 +230,18 @@ export const productEditUpdateVariantsWorkflow: ReturnWorkflow<
                 if (NON_EDITABLE_VARIANT_FIELDS.has(field)) continue
 
                 // `options` is a relation update (option-title → value
-                // pairs), not a scalar column we load for diffing. Forward
-                // it untouched when provided so the apply step can re-pair
-                // variant options; it carries no meaningful previous value.
+                // pairs). Diff it against the variant's current options so an
+                // unchanged map (the form always re-submits it) never surfaces
+                // as a phantom change row (MER-168). Forward the proposed map
+                // verbatim when it actually differs so the apply step can
+                // re-pair variant options.
                 if (field === "options") {
-                  if (proposedValue !== undefined) {
-                    changedFields.options = proposedValue
-                  }
+                  if (proposedValue === undefined) continue
+                  const currentOptions = toOptionsMap(current.options)
+                  if (optionsEqual(currentOptions, toOptionsMap(proposedValue)))
+                    continue
+                  changedFields.options = proposedValue
+                  previousFields.options = currentOptions
                   continue
                 }
 

--- a/packages/dashboard-shared/src/lib/product-change-diff.ts
+++ b/packages/dashboard-shared/src/lib/product-change-diff.ts
@@ -103,7 +103,7 @@ export const formatFieldValue = (value: unknown, field?: string): string => {
   if (typeof value === "boolean") return value ? "True" : "False"
   if (typeof value === "string") return value
   if (typeof value === "number") return String(value)
-  if (field === "attribute_values") {
+  if (field === "attribute_values" || field === "options") {
     const pretty = formatAttributeValues(value)
     if (pretty) return pretty
   }

--- a/packages/vendor/src/pages/products/[id]/_components/product-active-edit-section/product-active-edit-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-active-edit-section/product-active-edit-section.tsx
@@ -23,11 +23,7 @@ import { useTranslation } from "react-i18next";
 import { Thumbnail } from "@components/common/thumbnail";
 import { useCollection } from "@hooks/api/collections";
 import { useProductCategory } from "@hooks/api/categories";
-import {
-  useCancelProductEdit,
-  useProductChange,
-  variantsQueryKeys,
-} from "@hooks/api/products";
+import { useCancelProductEdit, useProductChange } from "@hooks/api/products";
 import {
   productAttributesQueryKeys,
   useProductAttribute,
@@ -45,16 +41,12 @@ type VariantInfo = {
 
 type ProductForActiveEdit = {
   id: string;
+  variants?: (VariantInfo | null)[] | null;
 };
 
 type ProductActiveEditSectionProps = {
   product: ProductForActiveEdit;
 };
-
-// The product-detail query only loads `*variants.images` (id + images), not
-// the variant title/sku the identity row needs (MER-168). Fetch those per
-// referenced variant instead of reading them off `product.variants`.
-const VARIANT_LOOKUP_FIELDS = "id,title,sku,*images";
 
 const ImageStrip = ({
   images,
@@ -446,6 +438,16 @@ export const ProductActiveEditSection = ({
 
   const productId = product.id;
 
+  // The product-detail query carries variant identity (title · sku · images),
+  // so the request block resolves it inline — no extra per-variant fetch.
+  const variantsById = useMemo(() => {
+    const map = new Map<string, VariantInfo>();
+    for (const variant of product.variants ?? []) {
+      if (variant?.id) map.set(variant.id, variant);
+    }
+    return map;
+  }, [product.variants]);
+
   const { product_change, isError } = useProductChange(productId, {
     retry: false,
   });
@@ -497,49 +499,6 @@ export const ProductActiveEditSection = ({
 
   const isLoadingAttributes = attributeQueries.some((q) => q.isPending);
 
-  // Resolve the identity (title · sku · thumbnail) for every variant
-  // referenced by an update or removal. The product-detail query does not
-  // carry variant title/sku, so look them up directly (MER-168).
-  const variantIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const action of removed) {
-      if (action.action === ProductChangeActionType.VARIANT_REMOVE) {
-        const details = (action.details ?? {}) as { variant_id?: string };
-        if (details.variant_id) ids.add(details.variant_id);
-      }
-    }
-    for (const diff of updated) {
-      if (diff.variant_id) ids.add(diff.variant_id);
-    }
-    return Array.from(ids);
-  }, [removed, updated]);
-
-  const variantQueryInput = { fields: VARIANT_LOOKUP_FIELDS } as const;
-
-  const variantQueries = useQueries({
-    queries: variantIds.map((variantId) => ({
-      queryKey: variantsQueryKeys.detail(variantId, variantQueryInput),
-      queryFn: () =>
-        sdk.vendor.products.$id.variants.$variantId.query({
-          $id: productId,
-          $variantId: variantId,
-          ...variantQueryInput,
-        }),
-    })),
-  });
-
-  const isLoadingVariants = variantQueries.some((q) => q.isPending);
-
-  const variantsById = useMemo(() => {
-    const map = new Map<string, VariantInfo>();
-    for (const query of variantQueries) {
-      const variant = (query.data as { variant?: VariantInfo } | undefined)
-        ?.variant;
-      if (variant?.id) map.set(variant.id, variant);
-    }
-    return map;
-  }, [variantQueries]);
-
   const onCancel = async () => {
     const confirmed = await prompt({
       title: t("products.edits.panel.cancelTitle"),
@@ -566,7 +525,7 @@ export const ProductActiveEditSection = ({
     return null;
   }
 
-  if (isLoadingAttributes || isLoadingVariants) {
+  if (isLoadingAttributes) {
     return null;
   }
 

--- a/packages/vendor/src/pages/products/[id]/_components/product-active-edit-section/product-active-edit-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-active-edit-section/product-active-edit-section.tsx
@@ -23,7 +23,11 @@ import { useTranslation } from "react-i18next";
 import { Thumbnail } from "@components/common/thumbnail";
 import { useCollection } from "@hooks/api/collections";
 import { useProductCategory } from "@hooks/api/categories";
-import { useCancelProductEdit, useProductChange } from "@hooks/api/products";
+import {
+  useCancelProductEdit,
+  useProductChange,
+  variantsQueryKeys,
+} from "@hooks/api/products";
 import {
   productAttributesQueryKeys,
   useProductAttribute,
@@ -41,12 +45,16 @@ type VariantInfo = {
 
 type ProductForActiveEdit = {
   id: string;
-  variants?: (VariantInfo | null)[] | null;
 };
 
 type ProductActiveEditSectionProps = {
   product: ProductForActiveEdit;
 };
+
+// The product-detail query only loads `*variants.images` (id + images), not
+// the variant title/sku the identity row needs (MER-168). Fetch those per
+// referenced variant instead of reading them off `product.variants`.
+const VARIANT_LOOKUP_FIELDS = "id,title,sku,*images";
 
 const ImageStrip = ({
   images,
@@ -438,14 +446,6 @@ export const ProductActiveEditSection = ({
 
   const productId = product.id;
 
-  const variantsById = useMemo(() => {
-    const map = new Map<string, VariantInfo>();
-    for (const variant of product.variants ?? []) {
-      if (variant?.id) map.set(variant.id, variant);
-    }
-    return map;
-  }, [product.variants]);
-
   const { product_change, isError } = useProductChange(productId, {
     retry: false,
   });
@@ -497,6 +497,49 @@ export const ProductActiveEditSection = ({
 
   const isLoadingAttributes = attributeQueries.some((q) => q.isPending);
 
+  // Resolve the identity (title · sku · thumbnail) for every variant
+  // referenced by an update or removal. The product-detail query does not
+  // carry variant title/sku, so look them up directly (MER-168).
+  const variantIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const action of removed) {
+      if (action.action === ProductChangeActionType.VARIANT_REMOVE) {
+        const details = (action.details ?? {}) as { variant_id?: string };
+        if (details.variant_id) ids.add(details.variant_id);
+      }
+    }
+    for (const diff of updated) {
+      if (diff.variant_id) ids.add(diff.variant_id);
+    }
+    return Array.from(ids);
+  }, [removed, updated]);
+
+  const variantQueryInput = { fields: VARIANT_LOOKUP_FIELDS } as const;
+
+  const variantQueries = useQueries({
+    queries: variantIds.map((variantId) => ({
+      queryKey: variantsQueryKeys.detail(variantId, variantQueryInput),
+      queryFn: () =>
+        sdk.vendor.products.$id.variants.$variantId.query({
+          $id: productId,
+          $variantId: variantId,
+          ...variantQueryInput,
+        }),
+    })),
+  });
+
+  const isLoadingVariants = variantQueries.some((q) => q.isPending);
+
+  const variantsById = useMemo(() => {
+    const map = new Map<string, VariantInfo>();
+    for (const query of variantQueries) {
+      const variant = (query.data as { variant?: VariantInfo } | undefined)
+        ?.variant;
+      if (variant?.id) map.set(variant.id, variant);
+    }
+    return map;
+  }, [variantQueries]);
+
   const onCancel = async () => {
     const confirmed = await prompt({
       title: t("products.edits.panel.cancelTitle"),
@@ -523,7 +566,7 @@ export const ProductActiveEditSection = ({
     return null;
   }
 
-  if (isLoadingAttributes) {
+  if (isLoadingAttributes || isLoadingVariants) {
     return null;
   }
 

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -12,6 +12,9 @@ export const PRODUCT_VARIANT_IDS_KEY = "product_variant_ids"
  */
 export const PRODUCT_DETAIL_FIELDS = [
   "*variants.images",
+  // Variant identity used by the active edit-request block (MER-168).
+  "variants.title",
+  "variants.sku",
   "*categories",
   "+additional_data",
   "*scoped_attributes",


### PR DESCRIPTION
## Summary
Follow-up for the reopened MER-168 review. Two checks were still failing on the vendor edit-variant **Product update request** block:

- **Variant identity not shown** — the block read variant info from `product.variants`, but the product-detail query only loads `*variants.images` (id + images, no `title`/`sku`), so the identity row fell back to the raw variant id. Now mirrors the admin block and fetches each referenced variant with `id,title,sku,*images`, so the row renders `title · sku` (+ thumbnail).
- **Unedited `options` shown** — the staging workflow forwarded the form's `options` map verbatim, and the edit form always re-submits it, so changing only the SKU still produced a phantom "Options" row. The workflow now loads the variant's current options and diffs the map, staging `options` (with `previous_fields`) only when a value actually changed.

Also formats a changed `options` map as `Color: Red` instead of raw JSON.

## Linear
[MER-168](https://linear.app/rigbyjs/issue/MER-168)

## Test plan
- [x] `bun run build` (9/9)
- [x] `bun run test:integration:http -- product-edit/vendor/product-edit` (18/18, incl. 2 new options-diff tests)
- [ ] Manual: vendor edits a variant's SKU only → request block shows the variant (title · sku) and an "Updated" section with just the SKU row, no Options/Manage inventory.
- [ ] Manual: vendor changes a variant option value → "Updated" shows the option change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)