### PR TITLE
fix(vendor): address offer shipping configuration review feedback (MER-178)

### DIFF
--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/_components/offer-variant-shipping-section.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/_components/offer-variant-shipping-section.tsx
@@ -7,15 +7,19 @@ import { ActionMenu } from "../../../../../../components/common/action-menu"
 import { NoRecords } from "../../../../../../components/common/empty-table-content"
 
 type OfferShippingData = {
-  shipping_profile?: { name?: string | null; type?: string | null } | null
+  shipping_profile?: {
+    id?: string | null
+    name?: string | null
+    type?: string | null
+  } | null
 }
 
 /**
  * Sidebar "Shipping Configuration" card of the Offer Variant detail
  * (Figma `40016503:749900`). Mirrors the offer detail's "Associated
  * product" card structure/size: an `Edit` kebab in the header and a
- * Pattern-A card (icon + name/subtitle + chevron) linking to the edit
- * drawer.
+ * Pattern-A card (icon + name/subtitle + chevron) linking to the
+ * shipping profile detail page under Settings.
  */
 export const OfferVariantShippingSection = ({
   offer,
@@ -46,7 +50,7 @@ export const OfferVariantShippingSection = ({
       {profile?.name ? (
         <div className="txt-small flex flex-col gap-2 px-2 pb-2">
           <Link
-            to="shipping"
+            to={`/settings/shipping-profiles/${profile.id}`}
             className="outline-none focus-within:shadow-borders-interactive-with-focus rounded-md [&:hover>div]:bg-ui-bg-component-hover"
             data-testid="offer-variant-shipping-link"
           >

--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/shipping/index.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/shipping/index.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Button, Heading, Select, toast } from "@medusajs/ui"
+import { Button, Heading, RadioGroup, toast } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
@@ -10,17 +10,19 @@ import { RouteDrawer, useRouteModal } from "../../../../../../components/modals"
 import { KeyboundForm } from "../../../../../../components/utilities/keybound-form"
 import { useShippingProfiles } from "../../../../../../hooks/api/shipping-profiles"
 import { useOffer, useUpdateOffer } from "../../../../../../hooks/api/offers"
-import { useDocumentDirection } from "../../../../../../hooks/use-document-direction"
 import { OFFER_VARIANT_DETAIL_FIELDS } from "../../../../common/constants"
 import { OfferDetail } from "../../../../common/types"
 
 const Schema = z.object({ shipping_profile_id: z.string().min(1) })
 type Values = z.infer<typeof Schema>
 
-/** Edit Shipping Configuration drawer — a single shipping-profile select. */
+/**
+ * Edit Shipping Configuration drawer — a single shipping-profile choice.
+ * Only one profile can be selected, so the options are rendered as radio
+ * buttons rather than a checkmark select.
+ */
 const EditShippingForm = ({ offer }: { offer: OfferDetail }) => {
   const { t } = useTranslation()
-  const dir = useDocumentDirection()
   const { handleSuccess } = useRouteModal()
   const { shipping_profiles } = useShippingProfiles({ limit: 1000 })
 
@@ -58,18 +60,20 @@ const EditShippingForm = ({ offer }: { offer: OfferDetail }) => {
               <Form.Item>
                 <Form.Label>{t("offers.fields.shippingProfile")}</Form.Label>
                 <Form.Control>
-                  <Select {...f} onValueChange={onChange} dir={dir}>
-                    <Select.Trigger ref={_r}>
-                      <Select.Value />
-                    </Select.Trigger>
-                    <Select.Content>
-                      {(shipping_profiles ?? []).map((p) => (
-                        <Select.Item key={p.id} value={p.id}>
-                          {p.name}
-                        </Select.Item>
-                      ))}
-                    </Select.Content>
-                  </Select>
+                  <RadioGroup
+                    {...f}
+                    onValueChange={onChange}
+                    className="flex flex-col gap-3"
+                  >
+                    {(shipping_profiles ?? []).map((p) => (
+                      <RadioGroup.ChoiceBox
+                        key={p.id}
+                        value={p.id}
+                        label={p.name ?? ""}
+                        description={p.type ?? ""}
+                      />
+                    ))}
+                  </RadioGroup>
                 </Form.Control>
                 <Form.ErrorMessage />
               </Form.Item>


### PR DESCRIPTION
## Summary
- Offer variant **Shipping Configuration** card now links to the shipping profile detail page under Settings (`/settings/shipping-profiles/:id`) instead of opening the edit drawer.
- The edit drawer renders shipping-profile options as **radio buttons** (`RadioGroup.ChoiceBox`) instead of a checkmark select, since only one profile can be selected.

## Linear
[MER-178](https://linear.app/rigbyjs/issue/MER-178)

Addresses review feedback:
1. Clicking the Shipping Profile block should redirect to Settings → Shipping Profile Details, not the editing modal.
2. Single-select options should use radio buttons instead of checkmarks.

## Test plan
- [ ] Open an offer variant detail → click the Shipping Configuration card → lands on the shipping profile detail page under Settings.
- [ ] Open the Shipping Configuration edit drawer (kebab → Edit) → profiles render as radio options; selecting one and saving persists.
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)