### PR TITLE
fix(vendor): use radio dot for required single-select attribute items

### DIFF
--- a/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
@@ -1,4 +1,4 @@
-import { CircleMiniFilledSolid, XMarkMini } from "@medusajs/icons";
+import { EllipseMiniSolid, XMarkMini } from "@medusajs/icons";
 import {
   Button,
   Heading,
@@ -523,7 +523,7 @@ const RadioSelectItem = forwardRef<
   >
     <span className="flex h-[15px] w-[15px] items-center justify-center">
       <RadixSelect.ItemIndicator className="flex items-center justify-center">
-        <CircleMiniFilledSolid />
+        <EllipseMiniSolid />
       </RadixSelect.ItemIndicator>
     </span>
     <RadixSelect.ItemText className="flex-1 truncate">


### PR DESCRIPTION
## Summary
- Required single-select / toggle attribute dropdowns in vendor product creation (Step 3) rendered the selected-item indicator with `CircleMiniFilledSolid`, a heavy radio-button glyph that didn't match the design (review flagged it as "Not Medusa component for radio item").
- Switched the indicator to `EllipseMiniSolid` — the small dot already used by the vendor `Combobox`, category select and table filters — so the menu item now matches the referenced Medusa Select component and the design's "correct" radio-dot.

## Linear
[MER-125](https://linear.app/rigbyjs/issue/MER-125)

## Test plan
- [ ] Vendor → create product → Step 3, pick a category with a required single-select attribute. Open the dropdown and select a value: the selected item shows a small dot (•) on the left, matching the design.
- [ ] `bun run lint` (no new errors; only pre-existing `exhaustive-deps` warnings remain)
- [ ] `bun run build` (vendor + types build clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)