### PR TITLE
fix(orders): resolve claim/exchange request filter through order_change

### DIFF
--- a/integration-tests/http/order/vendor/order-list-filters.spec.ts
+++ b/integration-tests/http/order/vendor/order-list-filters.spec.ts
@@ -449,6 +449,119 @@ medusaIntegrationTestRunner({
                     ).toBe(false)
                 })
 
+                // Regression (MER-185): claim/exchange have no `status`
+                // column — their open state lives on `order_change`. The
+                // filter used to query the `order_claim`/`order_exchange`
+                // entities by `status`, which threw a 500. These assert the
+                // filter resolves cleanly (200 + empty/list), never a 500.
+                it("returns empty list when request=claim and no open claim exists", async () => {
+                    await completeCartCheckout(seller1Seed.offer.id)
+
+                    const response = await api.get(
+                        `/vendor/orders?request=claim`,
+                        seller1Seed.headers
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.orders.length).toEqual(0)
+                })
+
+                it("returns empty list when request=exchange and no open exchange exists", async () => {
+                    await completeCartCheckout(seller1Seed.offer.id)
+
+                    const response = await api.get(
+                        `/vendor/orders?request=exchange`,
+                        seller1Seed.headers
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.orders.length).toEqual(0)
+                })
+
+                it("does not 500 when request=claim,exchange are combined", async () => {
+                    await completeCartCheckout(seller1Seed.offer.id)
+
+                    const response = await api.get(
+                        `/vendor/orders?request=claim,exchange`,
+                        seller1Seed.headers
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(Array.isArray(response.data.orders)).toBe(true)
+                })
+
+                it("returns the order when request=claim and a claim is in progress", async () => {
+                    const order = await completeCartCheckout(seller1Seed.offer.id)
+
+                    await api.post(
+                        `/vendor/claims`,
+                        {
+                            type: "refund",
+                            order_id: order.id,
+                            description: "Damaged on arrival",
+                        },
+                        seller1Seed.headers
+                    )
+
+                    const response = await api.get(
+                        `/vendor/orders?request=claim`,
+                        seller1Seed.headers
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(
+                        response.data.orders.some(
+                            (o: any) => o.id === order.id
+                        )
+                    ).toBe(true)
+                })
+
+                it("returns the order when request=exchange and an exchange is in progress", async () => {
+                    const order = await completeCartCheckout(seller1Seed.offer.id)
+
+                    await api.post(
+                        `/vendor/exchanges`,
+                        {
+                            order_id: order.id,
+                            description: "Customer wants different size",
+                        },
+                        seller1Seed.headers
+                    )
+
+                    const response = await api.get(
+                        `/vendor/orders?request=exchange`,
+                        seller1Seed.headers
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(
+                        response.data.orders.some(
+                            (o: any) => o.id === order.id
+                        )
+                    ).toBe(true)
+                })
+
+                it("scopes claim filter to the owning seller", async () => {
+                    const orderA = await completeCartCheckout(seller1Seed.offer.id)
+                    await api.post(
+                        `/vendor/claims`,
+                        { type: "refund", order_id: orderA.id },
+                        seller1Seed.headers
+                    )
+
+                    const response = await api.get(
+                        `/vendor/orders?request=claim`,
+                        seller2Headers
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(
+                        response.data.orders.some(
+                            (o: any) => o.id === orderA.id
+                        )
+                    ).toBe(false)
+                })
+
                 it("rejects legacy has_open_request param (hard-swap regression)", async () => {
                     // Session (hh) swapped has_open_request → request. The
                     // Medusa query validator is strict (rejects unknown

--- a/packages/core/src/api/vendor/orders/apply-request-filter.ts
+++ b/packages/core/src/api/vendor/orders/apply-request-filter.ts
@@ -65,6 +65,11 @@ export const applyRequestFilter = async (
 
   const emptyResult = Promise.resolve({ data: [] as { order_id: string }[] })
 
+  // `return` carries its own `status` column, so it is queried directly.
+  // `order_claim`/`order_exchange` do NOT have a status field — their open
+  // state lives on the associated `order_change` row (change_type
+  // "claim"/"exchange"). Filtering those entities by status throws, so we
+  // resolve claim/exchange through `order_change`, exactly like "edit".
   const [editRes, returnRes, exchangeRes, claimRes] = await promiseAll([
     wantsEdit
       ? query.graph({
@@ -86,16 +91,24 @@ export const applyRequestFilter = async (
       : emptyResult,
     wantsExchange
       ? query.graph({
-          entity: "order_exchange",
+          entity: "order_change",
           fields: ["order_id"],
-          filters: { ...isRequestedStatus, order_id: sellerOrderIds },
+          filters: {
+            ...isOpenOrderChange,
+            change_type: "exchange",
+            order_id: sellerOrderIds,
+          },
         })
       : emptyResult,
     wantsClaim
       ? query.graph({
-          entity: "order_claim",
+          entity: "order_change",
           fields: ["order_id"],
-          filters: { ...isRequestedStatus, order_id: sellerOrderIds },
+          filters: {
+            ...isOpenOrderChange,
+            change_type: "claim",
+            order_id: sellerOrderIds,
+          },
         })
       : emptyResult,
   ])


### PR DESCRIPTION
## Summary
- The vendor Orders list `request` filter crashed with a **500** when filtering by **Claim** or **Exchange** (MER-185, part 2).
- Root cause: the filter queried the `order_claim` / `order_exchange` entities by a `status` field, but those entities have **no `status` column** (only `return` does). Their open/requested state lives on the associated `order_change` row (`change_type: "claim"` / `"exchange"`). Filtering a non-existent column threw → 500.
- Fix: resolve claim/exchange through `order_change` the same way the `edit` filter already does, so the filter returns a proper list / empty state instead of erroring.
- Added regression tests for `claim`, `exchange`, and combined `claim,exchange` (empty, positive, and seller-scoped cases).

> **Out of scope (pending product decision):** the ticket also lists missing **Payment** and **Fulfillment** filters. Those don't map to real filterable columns for split per-vendor orders (payment status lives on the parent payment-collection; fulfillment status is a computed/aggregated status, not an indexable field). Asked on the Linear ticket whether they can be split into a follow-up — not included here.

## Linear
[MER-185](https://linear.app/rigbyjs/issue/MER-185)

## Test plan
- [x] `bun run build`
- [x] `bun run lint` (no new errors in changed files; pre-existing failures unrelated)
- [x] `bun run test:integration:http -- order-list-filters.spec` → 17 passed
- [ ] Manually: vendor Orders → filter by request = Claim and Exchange → returns list/empty state, no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)