### PR TITLE
ci(integration-tests): set DB_* env vars for medusa test runner

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,6 +43,14 @@ jobs:
 
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/mercur
+      # @medusajs/test-utils derives its Postgres connection from these DB_*
+      # vars (NOT DATABASE_URL). Without DB_PASSWORD the generated connection
+      # URL has no password segment and SCRAM auth fails with
+      # "client password must be a string".
+      DB_HOST: localhost
+      DB_PORT: "5432"
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
       REDIS_URL: redis://localhost:6379
       MEDUSA_FF_SELLER_REGISTRATION: "true"
       MEDUSA_FF_PRODUCT_REQUEST: "false"

--- a/integration-tests/.env.test
+++ b/integration-tests/.env.test
@@ -1,3 +1,9 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mercur
+# @medusajs/test-utils builds its Postgres connection from these DB_* vars,
+# not DATABASE_URL. Keep them in sync with DATABASE_URL above.
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
 MEDUSA_FF_SELLER_REGISTRATION=true
 MEDUSA_FF_PRODUCT_REQUEST=false


### PR DESCRIPTION
## Problem

The **Build & Integration Test** workflow fails at the database step with:

```
SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string
```

## Root cause

`@medusajs/test-utils` (`medusaIntegrationTestRunner`) does **not** read `DATABASE_URL`. It builds its Postgres connection from `DB_HOST` / `DB_PORT` / `DB_USERNAME` / `DB_PASSWORD` (see `database.js`):

```js
const DB_PASSWORD = process.env.DB_PASSWORD ?? ""   // pgGodCredentials (create/drop temp DB)
// getDatabaseURL():
`postgres://${DB_USERNAME}${DB_PASSWORD ? `:${DB_PASSWORD}` : ""}@${DB_HOST}:${DB_PORT}/${DB_NAME}`
```

The CI job set only `DATABASE_URL`, so `DB_PASSWORD` was `undefined`, the generated connection URL had **no password segment**, and `pg` connected to the CI Postgres (which requires SCRAM auth via `POSTGRES_PASSWORD: postgres`) with an undefined password — producing the SASL error. The temp DB name is auto-generated (`medusa-<module>-integration-<workerId>`), so only the credential vars were missing.

## Fix

- Add `DB_HOST` / `DB_PORT` / `DB_USERNAME` / `DB_PASSWORD` to the workflow job `env`, matching the `postgres` service.
- Mirror the same `DB_*` vars into `integration-tests/.env.test` so local `bun run test:integration:http` works against a password-protected Postgres too.

Config/env only — no source changes. Real confirmation is the integration-test run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)