### PR TITLE
fix(vendor): show stock levels and warning in create-fulfillment (MER-190)

### DIFF
--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1772,7 +1772,7 @@
       "markAsDelivered": "Mark as delivered",
       "itemsToFulfillDesc": "Choose items and quantities to fulfill",
       "locationDescription": "Choose which location you want to fulfill items from.",
-      "sendNotificationHint": "Notify customers about the created fulfillment.",
+      "sendNotificationHint": "Notify customer about fulfillment.",
       "methodDescription": "Choose a different shipping method from the one customer selected",
       "error": {
         "wrongQuantity": "Only one item is available for fulfillment",

--- a/packages/vendor/src/pages/orders/[id]/fulfillment/index.tsx
+++ b/packages/vendor/src/pages/orders/[id]/fulfillment/index.tsx
@@ -15,7 +15,7 @@ export const Component = () => {
     // to look up a literal property `*items` / `+items` on Order and
     // 500. Use `<rel>.*` plus bare scalar names.
     fields:
-      "currency_code,items.*,items.variant.*,items.variant.product.shipping_profile.id,items.offer.shipping_profile_id,shipping_address.*,shipping_methods.shipping_option_id,no_notification",
+      "currency_code,items.*,items.variant.*,items.variant.product.shipping_profile.id,items.offer.shipping_profile_id,items.offer.inventory_item_link.*,items.offer.inventory_item_link.inventory_item.location_levels.*,shipping_address.*,shipping_methods.shipping_option_id,no_notification",
   })
 
   if (isError) {

--- a/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-item.tsx
+++ b/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-item.tsx
@@ -7,13 +7,35 @@ import { HttpTypes } from "@medusajs/types"
 
 import { Form } from "@components/common/form/index"
 import { Thumbnail } from "@components/common/thumbnail/index"
-import { useProductVariant } from "@hooks/api/products"
 import { getFulfillableQuantity } from "@lib/order-item"
 import { CreateFulfillmentSchema } from "./constants"
 import { InformationCircleSolid } from "@medusajs/icons"
 
+// In Mercur inventory is owned by the offer's inventory item link
+// (per-seller), exposing per-location stock levels. The create-fulfillment
+// row reads available / in-stock quantities from there — the same source the
+// allocate-items flow uses — rather than the product variant, which is not
+// inventory-scoped to the seller and returns no levels here.
+type OfferLocationLevel = {
+  location_id?: string
+  stocked_quantity?: number | null
+  available_quantity?: number | null
+}
+
+type OfferInventoryLink = {
+  inventory_item?: {
+    location_levels?: OfferLocationLevel[] | null
+  } | null
+}
+
+type OrderLineItemWithOffer = HttpTypes.AdminOrderLineItem & {
+  offer?: {
+    inventory_item_link?: OfferInventoryLink[] | null
+  } | null
+}
+
 type OrderEditItemProps = {
-  item: HttpTypes.AdminOrderLineItem
+  item: OrderLineItemWithOffer
   currencyCode: string
   locationId?: string
   onItemRemove: (itemId: string) => void
@@ -33,16 +55,7 @@ export function OrderCreateFulfillmentItem({
 }: OrderEditItemProps) {
   const { t } = useTranslation()
 
-  const { variant } = useProductVariant(
-    item.product_id!,
-    item.variant_id!,
-    {
-      fields: "*inventory,*inventory.location_levels",
-    },
-    {
-      enabled: !!item.variant,
-    }
-  )
+  const firstLink = item.offer?.inventory_item_link?.[0]
 
   // Items are fulfilled by default; deselecting via the checkbox excludes
   // the item from the payload. Undefined (never toggled) reads as selected.
@@ -53,18 +66,15 @@ export function OrderCreateFulfillmentItem({
     }) !== false
 
   const { availableQuantity, inStockQuantity, missingLevel } = useMemo(() => {
-    const inventory = (variant as any)?.inventory
-    const hasInventoryItem = Array.isArray(inventory) && inventory.length > 0
-
-    if (!hasInventoryItem || !locationId) {
+    if (!firstLink || !locationId) {
       return { missingLevel: false }
     }
 
-    const locationInventory = inventory[0]?.location_levels?.find(
-      (inv: any) => inv.location_id === locationId
+    const locationInventory = firstLink.inventory_item?.location_levels?.find(
+      (inv) => inv.location_id === locationId
     )
 
-    // The variant is inventory-managed but has no level at the chosen
+    // The item is inventory-managed but has no level at the chosen
     // location — it cannot be fulfilled from here. Surface this up so the
     // form can render an aggregate warning.
     if (!locationInventory) {
@@ -76,7 +86,7 @@ export function OrderCreateFulfillmentItem({
       inStockQuantity: locationInventory.stocked_quantity,
       missingLevel: false,
     }
-  }, [variant, locationId])
+  }, [firstLink, locationId])
 
   useEffect(() => {
     onInventoryStatusChange(item.id, missingLevel)
@@ -156,7 +166,7 @@ export function OrderCreateFulfillmentItem({
                       {t("orders.fulfillment.available")}
                     </span>
                     <span className="text-ui-fg-subtle">
-                      {availableQuantity || "N/A"}
+                      {availableQuantity ?? "N/A"}
                     </span>
                   </div>
 
@@ -168,8 +178,8 @@ export function OrderCreateFulfillmentItem({
                         {t("orders.fulfillment.inStock")}
                       </span>
                       <span className="text-ui-fg-subtle">
-                        {inStockQuantity || "N/A"}{" "}
-                        {inStockQuantity && (
+                        {inStockQuantity ?? "N/A"}{" "}
+                        {!!inStockQuantity && (
                           <span className="font-medium text-red-500">
                             -{form.getValues(`quantity.${item.id}`)}
                           </span>


### PR DESCRIPTION
## Summary
Follow-up review fixes for the create-fulfillment form (MER-190, after #1008):
- **Stock showed "N/A"** — now reads available / in-stock quantities from the offer's `inventory_item_link.location_levels` (the seller-scoped source the allocate-items flow already uses) instead of the product variant, which returned no levels. A real `0` now renders as `0` instead of "N/A".
- **No-inventory-level warning never fired** — same root cause; the warning now triggers when a location without a stock level is selected, because `missingLevel` is derived from the offer inventory link.
- **Switch copy** — supporting text now reads "Notify customer about fulfillment."

## Linear
[MER-190](https://linear.app/rigbyjs/issue/MER-190)

## Test plan
- [ ] Open an order with unfulfilled, inventory-managed items → Create fulfillment → pick a location with stock: Available / In stock show quantities (not N/A).
- [ ] Pick a location with no inventory level for a selected item → no-inventory-level warning appears.
- [ ] Notification switch hint reads "Notify customer about fulfillment."
- [x] `bunx turbo run build --filter=@mercurjs/vendor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)