### PR TITLE
fix(admin): block default product variant routes without patching Medusa

### DIFF
--- a/apps/api/.mercur/index.d.ts
+++ b/apps/api/.mercur/index.d.ts
@@ -142,7 +142,7 @@ export type Routes = {
             $id: typeof import("@medusajs/medusa/api/admin/invites/[id]/route") & {
                 resend: typeof import("@medusajs/medusa/api/admin/invites/[id]/resend/route");
             };
-            accept: typeof import("@mercurjs/core/api/admin/invites/accept/route");
+            accept: typeof import("@medusajs/medusa/api/admin/invites/accept/route");
         };
         locales: typeof import("@medusajs/medusa/api/admin/locales/route") & {
             $code: typeof import("@medusajs/medusa/api/admin/locales/[code]/route");

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,9 +18,10 @@
     "medusa"
   ],
   "scripts": {
+    "build": "medusa build",
     "seed": "medusa exec ./src/scripts/seed.ts",
-    "start": "mercurjs start",
-    "dev": "mercurjs develop",
+    "start": "medusa start",
+    "dev": "medusa develop",
     "test:integration:http": "TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",
     "test:integration:modules": "TEST_TYPE=integration:modules NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",
     "test:unit": "TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules jest --silent --runInBand --forceExit"

--- a/integration-tests/http/admin/default-medusa-product-routes.spec.ts
+++ b/integration-tests/http/admin/default-medusa-product-routes.spec.ts
@@ -1,0 +1,33 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import {
+  adminHeaders,
+  createAdminUser,
+} from "../../helpers/create-admin-user"
+
+jest.setTimeout(60 * 1000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ api, getContainer, dbConnection }) => {
+    describe("Admin default Medusa product routes", () => {
+      let container: MedusaContainer
+
+      beforeAll(async () => {
+        container = getContainer()
+      })
+
+      beforeEach(async () => {
+        await createAdminUser(dbConnection, adminHeaders, container)
+      })
+
+      it("blocks Medusa's default admin product-variants route", async () => {
+        const response = await api
+          .get("/admin/product-variants", adminHeaders)
+          .catch((error) => error.response)
+
+        expect(response?.status).toBe(404)
+        expect(response?.data).toEqual({ message: "Not found" })
+      })
+    })
+  },
+})

