### PR TITLE
fix(orders): set requires_shipping on added offer items

### DIFF
--- a/integration-tests/http/order/vendor/order-edit.spec.ts
+++ b/integration-tests/http/order/vendor/order-edit.spec.ts
@@ -470,6 +470,68 @@ medusaIntegrationTestRunner({
                     expect(response.data.order_preview).toBeDefined()
                 })
 
+                it("sets requires_shipping on an added offer item so it keeps the Mark as Shipped action (MER-191)", async () => {
+                    const order = await completeCartCheckout(seller1Seed.offer.id)
+
+                    await api.post(
+                        `/vendor/order-edits`,
+                        { order_id: order.id },
+                        seller1Seed.headers
+                    )
+
+                    // Add a second item via offer_id (the path the vendor UI
+                    // uses). The offer carries a shipping profile, so the
+                    // resulting line item must require shipping — otherwise the
+                    // created fulfillment loses the "Mark as Shipped" action.
+                    const addResp = await api.post(
+                        `/vendor/order-edits/${order.id}/items`,
+                        {
+                            items: [
+                                {
+                                    offer_id: seller1Seed.offer.id,
+                                    quantity: 1,
+                                },
+                            ],
+                        },
+                        seller1Seed.headers
+                    )
+                    expect(addResp.status).toEqual(200)
+
+                    await api.post(
+                        `/vendor/order-edits/${order.id}/request`,
+                        {},
+                        seller1Seed.headers
+                    )
+                    await api.post(
+                        `/vendor/order-edits/${order.id}/confirm`,
+                        {},
+                        seller1Seed.headers
+                    )
+
+                    const query = appContainer.resolve(
+                        ContainerRegistrationKeys.QUERY
+                    )
+                    const { data: orders } = await query.graph({
+                        entity: "order",
+                        fields: ["id", "items.id", "items.requires_shipping"],
+                        filters: { id: order.id },
+                    })
+
+                    const items = (orders[0] as any).items as Array<{
+                        requires_shipping: boolean
+                    }>
+
+                    // The original checkout item already requires shipping; the
+                    // added item must too. Before the fix the added line item
+                    // defaulted to requires_shipping=false (Medusa derives it
+                    // from the product's shipping profile / inventory, neither
+                    // of which reflects Mercur's offer-owned shipping profile).
+                    expect(items.length).toBeGreaterThanOrEqual(1)
+                    for (const item of items) {
+                        expect(item.requires_shipping).toBe(true)
+                    }
+                })
+
                 it("rejects add-item from a non-owner seller", async () => {
                     const order = await completeCartCheckout(seller1Seed.offer.id)
 

--- a/packages/core/src/api/vendor/orders/resolve-offer-items.ts
+++ b/packages/core/src/api/vendor/orders/resolve-offer-items.ts
@@ -35,6 +35,7 @@ export type AddItemInput = {
 type ResolvedAddItem = Omit<AddItemInput, "offer_id"> & {
   variant_id: string
   unit_price?: number | null
+  requires_shipping?: boolean
   metadata?: Record<string, unknown> | null
 }
 
@@ -135,6 +136,15 @@ export const resolveOfferItems = async ({
       variant_id: offer.variant_id,
       quantity: item.quantity,
       unit_price: item.unit_price ?? offerPrice ?? null,
+      // In Mercur the shipping profile is owned by the offer (per-seller),
+      // not the product. Medusa's add-items workflow derives a line item's
+      // `requires_shipping` from `product.shipping_profile` /
+      // `inventory.requires_shipping`, neither of which reflects the offer —
+      // so offer items added via order-edit / exchange / claim flows would
+      // otherwise default to `requires_shipping: false` and lose the
+      // "Mark as Shipped" fulfillment action. Set it explicitly from the
+      // offer's shipping profile so it matches checkout behavior.
+      requires_shipping: !!offer.shipping_profile_id,
       internal_note: item.internal_note,
       allow_backorder: item.allow_backorder,
       metadata: {


### PR DESCRIPTION
## Summary
- Order-edit / exchange / claim "add item" flows resolve items through `resolveOfferItems`, then create line items via Medusa's stock add-line-items workflow. That workflow derives `requires_shipping` from the product's shipping profile / inventory — neither reflects Mercur, where the shipping profile is owned by the per-seller **offer**. Added items therefore defaulted to `requires_shipping: false`.
- Consequence (MER-191): a fulfillment created for newly-added items lost the **Mark as Shipped** action (only **Mark as Delivered** showed), and the items appeared as a separate unfulfilled block.
- Fix: set `requires_shipping` explicitly from the offer's `shipping_profile_id` in `resolveOfferItems`, so added offer items match checkout behavior. Single-point fix covering all vendor + admin add-item routes (order-edits, exchange/claim outbound).

## Linear
[MER-191](https://linear.app/rigbyjs/issue/MER-191)

## Test plan
- [x] New regression test in `integration-tests/http/order/vendor/order-edit.spec.ts`: adds an offer item via order-edit, confirms the edit, asserts every order line item has `requires_shipping: true`.
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test:integration:http -- order-edit.spec` (12/12 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)