### PR TITLE
fix(dev): align api dev scripts and codegen runner

### DIFF
--- a/apps/api/.mercur/index.d.ts
+++ b/apps/api/.mercur/index.d.ts
@@ -142,7 +142,7 @@ export type Routes = {
             $id: typeof import("@medusajs/medusa/api/admin/invites/[id]/route") & {
                 resend: typeof import("@medusajs/medusa/api/admin/invites/[id]/resend/route");
             };
-            accept: typeof import("@mercurjs/core/api/admin/invites/accept/route");
+            accept: typeof import("@medusajs/medusa/api/admin/invites/accept/route");
         };
         locales: typeof import("@medusajs/medusa/api/admin/locales/route") & {
             $code: typeof import("@medusajs/medusa/api/admin/locales/[code]/route");

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
     "medusa"
   ],
   "scripts": {
-    "build": "medusa build",
+    "build": "mercurjs build",
     "seed": "medusa exec ./src/scripts/seed.ts",
     "start": "mercurjs start",
     "dev": "medusa develop",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,9 +18,10 @@
     "medusa"
   ],
   "scripts": {
+    "build": "medusa build",
     "seed": "medusa exec ./src/scripts/seed.ts",
     "start": "mercurjs start",
-    "dev": "mercurjs develop",
+    "dev": "medusa develop",
     "test:integration:http": "TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",
     "test:integration:modules": "TEST_TYPE=integration:modules NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",
     "test:unit": "TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules jest --silent --runInBand --forceExit"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,7 @@
     "medusa"
   ],
   "scripts": {
-    "build": "mercurjs build",
+    "build": "bunx @mercurjs/cli build",
     "seed": "medusa exec ./src/scripts/seed.ts",
     "start": "mercurjs start",
     "dev": "medusa develop",

--- a/packages/core/src/modules/codegen/services/codegen-module-service.ts
+++ b/packages/core/src/modules/codegen/services/codegen-module-service.ts
@@ -1,6 +1,6 @@
 import { exec } from "child_process"
 import { existsSync } from "fs"
-import { join } from "path"
+import { dirname, join } from "path"
 import { Logger } from "@medusajs/medusa"
 
 export default class CodegenModuleService {
@@ -28,17 +28,34 @@ export default class CodegenModuleService {
         }
     }
 
-    private detectPackageRunner_(): string {
-        const cwd = process.cwd()
-        const lockfiles: [string, string][] = [
-            ["bun.lockb", "bunx"],
-            ["bun.lock", "bunx"],
-            ["pnpm-lock.yaml", "pnpm exec"],
-            ["yarn.lock", "yarn"],
-        ]
+    private findNearestLockfileRunner_(): string | undefined {
+        let currentDir = process.cwd()
 
-        const runner = lockfiles.find(([file]) => existsSync(join(cwd, file)))
-        return `${runner ? runner[1] : "npx"} @mercurjs/cli codegen`
+        while (true) {
+            const lockfiles: [string, string][] = [
+                ["bun.lockb", "bunx"],
+                ["bun.lock", "bunx"],
+                ["pnpm-lock.yaml", "pnpm exec"],
+                ["yarn.lock", "yarn"],
+            ]
+
+            const runner = lockfiles.find(([file]) => existsSync(join(currentDir, file)))
+            if (runner) {
+                return runner[1]
+            }
+
+            const parentDir = dirname(currentDir)
+            if (parentDir === currentDir) {
+                return undefined
+            }
+
+            currentDir = parentDir
+        }
+    }
+
+    private detectPackageRunner_(): string {
+        const runner = this.findNearestLockfileRunner_()
+        return `${runner ?? "npx"} @mercurjs/cli codegen`
     }
 
     private runCodegen_(): Promise<void> {


### PR DESCRIPTION
## Summary
- Align the starter API dev/build scripts with the current generated Mercur project by using Medusa CLI directly where safe.
- Keep production `start` on `mercurjs start` so the existing `patchMedusa()` behavior still disables default Medusa admin product/product-variant routes.
- Keep `build` on `mercurjs build` so route-type codegen (`writeRouteTypes()`) still runs before the Medusa build (see Notes).
- Fix the Mercur codegen module runner detection to walk up parent directories for lockfiles, so nested apps in a Bun workspace use `bunx` instead of falling back to `npx`.
- Regenerate API route types after the codegen fix.

## Why each script lands where it does
| Script | Value | Reason |
|--------|-------|--------|
| `dev` | `medusa develop` | `CodegenModuleService.onApplicationStart` runs codegen automatically, but only when `NODE_ENV=development` (which `medusa develop` sets). Route types stay fresh without the CLI wrapper. |
| `build` | `mercurjs build` | `medusa build` runs with `NODE_ENV=production`, so the codegen hook early-returns and route types would go stale. `mercurjs build` calls `writeRouteTypes()` first, then delegates to `medusa build` (no `patchMedusa()`), so types stay in sync. |
| `start` | `mercurjs start` | Still needs `patchMedusa()` to disable default admin product/product-variant routes in production. |

## About the `.mercur/index.d.ts` diff
The regenerated types change `admin.invites.accept` from
`@mercurjs/core/api/admin/invites/accept/route` to
`@medusajs/medusa/api/admin/invites/accept/route`. This is a **correction**, not a regression:
- There is no `packages/core/src/api/admin/invites/accept/route.ts` in core (the only invites/accept route is `vendor/members/invites/accept`), so the old path pointed at a module that does not exist.
- `packages/cli/src/codegen/constants.ts` explicitly maps `/admin/invites/accept` to `@medusajs/medusa/api/admin/invites/accept/route`, which the regenerated value now matches.

## Verification
- `cd apps/api && medusa db:migrate`
- `cd apps/api && bun run dev` -> server ready on port 9000
- `curl -i http://localhost:9000/health` -> HTTP 200 OK
- `bun run build` -> 10 successful / 10 total
- `bun run test:integration:http -- fulfillment-sets` -> 19 passed / 19 total

## Notes
- Initial push to upstream was denied for `wasin-creator`, so this PR is opened from the fork branch `wasin-creator:fix/api-dev-codegen-runner`.
- `start` intentionally remains `mercurjs start` until the Medusa route patching done by `patchMedusa()` is moved into a non-wrapper startup path.
