### PR TITLE
fix(vendor): reposition variant-step search and simplify placeholder

### DIFF
--- a/packages/vendor/src/components/data-grid/components/data-grid-root.tsx
+++ b/packages/vendor/src/components/data-grid/components/data-grid-root.tsx
@@ -907,8 +907,8 @@ const DataGridHeader = ({
           )}
         </div>
       )}
-      {headerContent}
       <div className="ml-auto flex items-center gap-x-2">
+        {headerContent}
         {errorCount > 0 && (
           <Button
             size="small"

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -521,7 +521,7 @@
           "placeholder": "Small, Medium, Large"
         },
         "productVariants": {
-          "searchPlaceholder": "Search variants...",
+          "searchPlaceholder": "Search",
           "media": "Media",
           "tip": "Only variants with prices and stock will be visible to customers.",
           "label": "Product variants",

--- a/packages/vendor/src/i18n/translations/pl.json
+++ b/packages/vendor/src/i18n/translations/pl.json
@@ -532,7 +532,7 @@
           "hint": "Ta kolejność wpłynie na porządek wariantów w Twoim sklepie.",
           "alert": "Dodaj opcje, aby utworzyć warianty.",
           "tip": "Warianty, które nie zostały wybrane, nie zostaną utworzone. Możesz zawsze później dodać i edytować warianty.",
-          "searchPlaceholder": "Wyszukaj warianty...",
+          "searchPlaceholder": "Wyszukaj",
           "media": "Media"
         },
         "productOptions": {


### PR DESCRIPTION
## Summary
- Move the product-creation variant-step search input into the data grid's right-aligned header cluster (beside **Shortcuts**) so it matches the [Figma design](https://www.figma.com/design/sYJoh84Owr5tomRjpxG0no/-Mercur-2.0----Vendor-Panel-B2C?node-id=40009019-257392) instead of sitting next to the **View** button on the left.
- Change the placeholder text from `Search variants...` to `Search` (en + pl locales).

Follow-up to the now-merged [#968](https://github.com/mercurjs/mercur/pull/968), which originally added the variant-step search.

## Linear
[MER-127](https://linear.app/rigbyjs/issue/MER-127)

## Test plan
- [ ] Vendor panel → Products → Create → Step 4 (Variants): search input renders on the right of the grid header with placeholder "Search"
- [x] `bun run --filter @mercurjs/vendor lint` (no new errors in changed files)
- [x] Translation JSON remains valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)