### PR TITLE
fix(vendor): add modal header to offer edit price & stock modals (MER-198)

### DIFF
--- a/packages/vendor/src/pages/offers/[id]/edit-price/index.tsx
+++ b/packages/vendor/src/pages/offers/[id]/edit-price/index.tsx
@@ -160,6 +160,7 @@ const EditPriceGrid = ({
         className="flex h-full flex-col overflow-hidden"
         data-testid="offer-edit-price-form"
       >
+        <RouteFocusModal.Header />
         <RouteFocusModal.Body className="flex-1 overflow-hidden p-0">
           <DataGrid
             columns={columns}

--- a/packages/vendor/src/pages/offers/[id]/edit-stock/index.tsx
+++ b/packages/vendor/src/pages/offers/[id]/edit-stock/index.tsx
@@ -225,6 +225,7 @@ const EditStockGrid = ({
         className="flex h-full flex-col overflow-hidden"
         data-testid="offer-edit-stock-form"
       >
+        <RouteFocusModal.Header />
         <RouteFocusModal.Body className="flex-1 overflow-hidden p-0">
           <DataGrid
             columns={columns}


### PR DESCRIPTION
## Summary
- The offer **edit prices** and **edit stock levels** modals (vendor panel) rendered only an `sr-only` title and no `RouteFocusModal.Header`, so the top bar (close control + the data grid's View/Shortcuts toolbar) was missing.
- Added `<RouteFocusModal.Header />` to both modals, matching the design and the other data-grid bulk-edit modals (`inventory-stock-form`, offer variant `inventory-batch-form` / `pricing-form`).

## Linear
[MER-198](https://linear.app/rigbyjs/issue/MER-198)

## Test plan
- [ ] Vendor → Offers → open an offer → edit prices / edit stock levels: the modal now shows the header bar (close + View/Shortcuts).
- [x] `bun run build` (vendor package, incl. DTS type-check)