### PR TITLE
fix(vendor): move fulfill items action into unfulfilled items menu

### DIFF
--- a/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -1,4 +1,4 @@
-import { XCircle } from "@medusajs/icons"
+import { DocumentText, XCircle } from "@medusajs/icons"
 import { AdminOrderLineItem } from "@medusajs/types"
 import {
   Button,
@@ -176,6 +176,20 @@ const UnfulfilledItemDisplay = ({
           <StatusBadge color="red" className="text-nowrap">
             {t("orders.fulfillment.awaitingFulfillmentBadge")}
           </StatusBadge>
+
+          <ActionMenu
+            groups={[
+              {
+                actions: [
+                  {
+                    label: t("orders.fulfillment.fulfillItems"),
+                    icon: <DocumentText />,
+                    to: `/orders/${order.id}/fulfillment?requires_shipping=${requiresShipping}`,
+                  },
+                ],
+              },
+            ]}
+          />
         </div>
       </div>
       <div>
@@ -186,13 +200,6 @@ const UnfulfilledItemDisplay = ({
             currencyCode={order.currency_code}
           />
         ))}
-      </div>
-      <div className="px-6 py-4 flex justify-end">
-        <Link
-          to={`/orders/${order.id}/fulfillment?requires_shipping=${requiresShipping}`}
-        >
-          <Button size="small">{t("orders.fulfillment.fulfillItems")}</Button>
-        </Link>
       </div>
     </Container>
   )


### PR DESCRIPTION
## Summary
- Moves the **Fulfill items** action in the vendor order detail page from the standalone footer button into a three-dots `ActionMenu` in the *Unfulfilled Items* section header, matching the [Figma design](https://www.figma.com/design/sYJoh84Owr5tomRjpxG0no/-Mercur-2.0----Vendor-Panel?node-id=40013324-305321).
- The action navigates to the same fulfillment route (`/orders/:id/fulfillment?requires_shipping=…`); no behavior change beyond placement.

## Linear
[MER-189](https://linear.app/rigbyjs/issue/MER-189/orders-vendor-panel-fulfilment-block)

## Test plan
- [ ] Open a vendor order with unfulfilled items → the *Unfulfilled Items* header shows the status badges followed by a three-dots menu; the menu contains **Fulfill items**, which opens the fulfillment flow.
- [ ] `bun run lint`
- [ ] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)