--- a/packages/cli/src/commands/develop.ts
+++ b/packages/cli/src/commands/develop.ts
@@ -31,7 +31,6 @@ async function runDevelop(opts: z.infer<typeof developOptionsSchema>) {
     const options = developOptionsSchema.parse(opts);
 
     await writeRouteTypes(options.cwd);
-    // await patchMedusa(); // TODO: re-enable when plugin provides full admin product route overrides
 
     const medusaBin = await getCommandBin("@medusajs/cli", "medusa", options.cwd);
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import spawn from "cross-spawn";
 import { writeRouteTypes } from "@/src/codegen";
 import { getCommandBin } from "@/src/utils/get-command-bin";
-import { patchMedusa } from "@/src/utils/patch-medusa";
 import { handleError } from "@/src/utils/handle-error";
 import { logger } from "@/src/utils/logger";
 
@@ -32,7 +31,6 @@ async function runStart(opts: z.infer<typeof startOptionsSchema>) {
     const options = startOptionsSchema.parse(opts);
 
     await writeRouteTypes(options.cwd);
-    await patchMedusa();
 
     const medusaBin = await getCommandBin("@medusajs/cli", "medusa", options.cwd);
 

--- a/packages/core/src/api/admin/default-product-route-blocker.ts
+++ b/packages/core/src/api/admin/default-product-route-blocker.ts
@@ -1,0 +1,11 @@
+import { MedusaNextFunction, MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+export const DEFAULT_ADMIN_PRODUCT_ROUTE_NOT_FOUND = { message: "Not found" }
+
+export const blockDefaultAdminProductRoute = (
+  _req: MedusaRequest,
+  res: MedusaResponse,
+  _next: MedusaNextFunction
+) => {
+  return res.status(404).json(DEFAULT_ADMIN_PRODUCT_ROUTE_NOT_FOUND)
+}

--- a/packages/core/src/api/admin/middlewares.ts
+++ b/packages/core/src/api/admin/middlewares.ts
@@ -16,6 +16,7 @@ import { adminMembersMiddlewares } from "./members/middlewares"
 import { adminAttributeMiddlewares } from "./attributes/middlewares"
 import { adminCommissionRatesMiddlewares } from "./commission-rates/middlewares"
 import { adminSubscriptionPlanRoutesMiddlewares } from "./subscription-plans/middlewares"
+import { blockDefaultAdminProductRoute } from "./default-product-route-blocker"
 
 const maybeApplySellerProductFilter = (
   req: AuthenticatedMedusaRequest,
@@ -54,6 +55,11 @@ const maybeApplySellerOrderFilter = (
 }
 
 export const adminMiddlewares: MiddlewareRoute[] = [
+  {
+    method: ["GET", "POST", "DELETE"],
+    matcher: "/admin/product-variants*",
+    middlewares: [blockDefaultAdminProductRoute],
+  },
   ...adminAttributeMiddlewares,
   ...adminOrderGroupsMiddlewares,
   {

--- a/packages/core/src/modules/codegen/services/codegen-module-service.ts
+++ b/packages/core/src/modules/codegen/services/codegen-module-service.ts
@@ -1,6 +1,6 @@
 import { exec } from "child_process"
 import { existsSync } from "fs"
-import { join } from "path"
+import { dirname, join, parse } from "path"
 import { Logger } from "@medusajs/medusa"
 
 export default class CodegenModuleService {
@@ -28,8 +28,9 @@ export default class CodegenModuleService {
         }
     }
 
-    private detectPackageRunner_(): string {
-        const cwd = process.cwd()
+    private findNearestLockfileRunner_(): string | null {
+        let current = process.cwd()
+        const { root } = parse(current)
         const lockfiles: [string, string][] = [
             ["bun.lockb", "bunx"],
             ["bun.lock", "bunx"],
@@ -37,8 +38,23 @@ export default class CodegenModuleService {
             ["yarn.lock", "yarn"],
         ]
 
-        const runner = lockfiles.find(([file]) => existsSync(join(cwd, file)))
-        return `${runner ? runner[1] : "npx"} @mercurjs/cli codegen`
+        while (true) {
+            const runner = lockfiles.find(([file]) => existsSync(join(current, file)))
+            if (runner) {
+                return runner[1]
+            }
+
+            if (current === root) {
+                return null
+            }
+
+            current = dirname(current)
+        }
+    }
+
+    private detectPackageRunner_(): string {
+        const runner = this.findNearestLockfileRunner_()
+        return `${runner ?? "npx"} @mercurjs/cli codegen`
     }
 
     private runCodegen_(): Promise<void> {


### PR DESCRIPTION
## Summary
- Replaces the startup-time Medusa node_modules patch for default admin product-variant routes with a Mercur admin middleware blocker.
- Switches the generated API app scripts to call Medusa CLI directly for build/dev/start.
- Keeps dev-time codegen working from generated apps by finding the nearest workspace lockfile before choosing bunx/pnpm/yarn/npx.

Closes #993

## Details
- Adds a 404 blocker for `/admin/product-variants*` in `@mercurjs/core` admin middleware.
- Removes `patchMedusa()` from `mercurjs start`.
- Leaves `/admin/products*` untouched because Mercur owns `packages/core/src/api/admin/products/route.ts`; blocking that matcher needs a separate route matrix to avoid shadowing Mercur's replacement route.

## Verification
- [x] RED: `bun run test:integration:http -- admin/default-medusa-product-routes` failed before the blocker with expected 404 / received 403 after rebuilding core from main source.
- [x] GREEN: `bun run test:integration:http -- admin/default-medusa-product-routes` passes.
- [x] `bun run build` passes: 10 successful / 10 total.
- [x] `cd apps/api && bun run dev` starts on port 9000; `/health` returns HTTP 200; no `Codegen failed` / command-not-found logs.
- [x] `cd apps/api && NODE_ENV=production bun run start` starts on port 9000; `/health` returns HTTP 200; no patch/command errors.

## Follow-up
- Decide the exact `/admin/products*` route matrix separately before replacing the remaining product-route patch behavior, because Mercur already provides its own admin products route.