### PR TITLE
fix(vendor): remove disabled cancel fulfillment tooltip (MER-192)

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -6938,9 +6938,6 @@
             "cancelWarning": {
               "type": "string"
             },
-            "cancelDisabledTooltip": {
-              "type": "string"
-            },
             "markAsDeliveredWarning": {
               "type": "string"
             },
@@ -7147,7 +7144,6 @@
           },
           "required": [
             "cancelWarning",
-            "cancelDisabledTooltip",
             "markAsDeliveredWarning",
             "differentOptionSelected",
             "disabledItemTooltip",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1749,7 +1749,6 @@
     },
     "fulfillment": {
       "cancelWarning": "You are about to cancel a fulfillment. This action cannot be undone.",
-      "cancelDisabledTooltip": "A shipped fulfillment can no longer be canceled.",
       "markAsDeliveredWarning": "You are about to mark fulfillment as delivered. This action cannot be undone.",
       "differentOptionSelected": "The selected shipping option is different from the one selected by the customer.",
       "disabledItemTooltip": "The location or shipping option you have selected don’t allow fulfillment of this item.",

--- a/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -361,9 +361,6 @@ const Fulfillment = ({
                     icon: <XCircle />,
                     onClick: handleCancel,
                     disabled: cancelDisabled,
-                    disabledTooltip: fulfillment.shipped_at
-                      ? t("orders.fulfillment.cancelDisabledTooltip")
-                      : undefined,
                   },
                 ],
               },


### PR DESCRIPTION
## Summary
- Review follow-up to [#1005](https://github.com/mercurjs/mercur/pull/1005). The cancel fulfillment action now renders disabled (no explanatory tooltip) once a fulfillment is shipped/delivered/canceled, matching the design.
- Removes the now-unused `orders.fulfillment.cancelDisabledTooltip` i18n key from `en.json` and `$schema.json`.

## Linear
[MER-192](https://linear.app/rigbyjs/issue/MER-192)

## Test plan
- [ ] Mark a fulfillment as shipped → Cancel action is disabled and shows **no** tooltip on hover.
- [ ] Unshipped fulfillment → Cancel action is enabled and works.
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)