### PR TITLE
ci: shard HTTP integration tests across parallel jobs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,9 +12,16 @@ concurrency:
 
 jobs:
   integration-http:
-    name: HTTP integration tests
+    name: HTTP integration tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
+
+    strategy:
+      # Run every shard to completion even if one fails, so a single broken
+      # shard doesn't mask failures (or passes) in the others.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     services:
       postgres:
@@ -84,8 +91,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          # Per-shard key so parallel shards don't race to save the same entry;
+          # restore-keys still lets each shard reuse another shard's build cache.
+          key: ${{ runner.os }}-turbo-${{ github.sha }}-${{ matrix.shard }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.sha }}-
             ${{ runner.os }}-turbo-
 
       - name: Install dependencies
@@ -95,4 +105,23 @@ jobs:
         run: bun run build
 
       - name: Run HTTP integration tests
-        run: bun run test:integration:http
+        # Jest balances spec files across shards by count; each shard runs an
+        # independent ~1/4 of the suite against its own Postgres/Redis service.
+        run: cd integration-tests && bun run test:integration:http -- --shard=${{ matrix.shard }}/4
+
+  # Single required status check that aggregates every shard. Branch protection
+  # should require this job instead of the individual matrix shards (whose names
+  # change if the shard count changes).
+  all-passed:
+    name: Integration tests passed
+    if: always()
+    needs: integration-http
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all shards succeeded
+        run: |
+          if [ "${{ needs.integration-http.result }}" != "success" ]; then
+            echo "One or more integration test shards did not succeed (result: ${{ needs.integration-http.result }})"
+            exit 1
+          fi
+          echo "All integration test shards passed."


### PR DESCRIPTION
## Problem

The `integration-http` CI job ran all **56 HTTP spec files serially** (`jest --runInBand`). Each spec boots a full Medusa server and migrates a fresh DB via `medusaIntegrationTestRunner`, so per-file bootstrap overhead dominates. As specs are added the suite creeps toward the **60-minute timeout**, which is what's been failing the build & integration test workflow.

## Change

- **4-way shard matrix** on `integration-http` using `jest --shard=${{ matrix.shard }}/4`. Jest balances spec files across shards by count (~14 each), and each shard runs against its own Postgres/Redis service container.
- `fail-fast: false` so one broken shard doesn't cancel/mask the others.
- `timeout-minutes` lowered 60 → 30 (each shard does ~¼ of the work).
- Turbo cache key is now per-shard with `restore-keys` fallbacks, so parallel shards don't race to write the same cache entry but still reuse each other's build output.
- New **`all-passed` gate job** (`needs: integration-http`, `if: always()`) that succeeds only when the aggregated shard result is `success`.

No test code changes — sharding is inherently DB-isolated since each shard gets its own service containers. This mirrors how Vendure shards its Playwright e2e suite.

## Expected effect

~4× faster wall-clock, comfortably under the 30-min budget, and re-scalable by bumping the `[1,2,3,4]` array and the `/4` divisor.

## ⚠️ Follow-up required (manual)

Update branch protection to require the **"Integration tests passed"** gate job instead of the individual per-shard checks. The per-shard check names contain the shard number, so they'd break if the shard count ever changes — the gate is the stable required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)