### PR TITLE
feat(vendor): category list thumbnail and read-only media/icon sections

### DIFF
--- a/packages/core/src/api/vendor/product-categories/query-config.ts
+++ b/packages/core/src/api/vendor/product-categories/query-config.ts
@@ -13,6 +13,12 @@ export const vendorProductCategoryFields = [
   "metadata",
   "*parent_category",
   "*category_children",
+  "images.id",
+  "images.url",
+  "images.type",
+  "images.is_thumbnail",
+  "images.is_banner",
+  "images.rank",
 ]
 
 export const vendorProductCategoryQueryConfig = {

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -3980,6 +3980,72 @@
           ],
           "additionalProperties": false
         },
+        "media": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "thumbnail": {
+              "type": "string"
+            },
+            "banner": {
+              "type": "string"
+            },
+            "empty": {
+              "type": "object",
+              "properties": {
+                "header": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "header",
+                "description"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "label",
+            "thumbnail",
+            "banner",
+            "empty"
+          ],
+          "additionalProperties": false
+        },
+        "icon": {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "empty": {
+              "type": "object",
+              "properties": {
+                "header": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "header",
+                "description"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "label",
+            "empty"
+          ],
+          "additionalProperties": false
+        },
         "fields": {
           "type": "object",
           "properties": {
@@ -4082,6 +4148,8 @@
         "delete",
         "products",
         "organize",
+        "media",
+        "icon",
         "fields"
       ],
       "additionalProperties": false
@@ -4545,16 +4613,12 @@
             "description": {
               "type": "string"
             },
-            "descriptionByName": {
-              "type": "string"
-            },
             "successToast": {
               "type": "string"
             }
           },
           "required": [
             "description",
-            "descriptionByName",
             "successToast"
           ],
           "additionalProperties": false

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -968,6 +968,22 @@
       "header": "Organize",
       "action": "Edit ranking"
     },
