### PR TITLE
fix(vendor): repair customers list/detail search, filtering, sorting and copy

### DIFF
--- a/packages/vendor/src/hooks/table/query/use-customer-table-query.tsx
+++ b/packages/vendor/src/hooks/table/query/use-customer-table-query.tsx
@@ -31,7 +31,7 @@ export const useCustomerTableQuery = ({
     offset: offset ? Number(offset) : 0,
     groups: groups?.split(","),
     has_account: has_account ? has_account === "true" : undefined,
-    order,
+    order: order ? order : "-created_at",
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,
     q,

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -5141,9 +5141,13 @@
               "properties": {
                 "noRecordsMessage": {
                   "type": "string"
+                },
+                "emptyTitle": {
+                  "type": "string"
                 }
               },
               "required": [
+                "emptyTitle",
                 "noRecordsMessage"
               ],
               "additionalProperties": false
@@ -5151,9 +5155,6 @@
             "add": {
               "type": "object",
               "properties": {
-                "success": {
-                  "type": "string"
-                },
                 "list": {
                   "type": "object",
                   "properties": {
@@ -5165,10 +5166,17 @@
                     "noRecordsMessage"
                   ],
                   "additionalProperties": false
+                },
+                "successOne": {
+                  "type": "string"
+                },
+                "successMany": {
+                  "type": "string"
                 }
               },
               "required": [
-                "success",
+                "successOne",
+                "successMany",
                 "list"
               ],
               "additionalProperties": false
@@ -5176,9 +5184,6 @@
             "removed": {
               "type": "object",
               "properties": {
-                "success": {
-                  "type": "string"
-                },
                 "list": {
                   "type": "object",
                   "properties": {
@@ -5190,10 +5195,17 @@
                     "noRecordsMessage"
                   ],
                   "additionalProperties": false
+                },
+                "successOne": {
+                  "type": "string"
+                },
+                "successMany": {
+                  "type": "string"
                 }
               },
               "required": [
-                "success",
+                "successOne",
+                "successMany",
                 "list"
               ],
               "additionalProperties": false
@@ -5356,12 +5368,20 @@
                 "successToast"
               ],
               "additionalProperties": false
+            },
+            "emptyTitle": {
+              "type": "string"
+            },
+            "emptyMessage": {
+              "type": "string"
             }
           },
           "required": [
             "title",
             "fields",
-            "create"
+            "create",
+            "emptyTitle",
+            "emptyMessage"
           ],
           "additionalProperties": false
         }

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1244,20 +1244,23 @@
     },
     "groups": {
       "label": "Customer groups",
-      "remove": "Are you sure you want to remove the customer from \"{{name}}\" customer group?",
-      "removeMany": "Are you sure you want to remove customer from following customer groups: {{groups}}?",
+      "remove": "You are about to remove customer from {{name}} group. This action cannot be undone.",
+      "removeMany": "You are about to remove customer from {{groups}} groups. This action cannot be undone.",
       "alreadyAddedTooltip": "The customer is already in this customer group.",
       "list": {
+        "emptyTitle": "No customer groups yet",
         "noRecordsMessage": "This customer doesn't belong to any group."
       },
       "add": {
-        "success": "Customer added to: {{groups}}.",
+        "successOne": "Customer was successfully added to {{groups}} group.",
+        "successMany": "Customer was successfully added to {{groups}} groups.",
         "list": {
           "noRecordsMessage": "Please create a customer group first."
         }
       },
       "removed": {
-        "success": "Customer removed from: {{groups}}.",
+        "successOne": "Customer was successfully removed from {{groups}} group.",
+        "successMany": "Customer was successfully removed from {{groups}} groups.",
         "list": {
           "noRecordsMessage": "Please create a customer group first."
         }
@@ -1283,6 +1286,8 @@
     "hasAccount": "Has account",
     "addresses": {
       "title": "Addresses",
+      "emptyTitle": "No addresses yet",
+      "emptyMessage": "This customer doesn't have any addresses",
       "fields": {
         "addressName": "Address name",
         "address1": "Address 1",

--- a/packages/vendor/src/pages/customers/[id]/_components/customer-address-section/customer-address-section.tsx
+++ b/packages/vendor/src/pages/customers/[id]/_components/customer-address-section/customer-address-section.tsx
@@ -44,8 +44,8 @@ export const CustomerAddressSection = ({
           <NoRecords
             className="flex h-full flex-col overflow-hidden p-6"
             icon={null}
-            title={t("general.noRecordsTitle")}
-            message={t("general.noRecordsMessage")}
+            title={t("customers.addresses.emptyTitle")}
+            message={t("customers.addresses.emptyMessage")}
           />
         </div>
       ) : (

--- a/packages/vendor/src/pages/customers/[id]/_components/customer-group-section/customer-group-section.tsx
+++ b/packages/vendor/src/pages/customers/[id]/_components/customer-group-section/customer-group-section.tsx
@@ -36,6 +36,7 @@ type CustomerGroupSectionProps = {
 
 const PAGE_SIZE = 10
 const PREFIX = "cusgr"
+const DEFAULT_ORDER = "-created_at"
 
 export const CustomerGroupSection = ({
   customer,
@@ -50,6 +51,29 @@ export const CustomerGroupSection = ({
 
   const flatCustomerGroups = customer.groups ?? []
   const groupIds = flatCustomerGroups.map((g) => g.id)
+
+  // The customer's groups are loaded as part of the customer payload, so
+  // search and sorting are applied client-side from the URL query params.
+  const displayedGroups = useMemo(() => {
+    const search = raw.q?.trim().toLowerCase()
+    let result = customer.groups ?? []
+
+    if (search) {
+      result = result.filter((g) => g.name?.toLowerCase().includes(search))
+    }
+
+    const order = raw.order || DEFAULT_ORDER
+    const desc = order.startsWith("-")
+    const key = order.replace("-", "") as "name" | "created_at" | "updated_at"
+
+    return [...result].sort((a, b) => {
+      const av = (a[key] ?? "") as string
+      const bv = (b[key] ?? "") as string
+      const cmp =
+        key === "name" ? av.localeCompare(bv) : av < bv ? -1 : av > bv ? 1 : 0
+      return desc ? -cmp : cmp
+    })
+  }, [customer.groups, raw.q, raw.order])
 
   const { customer_groups: groupsWithCounts } = useCustomerGroups(
     { id: groupIds, fields: "id,customers.id", limit: groupIds.length || 1 },
@@ -68,9 +92,9 @@ export const CustomerGroupSection = ({
   const columns = useColumns(customer.id, customerCountByGroup)
 
   const { table } = useDataTable({
-    data: flatCustomerGroups ?? [],
+    data: displayedGroups,
     columns,
-    count: flatCustomerGroups?.length ?? 0,
+    count: displayedGroups.length,
     getRowId: (row) => row.id,
     enablePagination: true,
     enableRowSelection: true,
@@ -84,15 +108,17 @@ export const CustomerGroupSection = ({
 
   const handleRemove = async () => {
     const selectedIds = Object.keys(rowSelection)
+    const selectedGroups = flatCustomerGroups.filter((g) =>
+      selectedIds.includes(g.id)
+    )
+    const names = selectedGroups.map((g) => g.name)
+    const isSingle = selectedGroups.length === 1
 
     const res = await prompt({
       title: t("general.areYouSure"),
-      description: t("customers.groups.removeMany", {
-        groups: flatCustomerGroups
-          ?.filter((g) => selectedIds.includes(g.id))
-          .map((g) => g.name)
-          .join(","),
-      }),
+      description: isSingle
+        ? t("customers.groups.remove", { name: names[0] })
+        : t("customers.groups.removeMany", { groups: names.join(", ") }),
       confirmText: t("actions.remove"),
       cancelText: t("actions.cancel"),
     })
@@ -101,20 +127,18 @@ export const CustomerGroupSection = ({
       return
     }
 
-    const customerGroupIds = flatCustomerGroups
-      ?.filter((g) => selectedIds.includes(g.id))
-      .map((g) => g.id) ?? []
+    const customerGroupIds = selectedGroups.map((g) => g.id)
 
     await batchCustomerCustomerGroups(
       { remove: customerGroupIds, add: [] },
       {
         onSuccess: () => {
           toast.success(
-            t("customers.groups.removed.success", {
-              groups: flatCustomerGroups
-                ?.filter((g) => selectedIds.includes(g.id))
-                .map((g) => g.name),
-            })
+            isSingle
+              ? t("customers.groups.removed.successOne", { groups: names[0] })
+              : t("customers.groups.removed.successMany", {
+                  groups: names.join(", "),
+                })
           )
         },
         onError: (error) => {
@@ -139,7 +163,7 @@ export const CustomerGroupSection = ({
         columns={columns}
         pageSize={PAGE_SIZE}
         isLoading={false}
-        count={flatCustomerGroups?.length ?? 0}
+        count={displayedGroups.length}
         prefix={PREFIX}
         navigateTo={(row) => `/customer-groups/${row.original.id}`}
         filters={filters}
@@ -150,6 +174,7 @@ export const CustomerGroupSection = ({
           { key: "created_at", label: t("fields.createdAt") },
           { key: "updated_at", label: t("fields.updatedAt") },
         ]}
+        defaultOrderBy={DEFAULT_ORDER}
         commands={[
           {
             action: handleRemove,
@@ -159,7 +184,9 @@ export const CustomerGroupSection = ({
         ]}
         queryObject={raw}
         noRecords={{
+          title: t("customers.groups.list.emptyTitle"),
           message: t("customers.groups.list.noRecordsMessage"),
+          icon: null,
         }}
       />
     </Container>
@@ -193,6 +220,11 @@ const CustomerGroupRowActions = ({
     }
 
     await mutateAsync([customerId], {
+      onSuccess: () => {
+        toast.success(
+          t("customers.groups.removed.successOne", { groups: group.name })
+        )
+      },
       onError: (error) => {
         toast.error(error.message)
       },

--- a/packages/vendor/src/pages/customers/[id]/_components/customer-order-section/customer-order-section.tsx
+++ b/packages/vendor/src/pages/customers/[id]/_components/customer-order-section/customer-order-section.tsx
@@ -30,20 +30,14 @@ export const CustomerOrderSection = ({
     prefix: PREFIX,
   });
 
-  const { orders, isLoading, isError, error } = useOrders({
+  const { orders, count, isLoading, isError, error } = useOrders({
     fields: DEFAULT_FIELDS + "," + DEFAULT_RELATIONS,
-    limit: searchParams.limit,
-    offset: searchParams.offset,
-    created_at: searchParams.created_at,
-    updated_at: searchParams.updated_at,
-    order: searchParams.order,
+    ...searchParams,
     customer_id: customer.id,
   });
 
   const columns = useColumns();
   const filters = useOrderTableFilters();
-
-  const count = orders?.length || 0;
 
   const { table } = useDataTable({
     data: orders ?? [],
@@ -67,6 +61,7 @@ export const CustomerOrderSection = ({
         columns={columns}
         table={table}
         pagination
+        search
         navigateTo={(row) => `/orders/${row.original.id}`}
         filters={filters}
         count={count}
@@ -86,6 +81,7 @@ export const CustomerOrderSection = ({
             label: t("fields.updatedAt"),
           },
         ]}
+        defaultOrderBy="-display_id"
         queryObject={raw}
         prefix={PREFIX}
       />

--- a/packages/vendor/src/pages/customers/[id]/add-customer-groups/add-customers-form/add-customer-groups-form.tsx
+++ b/packages/vendor/src/pages/customers/[id]/add-customer-groups/add-customers-form/add-customer-groups-form.tsx
@@ -123,7 +123,17 @@ export const AddCustomerGroupsForm = ({
         remove: [],
       })
 
-      toast.success("Customer groups added successfully")
+      const names = data.customer_group_ids
+        .map((id) => customer_groups?.find((g) => g.id === id)?.name)
+        .filter(Boolean)
+
+      toast.success(
+        names.length === 1
+          ? t("customers.groups.add.successOne", { groups: names[0] })
+          : t("customers.groups.add.successMany", {
+              groups: names.join(", "),
+            })
+      )
 
       handleSuccess(`/customers/${customerId}`)
     } catch (e: any) {

--- a/packages/vendor/src/pages/customers/_components/customer-list-table/customer-list-data-table.tsx
+++ b/packages/vendor/src/pages/customers/_components/customer-list-table/customer-list-data-table.tsx
@@ -20,16 +20,10 @@ export const CustomerListDataTable = () => {
 
   const { customers, count, isLoading, isError, error } = useCustomers(
     {
-      offset: searchParams.offset,
-      limit: searchParams.limit,
+      ...searchParams,
     },
     {
       placeholderData: keepPreviousData,
-    },
-    {
-      has_account: searchParams.has_account,
-      order: searchParams.order,
-      q: searchParams.q,
     },
   );
 
@@ -76,6 +70,7 @@ export const CustomerListDataTable = () => {
           label: t("fields.updatedAt"),
         },
       ]}
+      defaultOrderBy="-created_at"
       isLoading={isLoading}
       navigateTo={(row) => row.original.id}
       queryObject={raw}


### PR DESCRIPTION
## Summary
Fixes the batch of vendor-panel **Customers** bugs from the current cycle (MER-200 → MER-210). All of them came down to query params not reaching the API and a few copy/empty-state mismatches against the design.

- **List search/filter/sort (MER-200, MER-201, MER-202)** — `useCustomers` only accepts `(query, options)`, but the list table passed search/sort/filter as an ignored **third** argument, so none of it reached the API. Now spreads the full `searchParams`. Default sort is `-created_at` and shows as selected in the order-by menu.
- **Orders section (MER-203, MER-204)** — spreads the order table params (request + date filters now apply), adds search, uses the real `count` from the API, and marks `-display_id` as the default sort.
- **Customer groups section (MER-205, MER-206, MER-207)** — search and sorting are applied client-side over the customer's groups (which arrive in the customer payload), default sort shown, and the empty state now matches the design (title + no icon).
- **Addresses section (MER-208)** — addresses-specific empty-state copy.
- **Remove prompt + toasts (MER-209, MER-210)** — singular/plural, group-name-aware copy for the remove confirmation and the add/remove success toasts; the single-row remove now shows a success toast.

Empty-state copy verified against the Figma designs referenced in the tickets.

## Linear
- [MER-200](https://linear.app/rigbyjs/issue/MER-200) · [MER-201](https://linear.app/rigbyjs/issue/MER-201) · [MER-202](https://linear.app/rigbyjs/issue/MER-202) · [MER-203](https://linear.app/rigbyjs/issue/MER-203) · [MER-204](https://linear.app/rigbyjs/issue/MER-204) · [MER-205](https://linear.app/rigbyjs/issue/MER-205) · [MER-206](https://linear.app/rigbyjs/issue/MER-206) · [MER-207](https://linear.app/rigbyjs/issue/MER-207) · [MER-208](https://linear.app/rigbyjs/issue/MER-208) · [MER-209](https://linear.app/rigbyjs/issue/MER-209) · [MER-210](https://linear.app/rigbyjs/issue/MER-210)

## Test plan
- [x] `bun run build` (vendor package, incl. DTS type-check)
- [x] `oxlint` on changed files
- [ ] Vendor panel → Customers: search, filter by group/account/date, change sort
- [ ] Customer detail → Orders: filter + sort; Groups: search + sort + remove (single & bulk); empty states for Groups and Addresses
- [ ] Add customer to one/many groups and confirm toast copy

## Notes
- The i18n `validate-translations` test is red on `canary` for a pre-existing unrelated key (`store.validation.nameTooLong` missing from `en.json`); not touched here.