### PR TITLE
fix(vendor): default offer catalogue sort to title

### DIFF
--- a/packages/vendor/src/pages/offers/create/create-offer-form/create-offer-catalogue.tsx
+++ b/packages/vendor/src/pages/offers/create/create-offer-form/create-offer-catalogue.tsx
@@ -121,6 +121,7 @@ const Root = () => {
           { key: "created_at", label: t("fields.createdAt") },
           { key: "updated_at", label: t("fields.updatedAt") },
         ]}
+        defaultOrderBy="title"
         queryObject={raw}
         layout="fill"
         pagination


### PR DESCRIPTION
## Summary
- The Create Offer → Step 1 (Products) table already fetched products with `order=title` by default, but the sort dropdown showed no active selection because `defaultOrderBy` was not passed to `_DataTable`.
- Pass `defaultOrderBy="title"` so the sort UI reflects the default sort, consistent with the vendor product list and offer lists.

Addresses the review comment on MER-171: *"Sorting should be by title by default."*

## Linear
[MER-171](https://linear.app/rigbyjs/issue/MER-171)

## Test plan
- [ ] Open Vendor Panel → Offers → Create → Step 1 (Products); the sort dropdown shows **Title** selected by default and the list is ordered alphabetically by title.
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)