### PR TITLE
fix(vendor): disable cancel fulfillment action once shipped

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -6831,6 +6831,9 @@
             "cancelWarning": {
               "type": "string"
             },
+            "cancelDisabledTooltip": {
+              "type": "string"
+            },
             "markAsDeliveredWarning": {
               "type": "string"
             },
@@ -7026,6 +7029,7 @@
           },
           "required": [
             "cancelWarning",
+            "cancelDisabledTooltip",
             "markAsDeliveredWarning",
             "differentOptionSelected",
             "disabledItemTooltip",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1724,6 +1724,7 @@
     },
     "fulfillment": {
       "cancelWarning": "You are about to cancel a fulfillment. This action cannot be undone.",
+      "cancelDisabledTooltip": "A shipped fulfillment can no longer be canceled.",
       "markAsDeliveredWarning": "You are about to mark fulfillment as delivered. This action cannot be undone.",
       "differentOptionSelected": "The selected shipping option is different from the one selected by the customer.",
       "disabledItemTooltip": "The shipping option you have selected don’t allow fulfillment of this item",

--- a/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -270,6 +270,13 @@ const Fulfillment = ({
   const showDeliveryButton =
     !fulfillment.canceled_at && !fulfillment.delivered_at
 
+  // Once a fulfillment has shipped (or been delivered/canceled) it can no
+  // longer be canceled — keep the action visible but disabled.
+  const cancelDisabled =
+    !!fulfillment.canceled_at ||
+    !!fulfillment.shipped_at ||
+    !!fulfillment.delivered_at
+
   const handleMarkAsDelivered = async () => {
     const res = await prompt({
       title: t("general.areYouSure"),
@@ -353,7 +360,10 @@ const Fulfillment = ({
                     label: t("actions.cancel"),
                     icon: <XCircle />,
                     onClick: handleCancel,
-                    disabled: !!fulfillment.canceled_at,
+                    disabled: cancelDisabled,
+                    disabledTooltip: fulfillment.shipped_at
+                      ? t("orders.fulfillment.cancelDisabledTooltip")
+                      : undefined,
                   },
                 ],
               },


### PR DESCRIPTION
## Summary
- Once an order's fulfillment is shipped it can no longer be canceled, but the **Cancel** action in the vendor order fulfillment section still rendered as active and only surfaced a warning toast on click.
- Disable the Cancel action (with an explanatory tooltip when shipped) once the fulfillment is `shipped`, `delivered`, or `canceled`, so the menu item reflects its unavailable state — matching the design.

## Linear
[MER-192](https://linear.app/rigbyjs/issue/MER-192)

## Test plan
- [ ] Open a vendor order whose fulfillment has **not** shipped → Cancel action is enabled and works.
- [ ] Mark the fulfillment as shipped → Cancel action is disabled and shows the "A shipped fulfillment can no longer be canceled." tooltip on hover.
- [ ] Delivered / canceled fulfillments also show Cancel as disabled.
- [x] `bun run lint`
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)