### PR TITLE
fix(vendor): refresh product list after deleting a draft

### DIFF
--- a/packages/vendor/src/hooks/api/products.tsx
+++ b/packages/vendor/src/hooks/api/products.tsx
@@ -203,6 +203,9 @@ export const useDeleteProduct = (
         queryKey: productChangeQueryKeys.detail(id),
       });
       queryClient.invalidateQueries({ queryKey: productsQueryKeys.detail(id) });
+      // A draft delete applies inline (the product is gone on the server), so
+      // the list must refetch or the deleted row lingers and 404s on click.
+      queryClient.invalidateQueries({ queryKey: productsQueryKeys.lists() });
 
       options?.onSuccess?.(data, variables, context);
     },


### PR DESCRIPTION
## Summary
- Deleting a **draft** product applies inline on the server (the product is actually removed), but `useDeleteProduct` only invalidated the product *detail* query keys — never the list. The deleted draft lingered in the products table and threw a 404 when clicked.
- Invalidate `productsQueryKeys.lists()` on success so the table refetches, mirroring the other product mutations in the same hook file.

Root cause is purely frontend cache invalidation; the backend already deletes draft products inline (covered by `product-edit-draft-delete.spec.ts`, MER-181).

## Linear
[MER-193](https://linear.app/rigbyjs/issue/MER-193)

## Test plan
- [ ] Vendor panel → Products: delete a `draft` product → it disappears from the table immediately and is no longer clickable.
- [x] `bun run build` (9/9 packages)
- [x] `bun run test:integration:http -- product-edit-draft-delete` (2/2 — backend draft-delete contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)