### PR TITLE
fix(vendor): make offer variant SKU optional in edit drawer

### DIFF
--- a/integration-tests/http/offer/vendor/offer.spec.ts
+++ b/integration-tests/http/offer/vendor/offer.spec.ts
@@ -338,6 +338,35 @@ medusaIntegrationTestRunner({
                     )
                 })
 
+                it("should update an offer without a sku (sku is optional) and keep the existing sku", async () => {
+                    const deps = await seedSellerOfferDeps(seller1Headers)
+
+                    const created = await api.post(
+                        `/vendor/offers`,
+                        {
+                            sku: "UPD-NO-SKU",
+                            variant_id: deps.variant_id,
+                            shipping_profile_id: deps.shipping_profile_id,
+                            inventory_items: [{}],
+                            prices: [
+                                { amount: 1000, currency_code: "usd" },
+                            ],
+                        },
+                        seller1Headers
+                    )
+
+                    const offerId = created.data.offer.id
+
+                    const response = await api.post(
+                        `/vendor/offers/${offerId}`,
+                        { metadata: { note: "no sku in payload" } },
+                        seller1Headers
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offer.sku).toEqual("UPD-NO-SKU")
+                })
+
                 it("should add, update, and delete prices in one call (replace semantics)", async () => {
                     const deps = await seedSellerOfferDeps(seller1Headers)
 

--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/edit/index.tsx
@@ -12,7 +12,7 @@ import { useOffer, useUpdateOffer } from "../../../../../../hooks/api/offers"
 import { OFFER_VARIANT_DETAIL_FIELDS } from "../../../../common/constants"
 import { OfferDetail } from "../../../../common/types"
 
-const Schema = z.object({ sku: z.string().min(1).max(64) })
+const Schema = z.object({ sku: z.string().max(64).optional() })
 type Values = z.infer<typeof Schema>
 
 /**
@@ -30,8 +30,11 @@ const EditOfferVariantForm = ({ offer }: { offer: OfferDetail }) => {
   const { mutateAsync, isPending } = useUpdateOffer(offer.id)
 
   const handleSubmit = form.handleSubmit(async (values) => {
+    // SKU is optional: leave the offer's SKU untouched when the field is blank
+    // rather than sending an empty string (the API rejects "" on update).
+    const sku = values.sku?.trim()
     await mutateAsync(
-      { sku: values.sku },
+      sku ? { sku } : {},
       {
         onSuccess: () => {
           toast.success(t("offers.edit.successToast"))


### PR DESCRIPTION
## Summary
- The offer-variant **Edit details** drawer marked SKU as optional but enforced `z.string().min(1)` client-side, so saving with the field blank showed a validation error (per review on MER-176).
- Dropped the required client validation and now omit a blank SKU from the update payload — the vendor update API still rejects `""` via its own `min(1)`, so clearing the SKU no longer errors and leaves the existing SKU untouched.
- Added an integration test asserting `POST /vendor/offers/:id` succeeds without a `sku` and preserves the existing one.

## Linear
[MER-176](https://linear.app/rigbyjs/issue/MER-176)

## Test plan
- [x] `bun run build`
- [x] `bun run lint` (no new errors in changed files; pre-existing unrelated failures remain)
- [x] `bun run test:integration:http -- offer/vendor/offer.spec` (18 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)