### PR TITLE
fix(vendor): remove manage inventory action from offer variant inventory table (MER-199)

### DIFF
--- a/packages/vendor/src/pages/offers/[id]/_components/offer-inventory-section.tsx
+++ b/packages/vendor/src/pages/offers/[id]/_components/offer-inventory-section.tsx
@@ -1,4 +1,4 @@
-import { Buildings, Component } from "@medusajs/icons"
+import { Buildings } from "@medusajs/icons"
 import { Container, Heading, Text } from "@medusajs/ui"
 import { createColumnHelper } from "@tanstack/react-table"
 import { useMemo } from "react"
@@ -162,8 +162,6 @@ export const OfferInventorySection = ({ offer }: Props) => {
     pageSize: PAGE_SIZE,
   })
 
-  const hasKit = inventoryItems.length > 1
-
   return (
     <Container
       className="divide-y p-0"
@@ -171,21 +169,6 @@ export const OfferInventorySection = ({ offer }: Props) => {
     >
       <div className="flex items-center justify-between px-6 py-4">
         <Heading level="h2">{t("offers.detail.inventoryItems")}</Heading>
-        <ActionMenu
-          groups={[
-            {
-              actions: [
-                {
-                  icon: hasKit ? <Component /> : <Buildings />,
-                  label: hasKit
-                    ? t("offers.detail.manageKit")
-                    : t("offers.actions.manage_inventory"),
-                  to: "inventory",
-                },
-              ],
-            },
-          ]}
-        />
       </div>
 
       {inventoryItems.length === 0 ? (


### PR DESCRIPTION
## Summary
- Removed the **Manage inventory** action from the header of the *Inventory items* table on the offer variant detail page (vendor panel).
- Dropped the now-unused `Component` icon import and `hasKit` helper. `Buildings` / `ActionMenu` are retained — still used by the per-row "Go to inventory item" action.

## Linear
[MER-199](https://linear.app/rigbyjs/issue/MER-199)

## Test plan
- [ ] Vendor → Offers → open an offer → open a variant: the *Inventory items* table header no longer shows the `...` "Manage inventory" menu.
- [x] `bun run build` (vendor package, incl. DTS type-check)