### PR TITLE
fix(products): remove doubled divider above variant table filter bar

### DIFF
--- a/packages/admin/src/components/data-table/data-table.tsx
+++ b/packages/admin/src/components/data-table/data-table.tsx
@@ -98,6 +98,13 @@ interface DataTableProps<TData> {
     order: string[]
   }
   filterBarContent?: React.ReactNode
+  /**
+   * When true, the top toolbar row is hidden and Search is rendered inside
+   * the auto filter bar (single-row layout with Add filter on the left and
+   * Search/Sort on the right). FilterMenu and SortingMenu are not duplicated
+   * in a second row.
+   */
+  compact?: boolean
 }
 
 export const DataTable = <TData,>({
@@ -133,6 +140,7 @@ export const DataTable = <TData,>({
   entity: _entity,
   currentColumns: _currentColumns,
   filterBarContent,
+  compact = false,
 }: DataTableProps<TData>) => {
   const { t } = useTranslation()
 
@@ -358,6 +366,16 @@ export const DataTable = <TData,>({
 
   const shouldRenderHeading = heading || subHeading
 
+  const compactFilterBarContent =
+    compact && enableSearch ? (
+      <>
+        <UiDataTable.Search placeholder={t("filters.searchLabel")} />
+        {filterBarContent}
+      </>
+    ) : (
+      filterBarContent
+    )
+
   return (
     <UiDataTable
       instance={instance}
@@ -366,41 +384,48 @@ export const DataTable = <TData,>({
       }
     >
       <UiDataTable.Toolbar
-        className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center"
+        className={
+          compact
+            ? "hidden"
+            : "flex flex-col items-start justify-between gap-2 md:flex-row md:items-center"
+        }
         translations={toolbarTranslations}
-        filterBarContent={filterBarContent}
+        filterBarContent={compactFilterBarContent}
       >
-        <div className="flex w-full items-center justify-between gap-2">
-          <div className="flex items-center gap-x-4">
-            {shouldRenderHeading && (
-              <div>
-                {heading && <Heading level={headingLevel}>{heading}</Heading>}
-                {subHeading && (
-                  <Text size="small" className="text-ui-fg-subtle">
-                    {subHeading}
-                  </Text>
-                )}
-              </div>
-            )}
+        {compact ? null : (
+          <div className="flex w-full items-center justify-between gap-2">
+            <div className="flex items-center gap-x-4">
+              {shouldRenderHeading && (
+                <div>
+                  {heading && (
+                    <Heading level={headingLevel}>{heading}</Heading>
+                  )}
+                  {subHeading && (
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {subHeading}
+                    </Text>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="flex items-center gap-x-2">
+              {showFilterMenu && <UiDataTable.FilterMenu />}
+              {enableSorting && <UiDataTable.SortingMenu />}
+              {enableSearch && (
+                <div className="w-full md:w-auto">
+                  <UiDataTable.Search
+                    placeholder={t("filters.searchLabel")}
+                  />
+                </div>
+              )}
+              {actionMenu && <ActionMenu variant="primary" {...actionMenu} />}
+              {actions && actions.length > 0 && (
+                <DataTableActions actions={actions} />
+              )}
+              {!actions && action && <DataTableAction {...action} />}
+            </div>
           </div>
-          <div className="flex items-center gap-x-2">
-            {showFilterMenu && <UiDataTable.FilterMenu />}
-            {enableSorting && <UiDataTable.SortingMenu />}
-            {enableSearch && (
-              <div className="w-full md:w-auto">
-                <UiDataTable.Search
-                  placeholder={t("filters.searchLabel")}
-                  
-                />
-              </div>
-            )}
-            {actionMenu && <ActionMenu variant="primary" {...actionMenu} />}
-            {actions && actions.length > 0 && (
-              <DataTableActions actions={actions} />
-            )}
-            {!actions && action && <DataTableAction {...action} />}
-          </div>
-        </div>
+        )}
       </UiDataTable.Toolbar>
       <UiDataTable.Table emptyState={emptyState} />
       {enablePagination && (

--- a/packages/admin/src/components/data-table/data-table.tsx
+++ b/packages/admin/src/components/data-table/data-table.tsx
@@ -98,13 +98,6 @@ interface DataTableProps<TData> {
     order: string[]
   }
   filterBarContent?: React.ReactNode
-  /**
-   * When true, the top toolbar row is hidden and Search is rendered inside
-   * the auto filter bar (single-row layout with Add filter on the left and
-   * Search/Sort on the right). FilterMenu and SortingMenu are not duplicated
-   * in a second row.
-   */
-  compact?: boolean
 }
 
 export const DataTable = <TData,>({
@@ -140,7 +133,6 @@ export const DataTable = <TData,>({
   entity: _entity,
   currentColumns: _currentColumns,
   filterBarContent,
-  compact = false,
 }: DataTableProps<TData>) => {
   const { t } = useTranslation()
 
@@ -366,15 +358,18 @@ export const DataTable = <TData,>({
 
   const shouldRenderHeading = heading || subHeading
 
-  const compactFilterBarContent =
-    compact && enableSearch ? (
-      <>
-        <UiDataTable.Search placeholder={t("filters.searchLabel")} />
-        {filterBarContent}
-      </>
-    ) : (
-      filterBarContent
-    )
+  // When the consumer supplies a heading or toolbar actions, render the full
+  // toolbar (heading + filter/sort/search row) and let Medusa append its own
+  // filter bar underneath. When it supplies none of those — e.g. a section
+  // that draws its own header in a Container — render Medusa's filter bar
+  // directly: a single row with Add filter on the left and Search/Sort on the
+  // right (its own `border-t` acts as the separator), instead of an empty
+  // toolbar band stacked on top of the filter bar.
+  const hasToolbarHeader =
+    Boolean(shouldRenderHeading) ||
+    Boolean(actionMenu) ||
+    Boolean(actions && actions.length > 0) ||
+    Boolean(action)
 
   return (
     <UiDataTable
@@ -383,16 +378,12 @@ export const DataTable = <TData,>({
         layout === "fill" ? "h-full [&_tr]:last-of-type:!border-b" : undefined
       }
     >
-      <UiDataTable.Toolbar
-        className={
-          compact
-            ? "hidden"
-            : "flex flex-col items-start justify-between gap-2 md:flex-row md:items-center"
-        }
-        translations={toolbarTranslations}
-        filterBarContent={compactFilterBarContent}
-      >
-        {compact ? null : (
+      {hasToolbarHeader ? (
+        <UiDataTable.Toolbar
+          className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center"
+          translations={toolbarTranslations}
+          filterBarContent={filterBarContent}
+        >
           <div className="flex w-full items-center justify-between gap-2">
             <div className="flex items-center gap-x-4">
               {shouldRenderHeading && (
@@ -425,8 +416,20 @@ export const DataTable = <TData,>({
               {!actions && action && <DataTableAction {...action} />}
             </div>
           </div>
-        )}
-      </UiDataTable.Toolbar>
+        </UiDataTable.Toolbar>
+      ) : (
+        <UiDataTable.FilterBar
+          alwaysShow
+          clearAllFiltersLabel={toolbarTranslations.clearAll}
+          sortingTooltip={toolbarTranslations.sort}
+          columnsTooltip={toolbarTranslations.columns}
+        >
+          {enableSearch && (
+            <UiDataTable.Search placeholder={t("filters.searchLabel")} />
+          )}
+          {filterBarContent}
+        </UiDataTable.FilterBar>
+      )}
       <UiDataTable.Table emptyState={emptyState} />
       {enablePagination && (
         <UiDataTable.Pagination translations={paginationTranslations} />

--- a/packages/admin/src/pages/products/product-detail/components/product-variant-section/product-variant-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-variant-section/product-variant-section.tsx
@@ -65,11 +65,11 @@ export const ProductVariantSection = ({
     throw error;
   }
 
-  // No `divide-y` on the Container: in compact mode the DataTable's filter
-  // bar already renders its own `border-t`, so a Container divider would
-  // stack a second line between the header and the filter row (the doubled
-  // divider reported in MER-129). The compact filter bar always renders
-  // (search + sort + filters), so it owns the header/filter separator.
+  // No `divide-y` on the Container: this section draws its own header, so the
+  // DataTable renders only its filter bar, which already has a `border-t`. A
+  // Container divider would stack a second line between the header and the
+  // filter row (the doubled divider reported in MER-129); the filter bar owns
+  // that separator.
   return (
     <Container className="p-0" data-testid="product-variant-section">
       <div className="flex items-center justify-between px-6 py-4">
@@ -93,7 +93,6 @@ export const ProductVariantSection = ({
           rowHref={(row) => `/products/${product.id}/variants/${row.id}`}
           pageSize={PAGE_SIZE}
           isLoading={isPending}
-          compact
           emptyState={{
             empty: {
               heading: t("products.variants.empty.heading"),

--- a/packages/admin/src/pages/products/product-detail/components/product-variant-section/product-variant-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-variant-section/product-variant-section.tsx
@@ -65,8 +65,13 @@ export const ProductVariantSection = ({
     throw error;
   }
 
+  // No `divide-y` on the Container: in compact mode the DataTable's filter
+  // bar already renders its own `border-t`, so a Container divider would
+  // stack a second line between the header and the filter row (the doubled
+  // divider reported in MER-129). The compact filter bar always renders
+  // (search + sort + filters), so it owns the header/filter separator.
   return (
-    <Container className="divide-y p-0" data-testid="product-variant-section">
+    <Container className="p-0" data-testid="product-variant-section">
       <div className="flex items-center justify-between px-6 py-4">
         <Heading level="h2">{t("products.variants.header")}</Heading>
         <Button

--- a/packages/vendor/src/components/data-table/data-table.tsx
+++ b/packages/vendor/src/components/data-table/data-table.tsx
@@ -98,13 +98,6 @@ interface DataTableProps<TData> {
     order: string[]
   }
   filterBarContent?: React.ReactNode
-  /**
-   * When true, the top toolbar row is hidden and Search is rendered inside
-   * the auto filter bar (single-row layout with Add filter on the left and
-   * Search/Sort on the right). FilterMenu and SortingMenu are not duplicated
-   * in a second row.
-   */
-  compact?: boolean
 }
 
 export const DataTable = <TData,>({
@@ -140,7 +133,6 @@ export const DataTable = <TData,>({
   entity: _entity,
   currentColumns: _currentColumns,
   filterBarContent,
-  compact = false,
 }: DataTableProps<TData>) => {
   const { t } = useTranslation()
 
@@ -366,15 +358,18 @@ export const DataTable = <TData,>({
 
   const shouldRenderHeading = heading || subHeading
 
-  const compactFilterBarContent =
-    compact && enableSearch ? (
-      <>
-        <UiDataTable.Search placeholder={t("filters.searchLabel")} />
-        {filterBarContent}
-      </>
-    ) : (
-      filterBarContent
-    )
+  // When the consumer supplies a heading or toolbar actions, render the full
+  // toolbar (heading + filter/sort/search row) and let Medusa append its own
+  // filter bar underneath. When it supplies none of those — e.g. a section
+  // that draws its own header in a Container — render Medusa's filter bar
+  // directly: a single row with Add filter on the left and Search/Sort on the
+  // right (its own `border-t` acts as the separator), instead of an empty
+  // toolbar band stacked on top of the filter bar.
+  const hasToolbarHeader =
+    Boolean(shouldRenderHeading) ||
+    Boolean(actionMenu) ||
+    Boolean(actions && actions.length > 0) ||
+    Boolean(action)
 
   return (
     <UiDataTable
@@ -383,16 +378,12 @@ export const DataTable = <TData,>({
         layout === "fill" ? "h-full [&_tr]:last-of-type:!border-b" : undefined
       }
     >
-      <UiDataTable.Toolbar
-        className={
-          compact
-            ? "hidden"
-            : "flex flex-col items-start justify-between gap-2 md:flex-row md:items-center"
-        }
-        translations={toolbarTranslations}
-        filterBarContent={compactFilterBarContent}
-      >
-        {compact ? null : (
+      {hasToolbarHeader ? (
+        <UiDataTable.Toolbar
+          className="flex flex-col items-start justify-between gap-2 md:flex-row md:items-center"
+          translations={toolbarTranslations}
+          filterBarContent={filterBarContent}
+        >
           <div className="flex w-full items-center justify-between gap-2">
             <div className="flex items-center gap-x-4">
               {shouldRenderHeading && (
@@ -425,8 +416,20 @@ export const DataTable = <TData,>({
               {!actions && action && <DataTableAction {...action} />}
             </div>
           </div>
-        )}
-      </UiDataTable.Toolbar>
+        </UiDataTable.Toolbar>
+      ) : (
+        <UiDataTable.FilterBar
+          alwaysShow
+          clearAllFiltersLabel={toolbarTranslations.clearAll}
+          sortingTooltip={toolbarTranslations.sort}
+          columnsTooltip={toolbarTranslations.columns}
+        >
+          {enableSearch && (
+            <UiDataTable.Search placeholder={t("filters.searchLabel")} />
+          )}
+          {filterBarContent}
+        </UiDataTable.FilterBar>
+      )}
       <UiDataTable.Table emptyState={emptyState} />
       {enablePagination && (
         <UiDataTable.Pagination translations={paginationTranslations} />

--- a/packages/vendor/src/pages/offers/[id]/_components/offer-variants-section.tsx
+++ b/packages/vendor/src/pages/offers/[id]/_components/offer-variants-section.tsx
@@ -406,11 +406,10 @@ export const OfferVariantsSection = ({
   const columns = useColumns({ optionTitles, thumbnail, getActions })
   const filters = useDataTableDateFilters()
 
-  // No `divide-y` on the Container: in compact mode the DataTable's
-  // filter bar already renders its own `border-t`, so a Container divider
-  // would stack a second line between the header and the filter row. The
-  // filter bar always renders (search + sort + filters), so it owns the
-  // header/filter separator.
+  // No `divide-y` on the Container: this section draws its own header, so the
+  // DataTable renders only its filter bar, which already has a `border-t`. A
+  // Container divider would stack a second line between the header and the
+  // filter row; the filter bar owns that separator.
   return (
     <Container className="p-0" data-testid="offer-variants-section">
       <div className="flex items-center justify-between px-6 py-4">
@@ -445,7 +444,6 @@ export const OfferVariantsSection = ({
         rowCount={sortedRows.length}
         pageSize={PAGE_SIZE}
         prefix={PREFIX}
-        compact
         emptyState={{
           empty: {
             heading: t("offers.empty.heading"),

--- a/packages/vendor/src/pages/products/[id]/_components/product-variant-section/product-variant-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-variant-section/product-variant-section.tsx
@@ -67,8 +67,13 @@ export const ProductVariantSection = ({
     throw error;
   }
 
+  // No `divide-y` on the Container: in compact mode the DataTable's filter
+  // bar already renders its own `border-t`, so a Container divider would
+  // stack a second line between the header and the filter row (the doubled
+  // divider reported in MER-129). The compact filter bar always renders
+  // (search + sort + filters), so it owns the header/filter separator.
   return (
-    <Container className="divide-y p-0" data-testid="product-variant-section">
+    <Container className="p-0" data-testid="product-variant-section">
       <div className="flex items-center justify-between px-6 py-4">
         <Heading level="h2">{t("products.variants.header")}</Heading>
         <Button

--- a/packages/vendor/src/pages/products/[id]/_components/product-variant-section/product-variant-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-variant-section/product-variant-section.tsx
@@ -67,11 +67,11 @@ export const ProductVariantSection = ({
     throw error;
   }
 
-  // No `divide-y` on the Container: in compact mode the DataTable's filter
-  // bar already renders its own `border-t`, so a Container divider would
-  // stack a second line between the header and the filter row (the doubled
-  // divider reported in MER-129). The compact filter bar always renders
-  // (search + sort + filters), so it owns the header/filter separator.
+  // No `divide-y` on the Container: this section draws its own header, so the
+  // DataTable renders only its filter bar, which already has a `border-t`. A
+  // Container divider would stack a second line between the header and the
+  // filter row (the doubled divider reported in MER-129); the filter bar owns
+  // that separator.
   return (
     <Container className="p-0" data-testid="product-variant-section">
       <div className="flex items-center justify-between px-6 py-4">
@@ -95,7 +95,6 @@ export const ProductVariantSection = ({
           rowHref={(row) => `/products/${product.id}/variants/${row.id}`}
           pageSize={PAGE_SIZE}
           isLoading={isPending}
-          compact
           emptyState={{
             empty: {
               heading: t("products.variants.empty.heading"),

--- a/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-add-attributes-modal.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-add-attributes-modal.tsx
@@ -233,7 +233,6 @@ export const ProductCreateAddAttributesModal = () => {
           isLoading={isLoading}
           layout="fill"
           prefix={ADD_ATTRIBUTES_MODAL_ID}
-          compact
           emptyState={emptyState}
         />
       </StackedFocusModal.Body>


### PR DESCRIPTION
## Summary
Fixes the **doubled divider** above the Product Details → Variants table (MER-129, reviewer marked "Not fixed"), and removes the awkward `compact` flag that produced it.

**Root cause:** the variants section `Container` kept `divide-y` while the `DataTable` rendered a `compact` filter bar that already draws its own `border-t` — two stacked lines. The `compact` prop itself was a hack: it hid the toolbar's heading row with `className="hidden"` and re-injected Search into the auto filter bar, leaving an empty toolbar band in the DOM.

**Fix / refactor:**
- Dropped `divide-y` from the variant section `Container`s.
- Removed the `compact` prop from both dashboard `DataTable` wrappers (kept byte-identical) and every call site.
- The wrapper now renders Medusa's `DataTable.FilterBar` **directly** whenever the consumer supplies no heading/actions (it draws its own header in a `Container`): a single filter bar — Add filter (left), Search/Sort (right), with its own `border-t`. Consumers that pass a heading/actions keep the full toolbar, unchanged.

**Blast radius:** all *header-less* embedded tables using this wrapper now render the single filter bar instead of a toolbar row stacked on the auto filter bar. Besides the variant sections this also tidies: `offer-variants-section`, the sales-channels edit forms, the add-attributes modals, and the sales-channel drawer/data-table. Tables that pass a `heading` (sales-channel list, location list, refund-reason list, api-key sales-channel section) are untouched.

Note: the "Add filter" *text* button + `[Search][Sort]` order in the Figma mock reflect an older Medusa style; Medusa 4.1.1's stock `FilterBar` renders a funnel `IconButton` and `[Sort][Search]`. This matches the already-shipped `offer-variants-section`, so the variant tables are now consistent with it.

## Linear
[MER-129](https://linear.app/rigbyjs/issue/MER-129)

## Test plan
- [ ] Vendor + Admin product detail → **Variants**: single divider between the "Variants / Create" header and the filter bar; SKU column, filters, search, sort, row-nav all work.
- [ ] Spot-check other header-less embedded tables (offers variants, product sales-channels edit, add-attributes modal) still filter/search/sort correctly.
- [x] `bun run build` (all 9 packages, incl. admin + vendor DTS type-check)
- [x] `bun run lint` (no errors in changed files)
- Note: dashboard packages have no component-render (RTL/jsdom) test harness, so these presentational changes have no integration suite to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)