### PR TITLE
fix(vendor): address offers list review feedback (MER-170)

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -4545,12 +4545,16 @@
             "description": {
               "type": "string"
             },
+            "descriptionByName": {
+              "type": "string"
+            },
             "successToast": {
               "type": "string"
             }
           },
           "required": [
             "description",
+            "descriptionByName",
             "successToast"
           ],
           "additionalProperties": false

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1105,6 +1105,7 @@
     },
     "delete": {
       "description": "You are about to delete offer {{sku}}. This cannot be undone.",
+      "descriptionByName": "You are about to delete the offer {{name}}. This action cannot be undone.",
       "successToast": "Offer was successfully deleted."
     },
     "bulkDelete": {

--- a/packages/vendor/src/pages/offers/_components/offer-actions.tsx
+++ b/packages/vendor/src/pages/offers/_components/offer-actions.tsx
@@ -33,7 +33,7 @@ export const OfferActions = ({ product }: { product: OfferProductActions }) => {
       title: t("general.areYouSure"),
       // The product listing is one offer to the seller, regardless of how
       // many of its variants are offered under the hood.
-      description: t("offers.bulkDelete.description", { count: 1 }),
+      description: t("offers.delete.descriptionByName", { name: product.title }),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
       variant: "danger",
@@ -46,7 +46,7 @@ export const OfferActions = ({ product }: { product: OfferProductActions }) => {
     const result = await bulkDelete(product.offerIds)
 
     if (result.failed.length === 0) {
-      toast.success(t("offers.bulkDelete.successToast", { count: 1 }))
+      toast.success(t("offers.delete.successToast"))
     } else {
       toast.warning(
         t("offers.bulkDelete.partialToast", {

--- a/packages/vendor/src/pages/offers/_components/offer-list-header.tsx
+++ b/packages/vendor/src/pages/offers/_components/offer-list-header.tsx
@@ -12,7 +12,7 @@ export const OfferListActions = () => {
   const { t } = useTranslation()
 
   return (
-    <Button size="small" variant="primary" asChild>
+    <Button size="small" variant="secondary" asChild>
       <Link to="create" data-testid="offer-list-create-button">
         {t("offers.actions.create")}
       </Link>

--- a/packages/vendor/src/pages/offers/_components/use-offer-table-columns.tsx
+++ b/packages/vendor/src/pages/offers/_components/use-offer-table-columns.tsx
@@ -9,7 +9,6 @@ import {
 } from "../../../components/table/table-cells/product/category-cell"
 import {
   ProductCell,
-  ProductHeader,
 } from "../../../components/table/table-cells/product/product-cell"
 import {
   ProductStatusCell,
@@ -42,7 +41,7 @@ export const useOfferTableColumns = () => {
     () => [
       columnHelper.display({
         id: "product",
-        header: () => <ProductHeader />,
+        header: t("offers.domain"),
         cell: ({ row }) => (
           <ProductCell
             product={{


### PR DESCRIPTION
## Summary
Applies the design review comments on the vendor **Offers** list (MER-170):

- **Button variant** — header *Create* button now uses `secondary` instead of `primary`.
- **First column label** — header reads **"Offers"** instead of "Products".
- **Delete prompt** — row delete now reads *"You are about to delete the offer [name]. This action cannot be undone."* (uses the offer name, new wording).
- **Delete toast** — row delete success toast reads *"Offer was successfully deleted."*

Added `offers.delete.descriptionByName` to `en.json` and the i18n `$schema.json` to keep the two in sync.

## Linear
[MER-170](https://linear.app/rigbyjs/issue/MER-170)

## Test plan
- [ ] Vendor → Offers: *Create* button is secondary; first column header is "Offers".
- [ ] Delete an offer from the row kebab → prompt names the offer; success toast says "Offer was successfully deleted."
- [x] `bun run build` (9/9 packages)

> Note: the `validate-translations` suite has a pre-existing unrelated failure (`store.validation.nameTooLong` is in `$schema.json` but missing from `en.json` on `canary`); it is not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)