### PR TITLE
fix(offers): require shipping profile when creating vendor offers

### DIFF
--- a/integration-tests/http/offer/vendor/offer.spec.ts
+++ b/integration-tests/http/offer/vendor/offer.spec.ts
@@ -236,6 +236,80 @@ medusaIntegrationTestRunner({
                     expect(r1.status).toEqual(201)
                     expect(r2.status).toEqual(201)
                 })
+
+                it("should reject create when shipping_profile_id is missing", async () => {
+                    const deps = await seedSellerOfferDeps(seller1Headers)
+
+                    const response = await api
+                        .post(
+                            `/vendor/offers`,
+                            {
+                                sku: "NO-SHIPPING-PROFILE",
+                                variant_id: deps.variant_id,
+                                inventory_items: [{}],
+                                prices: [
+                                    { amount: 2000, currency_code: "usd" },
+                                ],
+                            },
+                            seller1Headers
+                        )
+                        .catch((e) => e.response)
+
+                    expect(response.status).toEqual(400)
+                })
+
+                it("should reject create when shipping_profile_id is an empty string", async () => {
+                    const deps = await seedSellerOfferDeps(seller1Headers)
+
+                    const response = await api
+                        .post(
+                            `/vendor/offers`,
+                            {
+                                sku: "EMPTY-SHIPPING-PROFILE",
+                                variant_id: deps.variant_id,
+                                shipping_profile_id: "",
+                                inventory_items: [{}],
+                                prices: [
+                                    { amount: 2000, currency_code: "usd" },
+                                ],
+                            },
+                            seller1Headers
+                        )
+                        .catch((e) => e.response)
+
+                    expect(response.status).toEqual(400)
+                })
+            })
+
+            describe("POST /vendor/offers/batch", () => {
+                it("should reject the batch when any item has an empty shipping_profile_id", async () => {
+                    const deps = await seedSellerOfferDeps(seller1Headers)
+
+                    const response = await api
+                        .post(
+                            `/vendor/offers/batch`,
+                            {
+                                offers: [
+                                    {
+                                        sku: "BATCH-EMPTY-SHIPPING",
+                                        variant_id: deps.variant_id,
+                                        shipping_profile_id: "",
+                                        inventory_items: [{}],
+                                        prices: [
+                                            {
+                                                amount: 2000,
+                                                currency_code: "usd",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            seller1Headers
+                        )
+                        .catch((e) => e.response)
+
+                    expect(response.status).toEqual(400)
+                })
             })
 
             describe("GET /vendor/offers", () => {

--- a/packages/core/src/api/vendor/offers/validators.ts
+++ b/packages/core/src/api/vendor/offers/validators.ts
@@ -72,7 +72,7 @@ export const VendorCreateOffer = z
   .object({
     sku: z.string().min(1),
     variant_id: z.string(),
-    shipping_profile_id: z.string(),
+    shipping_profile_id: z.string().min(1),
     inventory_items: z.array(VendorOfferInventoryItem).min(1),
     prices: z.array(VendorOfferPrice).min(1),
     ean: z.string().min(1).nullish(),
@@ -85,7 +85,7 @@ export type VendorUpdateOfferType = z.infer<typeof VendorUpdateOffer>
 export const VendorUpdateOffer = z
   .object({
     sku: z.string().min(1).optional(),
-    shipping_profile_id: z.string().optional(),
+    shipping_profile_id: z.string().min(1).optional(),
     metadata: z.record(z.string(), z.unknown()).nullish(),
     /**
      * Optional full price ladder. When set, the offer's PriceSet is rewritten
@@ -124,7 +124,7 @@ const VendorCreateOffersBatchItem = z
   .object({
     sku: z.string().min(1),
     variant_id: z.string(),
-    shipping_profile_id: z.string(),
+    shipping_profile_id: z.string().min(1),
     prices: z.array(VendorOfferPrice).min(1),
     inventory_items: z.array(VendorOfferInventoryItem).min(1),
     ean: z.string().min(1).nullish(),

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -4853,6 +4853,9 @@
             "skuRequired": {
               "type": "string"
             },
+            "shippingProfileRequired": {
+              "type": "string"
+            },
             "duplicateSku": {
               "type": "string"
             },
@@ -4874,6 +4877,7 @@
           },
           "required": [
             "skuRequired",
+            "shippingProfileRequired",
             "duplicateSku",
             "duplicatePriceRule",
             "duplicateInventoryItem",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1181,6 +1181,7 @@
     },
     "validation": {
       "skuRequired": "SKU is required for rows with a stock location enabled or a non-zero price.",
+      "shippingProfileRequired": "Select a shipping profile to publish this row.",
       "duplicateSku": "Another row in this submission already uses this SKU.",
       "duplicatePriceRule": "Another price row already has this combination of currency, region, customer group, and quantity bounds.",
       "duplicateInventoryItem": "This inventory item is already attached.",

--- a/packages/vendor/src/pages/offers/create/create-offer-form/create-offer-form.tsx
+++ b/packages/vendor/src/pages/offers/create/create-offer-form/create-offer-form.tsx
@@ -172,24 +172,25 @@ export const CreateOfferForm = () => {
           message: t("offers.validation.skuRequired"),
         });
         hasValidationError = true;
-        continue;
-      }
-      if (sku) {
+      } else if (sku) {
         if (skuSeen.has(sku)) {
           form.setError(`variants.${i}.sku`, {
             type: "manual",
             message: t("offers.validation.duplicateSku"),
           });
           hasValidationError = true;
-          continue;
+        } else {
+          skuSeen.set(sku, i);
         }
-        skuSeen.set(sku, i);
       }
 
+      // Every publishable row needs a shipping profile; validate it
+      // independently of the SKU checks so a row missing both surfaces
+      // both errors instead of hiding the shipping requirement.
       if (!row.shipping_profile_id) {
         form.setError(`variants.${i}.shipping_profile_id`, {
           type: "manual",
-          message: t("offers.validation.skuRequired"),
+          message: t("offers.validation.shippingProfileRequired"),
         });
         hasValidationError = true;
       }


### PR DESCRIPTION
## Summary
- Vendor offer create/batch validators typed `shipping_profile_id` as `z.string()`, which accepts `""` — the API would create offers with **no shipping profile**. It is now `z.string().min(1)` on create, batch-create, and update.
- The create form mislabeled the missing-shipping error as "SKU required" and `continue`d past the shipping check for rows missing a SKU, hiding the requirement for variants without a SKU. The shipping-profile error is now surfaced independently with a dedicated `shippingProfileRequired` message.

## Linear
[MER-172](https://linear.app/rigbyjs/issue/MER-172)

## Test plan
- [x] New integration tests: reject create with missing / empty `shipping_profile_id` (single + batch)
- [x] `bun run build`
- [x] `bun run test:integration:http -- offer/vendor/offer.spec.ts` (21 passed)
- [ ] Vendor panel: create an offer for a product whose variant has no SKU, leave the shipping profile unset → Publish is blocked with "Select a shipping profile to publish this row."

🤖 Generated with [Claude Code](https://claude.com/claude-code)