+    "media": {
+      "label": "Media",
+      "thumbnail": "Thumbnail",
+      "banner": "Banner",
+      "empty": {
+        "header": "No media yet",
+        "description": "Media added by the marketplace operator will appear here."
+      }
+    },
+    "icon": {
+      "label": "Icon",
+      "empty": {
+        "header": "No icon yet",
+        "description": "An icon added by the marketplace operator will appear here."
+      }
+    },
     "fields": {
       "visibility": {
         "label": "Visibility",
@@ -1105,7 +1121,6 @@
     },
     "delete": {
       "description": "You are about to delete offer {{sku}}. This cannot be undone.",
-      "descriptionByName": "You are about to delete the offer {{name}}. This action cannot be undone.",
       "successToast": "Offer was successfully deleted."
     },
     "bulkDelete": {

--- a/packages/vendor/src/pages/categories/[id]/_components/category-icon-section/category-icon-section.tsx
+++ b/packages/vendor/src/pages/categories/[id]/_components/category-icon-section/category-icon-section.tsx
@@ -1,0 +1,54 @@
+import { HttpTypes } from "@medusajs/types"
+import { Container, Heading, Text } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
+
+import {
+  CategoryWithImages,
+  getCategoryIcon,
+} from "../../../common/components/category-image-fields"
+
+type CategoryIconSectionProps = {
+  category: HttpTypes.AdminProductCategory & CategoryWithImages
+}
+
+export const CategoryIconSection = ({
+  category,
+}: CategoryIconSectionProps) => {
+  const { t } = useTranslation()
+
+  const icon = getCategoryIcon(category.images)
+
+  return (
+    <Container className="divide-y p-0" data-testid="category-icon-section">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading>{t("categories.icon.label")}</Heading>
+      </div>
+      <div className="px-6 py-4">
+        {icon ? (
+          <div className="bg-ui-bg-base shadow-elevation-card-rest relative aspect-square w-24 overflow-hidden rounded-[8px]">
+            <img
+              src={icon.url}
+              alt=""
+              className="size-full object-contain object-center p-2"
+              data-testid="category-icon-section-image"
+            />
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-y-1 py-8">
+            <Text
+              size="small"
+              leading="compact"
+              weight="plus"
+              className="text-ui-fg-subtle"
+            >
+              {t("categories.icon.empty.header")}
+            </Text>
+            <Text size="small" className="text-ui-fg-muted">
+              {t("categories.icon.empty.description")}
+            </Text>
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/packages/vendor/src/pages/categories/[id]/_components/category-icon-section/index.ts
+++ b/packages/vendor/src/pages/categories/[id]/_components/category-icon-section/index.ts
@@ -1,0 +1,1 @@
+export * from "./category-icon-section"

--- a/packages/vendor/src/pages/categories/[id]/_components/category-media-section/category-media-section.tsx
+++ b/packages/vendor/src/pages/categories/[id]/_components/category-media-section/category-media-section.tsx
@@ -1,0 +1,76 @@
+import { FeaturedBadge, ThumbnailBadge } from "@medusajs/icons"
+import { HttpTypes } from "@medusajs/types"
+import { Container, Heading, Text, Tooltip } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
+
+import {
+  CategoryWithImages,
+  getCategoryGallery,
+} from "../../../common/components/category-image-fields"
+
+type CategoryMediaSectionProps = {
+  category: HttpTypes.AdminProductCategory & CategoryWithImages
+}
+
+export const CategoryMediaSection = ({
+  category,
+}: CategoryMediaSectionProps) => {
+  const { t } = useTranslation()
+
+  const gallery = getCategoryGallery(category.images)
+
+  return (
+    <Container className="divide-y p-0" data-testid="category-media-section">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading>{t("categories.media.label")}</Heading>
+      </div>
+      <div className="px-6 py-4">
+        {gallery.length > 0 ? (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-4">
+            {gallery.map((image) => (
+              <div
+                key={image.id}
+                className="shadow-elevation-card-rest relative aspect-square size-full overflow-hidden rounded-[8px]"
+                data-testid={`category-media-section-item-${image.id}`}
+              >
+                <img
+                  src={image.url}
+                  alt=""
+                  className="size-full object-cover object-center"
+                />
+                {(image.is_thumbnail || image.is_banner) && (
+                  <div className="absolute left-2 top-2 flex items-center gap-x-1">
+                    {image.is_thumbnail && (
+                      <Tooltip content={t("categories.media.thumbnail")}>
+                        <ThumbnailBadge />
+                      </Tooltip>
+                    )}
+                    {image.is_banner && (
+                      <Tooltip content={t("categories.media.banner")}>
+                        <FeaturedBadge className="text-ui-fg-interactive" />
+                      </Tooltip>
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-y-1 py-8">
+            <Text
+              size="small"
+              leading="compact"
+              weight="plus"
+              className="text-ui-fg-subtle"
+            >
+              {t("categories.media.empty.header")}
+            </Text>
+            <Text size="small" className="text-ui-fg-muted">
+              {t("categories.media.empty.description")}
+            </Text>
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/packages/vendor/src/pages/categories/[id]/_components/category-media-section/index.ts
+++ b/packages/vendor/src/pages/categories/[id]/_components/category-media-section/index.ts
@@ -1,0 +1,1 @@
+export * from "./category-media-section"

--- a/packages/vendor/src/pages/categories/[id]/_components/index.ts
+++ b/packages/vendor/src/pages/categories/[id]/_components/index.ts
@@ -1,3 +1,5 @@
 export * from "./category-general-section"
+export * from "./category-icon-section"
+export * from "./category-media-section"
 export * from "./category-organize-section"
 export * from "./category-product-section"

--- a/packages/vendor/src/pages/categories/[id]/category-detail-page.tsx
+++ b/packages/vendor/src/pages/categories/[id]/category-detail-page.tsx
@@ -6,6 +6,8 @@ import { TwoColumnPage } from "@components/layout/pages";
 import { useProductCategory } from "@hooks/api";
 
 import { CategoryGeneralSection } from "./_components/category-general-section";
+import { CategoryIconSection } from "./_components/category-icon-section";
+import { CategoryMediaSection } from "./_components/category-media-section";
 import { CategoryOrganizeSection } from "./_components/category-organize-section";
 import { CategoryProductSection } from "./_components/category-product-section";
 
@@ -24,7 +26,7 @@ const Root = ({ children }: { children?: ReactNode }) => {
   if (categoryLoading || !product_category) {
     return (
       <TwoColumnPageSkeleton
-        mainSections={2}
+        mainSections={4}
         sidebarSections={1}
         showJSON
         showMetadata
@@ -44,6 +46,8 @@ const Root = ({ children }: { children?: ReactNode }) => {
         <TwoColumnPage data={product_category}>
           <TwoColumnPage.Main>
             <CategoryGeneralSection category={product_category} />
+            <CategoryMediaSection category={product_category} />
+            <CategoryIconSection category={product_category} />
             <CategoryProductSection category={product_category} />
           </TwoColumnPage.Main>
           <TwoColumnPage.Sidebar>
@@ -59,6 +63,8 @@ export const CategoryDetailPage = Object.assign(Root, {
   Main: TwoColumnPage.Main,
   Sidebar: TwoColumnPage.Sidebar,
   MainGeneralSection: CategoryGeneralSection,
+  MainMediaSection: CategoryMediaSection,
+  MainIconSection: CategoryIconSection,
   MainProductSection: CategoryProductSection,
   SidebarOrganizeSection: CategoryOrganizeSection,
 });

--- a/packages/vendor/src/pages/categories/_components/category-list-table/use-category-table-columns.tsx
+++ b/packages/vendor/src/pages/categories/_components/category-list-table/use-category-table-columns.tsx
@@ -5,15 +5,20 @@ import { createColumnHelper } from "@tanstack/react-table"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
-// import { StatusCell } from "@components/table/table-cells/common/status-cell';
+import { Thumbnail } from "@components/common/thumbnail"
+import { StatusCell } from "@components/table/table-cells/common/status-cell"
 import {
   TextCell,
   TextHeader,
 } from "@components/table/table-cells/common/text-cell"
 import {
+  CategoryWithImages,
+  getCategoryGallery,
+} from "../../common/components/category-image-fields"
+import {
   getCategoryPath,
-  // getIsActiveProps,
-  // getIsInternalProps,
+  getIsActiveProps,
+  getIsInternalProps,
 } from "../../common/utils"
 
 const columnHelper =
@@ -56,6 +61,14 @@ export const useCategoryTableColumns = () => {
             )
           }
 
+          const gallery = getCategoryGallery(
+            (row.original as CategoryWithImages).images
+          )
+          const thumbnailSrc =
+            gallery.find((image) => image.is_thumbnail)?.url ??
+            gallery[0]?.url ??
+            null
+
           return (
             <div className="flex size-full items-center gap-x-3 overflow-hidden">
               <div className="flex size-7 items-center justify-center">
@@ -81,6 +94,7 @@ export const useCategoryTableColumns = () => {
                   </IconButton>
                 ) : null}
               </div>
+              <Thumbnail src={thumbnailSrc} />
               <span className="truncate">{getValue()}</span>
             </div>
           )
@@ -92,38 +106,24 @@ export const useCategoryTableColumns = () => {
           return <TextCell text={`/${getValue()}`} />
         },
       }),
-      // columnHelper.accessor('is_active', {
-      //   header: () => (
-      //     <TextHeader text={t('fields.status')} />
-      //   ),
-      //   cell: ({ getValue }) => {
-      //     console.log('getValue', getValue());
-      //     // const { color, label } = getIsActiveProps(
-      //     //   getValue(),
-      //     //   t
-      //     // );
+      columnHelper.accessor("is_active", {
+        header: () => <TextHeader text={t("fields.status")} />,
+        cell: ({ getValue }) => {
+          const { color, label } = getIsActiveProps(getValue(), t)
 
-      //     return (
-      //       // <StatusCell color={color}>{label}</StatusCell>
-      //       <span>eee</span>
-      //     );
-      //   },
-      // }),
-      // columnHelper.accessor('is_internal', {
-      //   header: () => (
-      //     <TextHeader
-      //       text={t('categories.fields.visibility.label')}
-      //     />
-      //   ),
-      //   cell: ({ getValue }) => {
-      //     // const { color, label } = getIsInternalProps(
-      //     //   getValue(),
-      //     //   t
-      //     // );
+          return <StatusCell color={color}>{label}</StatusCell>
+        },
+      }),
+      columnHelper.accessor("is_internal", {
+        header: () => (
+          <TextHeader text={t("categories.fields.visibility.label")} />
+        ),
+        cell: ({ getValue }) => {
+          const { color, label } = getIsInternalProps(getValue(), t)
 
-      //     return <span>ddd</span>;
-      //   },
-      // }),
+          return <StatusCell color={color}>{label}</StatusCell>
+        },
+      }),
     ],
     [t]
   )

--- a/packages/vendor/src/pages/categories/common/components/category-image-fields/index.ts
+++ b/packages/vendor/src/pages/categories/common/components/category-image-fields/index.ts
@@ -1,0 +1,1 @@
+export * from "./types"

--- a/packages/vendor/src/pages/categories/common/components/category-image-fields/types.ts
+++ b/packages/vendor/src/pages/categories/common/components/category-image-fields/types.ts
@@ -1,0 +1,27 @@
+/** Shape of a category image as returned by the vendor API (linked `images`). */
+export type CategoryApiImage = {
+  id: string
+  url: string
+  type: string | null
+  is_thumbnail: boolean
+  is_banner: boolean
+  rank?: number
+}
+
+export type CategoryWithImages = {
+  images?: CategoryApiImage[] | null
+}
+
+/** Gallery images (type = null), ordered by rank. */
+export const getCategoryGallery = (
+  images?: CategoryApiImage[] | null
+): CategoryApiImage[] =>
+  (images ?? [])
+    .filter((image) => !image.type)
+    .sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0))
+
+/** The single icon image (type = "icon"), or null. */
+export const getCategoryIcon = (
+  images?: CategoryApiImage[] | null
+): CategoryApiImage | null =>
+  (images ?? []).find((image) => image.type === "icon") ?? null


### PR DESCRIPTION
## What

Migrates the **vendor panel categories** to the [Vendor Panel 2.0 Figma](https://www.figma.com/design/sYJoh84Owr5tomRjpxG0no/-Mercur-2.0----Vendor-Panel?node-id=40013450-771794), mirroring the admin category media gallery + icon work shipped in MER-156 ([#1017](https://github.com/mercurjs/mercur/pull/1017)). On the vendor side these surfaces are **read-only** — media and icon are owned/edited by the marketplace operator in admin; the vendor only views them.

### 1. Category list
- Thumbnail next to the category name (uses the category's thumbnail image, falling back to the first gallery image).
- Restored the **Status** and **Visibility** columns (previously commented out) to match the design.

### 2. Category detail
- New **read-only Media** section: gallery grid with thumbnail/banner badges, plus an empty state.
- New **read-only Icon** section: single icon preview, plus an empty state.
- Section order now matches the design and admin: General → Media → Icon → Products, with Organize in the sidebar.

### Backend
- Expose the linked category `images` (`id`, `url`, `type`, `is_thumbnail`, `is_banner`, `rank`) on the vendor `product-categories` API via its query config. The category → image link already existed and is entity-agnostic.

### i18n
- Added `categories.media.*` and `categories.icon.*` keys to vendor `en.json` and `$schema.json` (read-only subset).

## Notes
- Components were heavily inspired by the existing admin implementation, stripped of the edit affordances (no edit `ActionMenu`, no upload forms) to keep the vendor surface read-only.

## Verification
- `bun run build --filter=@mercurjs/vendor --filter=@mercurjs/core` passes, including full DTS type-checking.
- `oxlint` on the changed vendor files reports no new warnings.
- The new `categories.media`/`categories.icon` keys validate cleanly against the i18n schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)