### PR TITLE
fix(vendor): correct offer variant detail & shipping toast copy

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -4559,6 +4559,40 @@
           ],
           "additionalProperties": false
         },
+        "variant": {
+          "type": "object",
+          "properties": {
+            "edit": {
+              "type": "object",
+              "properties": {
+                "successToast": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "successToast"
+              ],
+              "additionalProperties": false
+            },
+            "shipping": {
+              "type": "object",
+              "properties": {
+                "successToast": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "successToast"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "edit",
+            "shipping"
+          ],
+          "additionalProperties": false
+        },
         "pricing": {
           "type": "object",
           "properties": {
@@ -4890,6 +4924,7 @@
         "create",
         "detail",
         "edit",
+        "variant",
         "pricing",
         "inventory",
         "delete",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1107,6 +1107,14 @@
       "description": "Update the offer's identity, shipping profile, or metadata.",
       "successToast": "Offer updated"
     },
+    "variant": {
+      "edit": {
+        "successToast": "Offer variant was successfully updated."
+      },
+      "shipping": {
+        "successToast": "Shipping configuration was successfully updated."
+      }
+    },
     "pricing": {
       "header": "Manage prices",
       "description": "Add, change, or remove prices on this offer's ladder.",

--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/edit/index.tsx
@@ -37,7 +37,7 @@ const EditOfferVariantForm = ({ offer }: { offer: OfferDetail }) => {
       sku ? { sku } : {},
       {
         onSuccess: () => {
-          toast.success(t("offers.edit.successToast"))
+          toast.success(t("offers.variant.edit.successToast"))
           handleSuccess()
         },
         onError: (error) => toast.error(error.message),

--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/shipping/index.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/shipping/index.tsx
@@ -35,7 +35,7 @@ const EditShippingForm = ({ offer }: { offer: OfferDetail }) => {
       { shipping_profile_id: values.shipping_profile_id },
       {
         onSuccess: () => {
-          toast.success(t("offers.edit.successToast"))
+          toast.success(t("offers.variant.shipping.successToast"))
           handleSuccess()
         },
         onError: (error) => toast.error(error.message),


### PR DESCRIPTION
## Summary
- Offer **variant detail** edit drawer now toasts `Offer variant was successfully updated.` (item 5)
- Offer **shipping configuration** drawer now toasts `Shipping configuration was successfully updated.` (item 7)
- Both drawers previously fired the generic `offers.edit.successToast` ("Offer updated"). The merged MER-179 PR (#962) only updated product-namespace keys, so these two offer drawers were never actually corrected — flagged by the reviewer as NOT FIXED.
- Added dedicated `offers.variant.edit.successToast` / `offers.variant.shipping.successToast` keys (en.json + `$schema.json`) and pointed each drawer at its own message, leaving the shared `offers.edit.successToast` untouched for the general offer-edit form.

## Linear
[MER-179](https://linear.app/rigbyjs/issue/MER-179)

## Test plan
- [ ] Vendor panel → Offer → edit offer variant SKU → toast reads "Offer variant was successfully updated."
- [ ] Vendor panel → Offer → edit shipping configuration → toast reads "Shipping configuration was successfully updated."
- [x] `bun run build --filter=@mercurjs/vendor`
- [x] i18n schema validation passes for the new `offers.variant.*` keys (pre-existing unrelated `store.validation.nameTooLong` mismatch on canary is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)