### PR TITLE
fix(vendor): preserve product/variant defaults in detail fields

### DIFF
--- a/packages/vendor/src/pages/product-variants/product-variant-detail/loader.ts
+++ b/packages/vendor/src/pages/product-variants/product-variant-detail/loader.ts
@@ -4,8 +4,10 @@ import { variantsQueryKeys } from "@hooks/api/products"
 import { sdk } from "@lib/client"
 import { queryClient } from "@lib/query-client"
 
+// Prefix bare fields with `+` so they're additive — otherwise Medusa's
+// FieldParser treats them as "replace defaults" and strips title/sku/etc.
 export const VARIANT_DETAIL_FIELDS =
-  "*options,*options.option,thumbnail,images.id,images.url,images.rank,images.variants.id,product.images.id,product.images.url,product.images.rank,product.images.variants.id"
+  "*options,*options.option,+thumbnail,+images.id,+images.url,+images.rank,+images.variants.id,+product.images.id,+product.images.url,+product.images.rank,+product.images.variants.id"
 
 const variantDetailQuery = (productId: string, variantId: string) => ({
   queryKey: variantsQueryKeys.detail(variantId, { fields: VARIANT_DETAIL_FIELDS }),

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -13,8 +13,10 @@ export const PRODUCT_VARIANT_IDS_KEY = "product_variant_ids"
 export const PRODUCT_DETAIL_FIELDS = [
   "*variants.images",
   // Variant identity used by the active edit-request block (MER-168).
-  "variants.title",
-  "variants.sku",
+  // Use `+` so these don't trigger Medusa's "replace defaults" rule
+  // (any bare field strips title/description/subtitle from the product).
+  "+variants.title",
+  "+variants.sku",
   "*categories",
   "+additional_data",
   "*scoped_attributes",


### PR DESCRIPTION
## Summary
- Vendor product detail (`/vendor/products/:id`) returned empty `title`/`subtitle`/`description` because the UI passed bare fields like `variants.title` / `variants.sku`, triggering Medusa's `FieldParser` "replace defaults" rule.
- Vendor variant detail (`/vendor/products/:id/variants/:variant_id`) had the same issue from `thumbnail`, `images.id`, `product.images.*` etc. being bare.
- Prefixed those fields with `+` so they're additive and the route's `defaults` (title, sku, subtitle, description, …) are preserved.

Admin worked because its detail field strings only used modifier-prefixed fields (`*`, `-`).

## Test plan
- [ ] Open a vendor product detail page — verify `title`, `subtitle`, `description` are populated.
- [ ] Open a vendor variant detail page — verify `title`, `sku` are populated and images still load.
- [ ] Regression: confirm the edit-request block (MER-168) still sees `variants.title` / `variants.sku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)