### PR TITLE
fix(vendor): polish create-fulfillment form to match design

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -6840,6 +6840,17 @@
             "disabledItemTooltip": {
               "type": "string"
             },
+            "noInventoryLevel": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            },
             "unfulfilledItems": {
               "type": "string"
             },

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1726,7 +1726,11 @@
       "cancelWarning": "You are about to cancel a fulfillment. This action cannot be undone.",
       "markAsDeliveredWarning": "You are about to mark fulfillment as delivered. This action cannot be undone.",
       "differentOptionSelected": "The selected shipping option is different from the one selected by the customer.",
-      "disabledItemTooltip": "The shipping option you have selected don’t allow fulfillment of this item",
+      "disabledItemTooltip": "The location or shipping option you have selected don’t allow fulfillment of this item.",
+      "noInventoryLevel": {
+        "title": "No inventory level",
+        "description": "The selected location does not have an inventory level for the selected items. To proceed with fulfillment, create an inventory level for selected location."
+      },
       "unfulfilledItems": "Unfulfilled Items",
       "statusLabel": "Fulfillment status",
       "statusTitle": "Fulfillment Status",

--- a/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/constants.ts
+++ b/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/constants.ts
@@ -2,6 +2,9 @@ import { z } from "zod"
 
 export const CreateFulfillmentSchema = z.object({
   quantity: z.record(z.string(), z.number()),
+  // Per-item inclusion. Items default to selected; deselecting one
+  // excludes it from the fulfillment payload.
+  selection: z.record(z.string(), z.boolean()).optional(),
   location_id: z.string(),
   shipping_option_id: z.string().optional(),
   send_notification: z.boolean().optional(),

--- a/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-form.tsx
+++ b/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-form.tsx
@@ -1,10 +1,10 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
 
 import { AdminOrder, HttpTypes } from "@medusajs/types"
-import { Alert, Button, Select, Switch, toast } from "@medusajs/ui"
+import { Alert, Button, Heading, Select, Switch, toast } from "@medusajs/ui"
 import { useForm, useWatch } from "react-hook-form"
 
 import { OrderLineItemDTO } from "@medusajs/types"
@@ -68,6 +68,36 @@ export function OrderCreateFulfillmentForm({
   })
 
   const { stock_locations = [] } = useStockLocations()
+
+  // Per-item "no inventory level at the selected location" flags, reported
+  // up from each item row, used to render the aggregate warning below.
+  const [missingLevelMap, setMissingLevelMap] = useState<
+    Record<string, boolean>
+  >({})
+
+  const handleInventoryStatusChange = useCallback(
+    (itemId: string, missingLevel: boolean) => {
+      setMissingLevelMap((prev) => {
+        if (prev[itemId] === missingLevel) {
+          return prev
+        }
+        return { ...prev, [itemId]: missingLevel }
+      })
+    },
+    []
+  )
+
+  const handleToggleSelected = useCallback(
+    (itemId: string, checked: boolean) => {
+      form.setValue(
+        `selection.${itemId}` as `selection.${string}`,
+        checked
+      )
+    },
+    [form]
+  )
+
+  const selection = useWatch({ name: "selection", control: form.control })
 
   const { shipping_options = [], isLoading: isShippingOptionsLoading } =
     useShippingOptions({
@@ -133,7 +163,9 @@ export function OrderCreateFulfillmentForm({
       items: Object.entries(data.quantity)
         .filter(
           ([id, value]) =>
-            !!value && itemShippingProfileMap[id] === selectedShippingProfileId
+            !!value &&
+            data.selection?.[id] !== false &&
+            itemShippingProfileMap[id] === selectedShippingProfileId
         )
         .map(([id, quantity]) => ({
           id,
@@ -229,6 +261,15 @@ export function OrderCreateFulfillmentForm({
     shippingOptionId &&
     order.shipping_methods?.[0]?.shipping_option_id !== shippingOptionId
 
+  // Warn when a location is picked but a selected item has no inventory
+  // level there — it can't be fulfilled from this location.
+  const showNoInventoryWarning =
+    !!selectedLocationId &&
+    fulfillableItems.some(
+      (item) =>
+        selection?.[item.id] !== false && missingLevelMap[item.id] === true
+    )
+
   return (
     <RouteFocusModal.Form form={form}>
       <KeyboundForm
@@ -240,6 +281,9 @@ export function OrderCreateFulfillmentForm({
         <RouteFocusModal.Body className="flex h-full w-full flex-col items-center divide-y overflow-y-auto">
           <div className="flex size-full flex-col items-center overflow-auto p-16">
             <div className="flex w-full max-w-[736px] flex-col justify-center px-2 pb-2">
+              <Heading className="mb-8">
+                {t("orders.fulfillment.create")}
+              </Heading>
               <div className="flex flex-col divide-y divide-dashed">
                 <div className="pb-8">
                   <Form.Field
@@ -280,6 +324,22 @@ export function OrderCreateFulfillmentForm({
                       )
                     }}
                   />
+
+                  {showNoInventoryWarning && (
+                    <Alert
+                      key={selectedLocationId}
+                      variant="warning"
+                      className="mt-4 p-4"
+                      data-testid="fulfillment-no-inventory-warning"
+                    >
+                      <span className="-mt-[3px] block font-medium">
+                        {t("orders.fulfillment.noInventoryLevel.title")}
+                      </span>
+                      <span className="text-ui-fg-muted">
+                        {t("orders.fulfillment.noInventoryLevel.description")}
+                      </span>
+                    </Alert>
+                  )}
                 </div>
 
                 <div className="py-8">
@@ -346,8 +406,8 @@ export function OrderCreateFulfillmentForm({
                     </Alert>
                   )}
                 </div>
-                <div>
-                  <Form.Item className="mt-8">
+                <div className="py-8">
+                  <Form.Item>
                     <Form.Label>
                       {t("orders.fulfillment.itemsToFulfill")}
                     </Form.Label>
@@ -355,7 +415,7 @@ export function OrderCreateFulfillmentForm({
                       {t("orders.fulfillment.itemsToFulfillDesc")}
                     </Form.Hint>
 
-                    <div className="flex flex-col gap-y-1">
+                    <div className="flex flex-col gap-y-2 pt-4">
                       {fulfillableItems.map((item) => {
                         const offerProfileId = (
                           item as unknown as {
@@ -388,6 +448,8 @@ export function OrderCreateFulfillmentForm({
                             currencyCode={order.currency_code}
                             onItemRemove={() => {}}
                             disabled={disabled}
+                            onToggleSelected={handleToggleSelected}
+                            onInventoryStatusChange={handleInventoryStatusChange}
                           />
                         )
                       })}
@@ -405,35 +467,41 @@ export function OrderCreateFulfillmentForm({
                   )}
                 </div>
 
-                <div className="mt-8 pt-8 ">
-                  <Form.Field
-                    control={form.control}
-                    name="send_notification"
-                    render={({ field: { onChange, value, ...field } }) => {
-                      return (
-                        <Form.Item>
-                          <div className="flex items-center justify-between">
-                            <Form.Label>
-                              {t("orders.returns.sendNotification")}
-                            </Form.Label>
-                            <Form.Control>
-                              <Form.Control>
+                <div className="pt-8">
+                  <div className="bg-ui-bg-field rounded-lg border py-2 pl-2 pr-4">
+                    <Form.Field
+                      control={form.control}
+                      name="send_notification"
+                      render={({ field: { onChange, value, ...field } }) => {
+                        return (
+                          <Form.Item>
+                            <div className="flex items-center">
+                              <Form.Control className="mr-4 self-start">
                                 <Switch
+                                  className="mt-[2px]"
                                   checked={!!value}
                                   onCheckedChange={onChange}
                                   {...field}
+                                  data-testid="fulfillment-send-notification"
                                 />
                               </Form.Control>
-                            </Form.Control>
-                          </div>
-                          <Form.Hint className="!mt-1">
-                            {t("orders.fulfillment.sendNotificationHint")}
-                          </Form.Hint>
-                          <Form.ErrorMessage />
-                        </Form.Item>
-                      )
-                    }}
-                  />
+                              <div className="block">
+                                <Form.Label>
+                                  {t("orders.returns.sendNotification")}
+                                </Form.Label>
+                                <Form.Hint className="!mt-1">
+                                  {t(
+                                    "orders.fulfillment.sendNotificationHint"
+                                  )}
+                                </Form.Hint>
+                              </div>
+                            </div>
+                            <Form.ErrorMessage />
+                          </Form.Item>
+                        )
+                      }}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -452,7 +520,7 @@ export function OrderCreateFulfillmentForm({
               isLoading={isMutating}
               disabled={!shippingOptionId}
             >
-              {t("orders.fulfillment.create")}
+              {t("actions.confirm")}
             </Button>
           </div>
         </RouteFocusModal.Footer>

--- a/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-item.tsx
+++ b/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-item.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from "react"
+import { useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
-import { clx, Input, Text, Tooltip } from "@medusajs/ui"
-import { UseFormReturn } from "react-hook-form"
+import { Checkbox, clx, Input, Text, Tooltip } from "@medusajs/ui"
+import { UseFormReturn, useWatch } from "react-hook-form"
 import { HttpTypes } from "@medusajs/types"
 
 import { Form } from "@components/common/form/index"
@@ -19,6 +19,8 @@ type OrderEditItemProps = {
   onItemRemove: (itemId: string) => void
   form: UseFormReturn<zod.infer<typeof CreateFulfillmentSchema>>
   disabled: boolean
+  onToggleSelected: (itemId: string, checked: boolean) => void
+  onInventoryStatusChange: (itemId: string, missingLevel: boolean) => void
 }
 
 export function OrderCreateFulfillmentItem({
@@ -26,6 +28,8 @@ export function OrderCreateFulfillmentItem({
   form,
   locationId,
   disabled,
+  onToggleSelected,
+  onInventoryStatusChange,
 }: OrderEditItemProps) {
   const { t } = useTranslation()
 
@@ -40,32 +44,51 @@ export function OrderCreateFulfillmentItem({
     }
   )
 
-  const { availableQuantity, inStockQuantity } = useMemo(() => {
-    if (!variant || !locationId) {
-      return {}
+  // Items are fulfilled by default; deselecting via the checkbox excludes
+  // the item from the payload. Undefined (never toggled) reads as selected.
+  const isSelected =
+    useWatch({
+      control: form.control,
+      name: `selection.${item.id}` as `selection.${string}`,
+    }) !== false
+
+  const { availableQuantity, inStockQuantity, missingLevel } = useMemo(() => {
+    const inventory = (variant as any)?.inventory
+    const hasInventoryItem = Array.isArray(inventory) && inventory.length > 0
+
+    if (!hasInventoryItem || !locationId) {
+      return { missingLevel: false }
     }
 
-    const { inventory } = variant as any
-
-    const locationInventory = inventory?.[0]?.location_levels?.find(
+    const locationInventory = inventory[0]?.location_levels?.find(
       (inv: any) => inv.location_id === locationId
     )
 
+    // The variant is inventory-managed but has no level at the chosen
+    // location — it cannot be fulfilled from here. Surface this up so the
+    // form can render an aggregate warning.
     if (!locationInventory) {
-      return {}
+      return { missingLevel: true }
     }
 
     return {
       availableQuantity: locationInventory.available_quantity,
       inStockQuantity: locationInventory.stocked_quantity,
+      missingLevel: false,
     }
   }, [variant, locationId])
+
+  useEffect(() => {
+    onInventoryStatusChange(item.id, missingLevel)
+  }, [item.id, missingLevel, onInventoryStatusChange])
 
   const minValue = 0
   const maxValue = Math.min(
     getFulfillableQuantity(item as any),
     availableQuantity || Number.MAX_SAFE_INTEGER
   )
+
+  const inputDisabled = disabled || !isSelected
 
   return (
     <Form.Field
@@ -78,18 +101,31 @@ export function OrderCreateFulfillmentItem({
       }}
       render={({ field }) => {
         return (
-          <div className="bg-ui-bg-subtle shadow-elevation-card-rest my-2 rounded-xl">
+          <div
+            className={clx(
+              "bg-ui-bg-subtle shadow-elevation-card-rest rounded-xl",
+              !isSelected && "opacity-60"
+            )}
+          >
             <div className="flex flex-row items-center">
-              {disabled && (
-                <div className="inline-flex items-center ml-4">
+              <div className="ml-4 flex items-center gap-x-2">
+                <Checkbox
+                  checked={isSelected}
+                  disabled={disabled}
+                  onCheckedChange={(value) =>
+                    onToggleSelected(item.id, value === true)
+                  }
+                  data-testid={`fulfillment-item-${item.id}-checkbox`}
+                />
+                {disabled && (
                   <Tooltip
                     content={t("orders.fulfillment.disabledItemTooltip")}
                     side="top"
                   >
                     <InformationCircleSolid className="text-ui-tag-orange-icon" />
                   </Tooltip>
-                </div>
-              )}
+                )}
+              </div>
 
               <div
                 className={clx(
@@ -143,42 +179,41 @@ export function OrderCreateFulfillmentItem({
                   </div>
 
                   <div className="flex flex-1 items-center gap-1">
+                    <Form.Item>
+                      <Form.Control>
+                        <Input
+                          className="bg-ui-bg-base txt-small w-[50px] rounded-lg text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                          type="number"
+                          {...field}
+                          disabled={inputDisabled}
+                          onChange={(e) => {
+                            const val =
+                              e.target.value === ""
+                                ? null
+                                : Number(e.target.value)
 
-                          <Form.Item>
-                            <Form.Control>
-                              <Input
-                                className="bg-ui-bg-base txt-small w-[50px] rounded-lg text-right [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                                type="number"
-                                {...field}
-                                onChange={(e) => {
-                                  const val =
-                                    e.target.value === ""
-                                      ? null
-                                      : Number(e.target.value)
+                            field.onChange(val)
 
-                                  field.onChange(val)
-
-                                  if (val !== null && !isNaN(val ?? 0)) {
-                                    if (val < minValue || val > maxValue) {
-                                      form.setError(`quantity.${item.id}`, {
-                                        type: "manual",
-                                        message: t(
-                                          "orders.fulfillment.error.wrongQuantity",
-                                          {
-                                            count: maxValue,
-                                            number: maxValue,
-                                          }
-                                        ),
-                                      })
-                                    } else {
-                                      form.clearErrors(`quantity.${item.id}`)
+                            if (val !== null && !isNaN(val ?? 0)) {
+                              if (val < minValue || val > maxValue) {
+                                form.setError(`quantity.${item.id}`, {
+                                  type: "manual",
+                                  message: t(
+                                    "orders.fulfillment.error.wrongQuantity",
+                                    {
+                                      count: maxValue,
+                                      number: maxValue,
                                     }
-                                  }
-                                }}
-                              />
-                            </Form.Control>
-                          </Form.Item>
-
+                                  ),
+                                })
+                              } else {
+                                form.clearErrors(`quantity.${item.id}`)
+                              }
+                            }
+                          }}
+                        />
+                      </Form.Control>
+                    </Form.Item>
 
                     <span className="text-ui-fg-subtle">
                       / {item.quantity} {t("fields.qty")}


### PR DESCRIPTION
## Summary
Design-polish pass over the vendor panel **Create Fulfillment** modal (MER-190), addressing all 7 reported items:

1. Add the missing **"Create Fulfillment"** heading above the form body.
2. Improve spacing — consistent dashed section dividers and `gap-y-2` between item blocks.
3. Add per-item **checkboxes**, selected by default; deselecting excludes the item from the payload (and disables its quantity input).
4. Restyle the **Send notification** switch into the bordered card layout from the design (and remove a stray nested `Form.Control`).
5. Rename the submit button copy from "Create Fulfillment" → **"Confirm"**.
6. Add the **"No inventory level"** warning when the selected location has no inventory level for the selected items.
7. Update the disabled-item **tooltip copy** to "The location or shipping option you have selected don't allow fulfillment of this item."

New i18n keys (`orders.fulfillment.noInventoryLevel.title/description`) were added to both `en.json` and `$schema.json` to keep them in sync.

## Linear
[MER-190](https://linear.app/rigbyjs/issue/MER-190)

## Test plan
- [ ] Open an order → Create fulfillment in the vendor panel; verify heading, spacing, checkboxes (default on, deselect excludes the item), switch card, and the "Confirm" button.
- [ ] Pick a stock location with no inventory level for the items → the "No inventory level" warning appears.
- [ ] Hover a disabled item's info icon → updated tooltip copy.
- [x] `bun run build` (all 9 packages green)
- [x] `oxlint` clean on changed files

> Note: `validate-translations.spec.ts` fails on `canary` for pre-existing schema drift (`store.validation.nameTooLong`, many `orders.claims.*` keys) unrelated to this change; the keys added here are in sync between `en.json` and `$schema.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)