### PR TITLE
fix(admin): commission admin panel polish and validation

### DIFF
--- a/integration-tests/http/commission-rates/admin/commission-rates.spec.ts
+++ b/integration-tests/http/commission-rates/admin/commission-rates.spec.ts
@@ -128,6 +128,72 @@ medusaIntegrationTestRunner({
             expect(rate.is_enabled).toEqual(false)
           })
         })
+
+        it("should filter commission rates by scope_type", async () => {
+          const storeRate = await api.post(
+            `/admin/commission-rates`,
+            {
+              name: "Store Scoped Rate",
+              code: "SCOPE_STORE",
+              type: "percentage",
+              value: 5,
+              rules: [{ reference: "seller", reference_id: seller.id }],
+            },
+            adminHeaders
+          )
+
+          await api.post(
+            `/admin/commission-rates`,
+            {
+              name: "Product Type Scoped Rate",
+              code: "SCOPE_PRODUCT_TYPE",
+              type: "percentage",
+              value: 6,
+              rules: [
+                { reference: "product_type", reference_id: "ptyp_test123" },
+              ],
+            },
+            adminHeaders
+          )
+
+          const comboRate = await api.post(
+            `/admin/commission-rates`,
+            {
+              name: "Store Product Type Scoped Rate",
+              code: "SCOPE_STORE_PRODUCT_TYPE",
+              type: "percentage",
+              value: 7,
+              rules: [
+                { reference: "seller", reference_id: seller.id },
+                { reference: "product_type", reference_id: "ptyp_test456" },
+              ],
+            },
+            adminHeaders
+          )
+
+          const storeOnly = await api.get(
+            `/admin/commission-rates?scope_type=store`,
+            adminHeaders
+          )
+
+          expect(storeOnly.status).toEqual(200)
+          const storeIds = storeOnly.data.commission_rates.map(
+            (r: any) => r.id
+          )
+          expect(storeIds).toContain(storeRate.data.commission_rate.id)
+          // The store + product_type combo must NOT match the plain "store" scope.
+          expect(storeIds).not.toContain(comboRate.data.commission_rate.id)
+
+          const combo = await api.get(
+            `/admin/commission-rates?scope_type=store_product_type`,
+            adminHeaders
+          )
+
+          expect(combo.status).toEqual(200)
+          const comboIds = combo.data.commission_rates.map((r: any) => r.id)
+          expect(comboIds).toContain(comboRate.data.commission_rate.id)
+          expect(comboIds).not.toContain(storeRate.data.commission_rate.id)
+        })
       })
 
       describe("POST /admin/commission-rates", () => {
@@ -564,7 +630,7 @@ medusaIntegrationTestRunner({
           expect(response.status).toEqual(400)
         })
 
-        it("should require code field", async () => {
+        it("should auto-generate a unique code when none is provided", async () => {
           const response = await api.post(
             `/admin/commission-rates`,
             {
@@ -573,9 +639,28 @@ medusaIntegrationTestRunner({
               value: 10,
             },
             adminHeaders
-          ).catch((e) => e.response)
+          )
 
-          expect(response.status).toEqual(400)
+          expect(response.status).toEqual(201)
+          expect(response.data.commission_rate.code).toEqual(
+            expect.stringMatching(/^no-code-rate-[a-z0-9]+$/)
+          )
+
+          // A second rate with the same name still gets a distinct code.
+          const second = await api.post(
+            `/admin/commission-rates`,
+            {
+              name: "No Code Rate",
+              type: "percentage",
+              value: 10,
+            },
+            adminHeaders
+          )
+
+          expect(second.status).toEqual(201)
+          expect(second.data.commission_rate.code).not.toEqual(
+            response.data.commission_rate.code
+          )
         })
 
         it("should require type field", async () => {

--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -14749,9 +14749,28 @@
           ],
           "additionalProperties": false
         },
+        "commissionEdit": {
+          "type": "object",
+          "properties": {
+            "header": {
+              "type": "string"
+            },
+            "successToast": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "header",
+            "successToast"
+          ],
+          "additionalProperties": false
+        },
         "delete": {
           "type": "object",
           "properties": {
+            "title": {
+              "type": "string"
+            },
             "description": {
               "type": "string"
             },
@@ -14760,6 +14779,7 @@
             }
           },
           "required": [
+            "title",
             "description",
             "successToast"
           ],
@@ -14812,12 +14832,20 @@
                 },
                 "fixed": {
                   "type": "string"
+                },
+                "percentageHint": {
+                  "type": "string"
+                },
+                "fixedHint": {
+                  "type": "string"
                 }
               },
               "required": [
                 "label",
                 "percentage",
-                "fixed"
+                "fixed",
+                "percentageHint",
+                "fixedHint"
               ],
               "additionalProperties": false
             },
@@ -14841,6 +14869,21 @@
                 },
                 "storeCategory": {
                   "type": "string"
+                },
+                "storeHint": {
+                  "type": "string"
+                },
+                "productTypeHint": {
+                  "type": "string"
+                },
+                "categoryHint": {
+                  "type": "string"
+                },
+                "storeProductTypeHint": {
+                  "type": "string"
+                },
+                "storeCategoryHint": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -14849,7 +14892,12 @@
                 "productType",
                 "category",
                 "storeProductType",
-                "storeCategory"
+                "storeCategory",
+                "storeHint",
+                "productTypeHint",
+                "categoryHint",
+                "storeProductTypeHint",
+                "storeCategoryHint"
               ],
               "additionalProperties": false
             }
@@ -14961,11 +15009,28 @@
                 "status"
               ],
               "additionalProperties": false
+            },
+            "empty": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "heading",
+                "description"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
             "title",
-            "columns"
+            "columns",
+            "empty"
           ],
           "additionalProperties": false
         },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3857,15 +3857,20 @@
       "header": "Create Commission Rule",
       "details": "Details",
       "commission": "Commission",
-      "successToast": "Commission rule created"
+      "successToast": "Commission rule was successfully created."
     },
     "edit": {
       "header": "Edit Commission Rule",
-      "successToast": "Commission rule updated"
+      "successToast": "Commission rule was successfully updated."
+    },
+    "commissionEdit": {
+      "header": "Edit Commission",
+      "successToast": "Commission was successfully updated."
     },
     "delete": {
-      "description": "Are you sure you want to delete this commission rule?",
-      "successToast": "Commission rule deleted"
+      "title": "Delete commission rule",
+      "description": "You are about to delete commission rule {{name}}. This action cannot be undone.",
+      "successToast": "Commission rule was successfully deleted."
     },
     "fields": {
       "code": "Code",
@@ -3882,7 +3887,9 @@
       "type": {
         "label": "Type",
         "percentage": "Percentage",
-        "fixed": "Fixed"
+        "fixed": "Fixed",
+        "percentageHint": "Charge a percentage of the order total.",
+        "fixedHint": "Charge a fixed amount per order."
       },
       "scopeType": {
         "label": "Type",
@@ -3890,7 +3897,12 @@
         "productType": "Product Type",
         "category": "Category",
         "storeProductType": "Store + Product Type",
-        "storeCategory": "Store + Category"
+        "storeCategory": "Store + Category",
+        "storeHint": "Apply to specific stores.",
+        "productTypeHint": "Apply to specific product types.",
+        "categoryHint": "Apply to specific categories.",
+        "storeProductTypeHint": "Apply to product types within specific stores.",
+        "storeCategoryHint": "Apply to categories within specific stores."
       }
     },
     "global": {
@@ -3904,7 +3916,7 @@
       "notIncluded": "Not included in commission",
       "edit": {
         "header": "Edit Global Commission",
-        "successToast": "Global commission updated"
+        "successToast": "Global commission was successfully updated."
       }
     },
     "rules": {
@@ -3915,6 +3927,10 @@
         "type": "Type",
         "value": "Value",
         "status": "Status"
+      },
+      "empty": {
+        "heading": "No commission rules yet",
+        "description": "Create a commission rule to override the global commission for specific stores, product types, or categories."
       }
     },
     "status": {

--- a/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
@@ -63,7 +63,7 @@ const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
         onSuccess: () => {
           toast.success(
             t("commissions.commissionEdit.successToast", {
-              defaultValue: "Commission updated",
+              defaultValue: "Commission was successfully updated.",
             })
           );
           handleSuccess();

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-commission.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-commission.tsx
@@ -1,4 +1,4 @@
-import { Heading, Select } from "@medusajs/ui";
+import { Heading, RadioGroup } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
 import { Form } from "../../../../../components/common/form";
@@ -28,25 +28,41 @@ export const CreateCommissionRuleCommission = () => {
           <Form.Field
             control={form.control}
             name="commissionType"
-            render={({ field: { onChange, ref, ...field } }) => (
+            render={({ field: { onChange, ...rest } }) => (
               <Form.Item>
                 <Form.Label>
                   {t("commissions.fields.type.label", "Type")}
                 </Form.Label>
                 <Form.Control>
-                  <Select {...field} onValueChange={onChange} dir={direction}>
-                    <Select.Trigger ref={ref}>
-                      <Select.Value />
-                    </Select.Trigger>
-                    <Select.Content>
-                      <Select.Item value="percentage">
-                        {t("commissions.fields.type.percentage", "Percentage")}
-                      </Select.Item>
-                      <Select.Item value="fixed">
-                        {t("commissions.fields.type.fixed", "Fixed")}
-                      </Select.Item>
-                    </Select.Content>
-                  </Select>
+                  <RadioGroup
+                    dir={direction}
+                    onValueChange={onChange}
+                    {...rest}
+                    className="grid grid-cols-1 gap-4 md:grid-cols-2"
+                    data-testid="commission-rule-commission-type-radio-group"
+                  >
+                    <RadioGroup.ChoiceBox
+                      value="percentage"
+                      label={t(
+                        "commissions.fields.type.percentage",
+                        "Percentage"
+                      )}
+                      description={t(
+                        "commissions.fields.type.percentageHint",
+                        "Charge a percentage of the order total."
+                      )}
+                      data-testid="commission-rule-commission-type-option-percentage"
+                    />
+                    <RadioGroup.ChoiceBox
+                      value="fixed"
+                      label={t("commissions.fields.type.fixed", "Fixed")}
+                      description={t(
+                        "commissions.fields.type.fixedHint",
+                        "Charge a fixed amount per order."
+                      )}
+                      data-testid="commission-rule-commission-type-option-fixed"
+                    />
+                  </RadioGroup>
                 </Form.Control>
                 <Form.ErrorMessage />
               </Form.Item>
@@ -90,5 +106,5 @@ CreateCommissionRuleCommission._tabMeta =
   defineTabMeta<CreateCommissionRuleSchemaType>({
     id: "commission",
     labelKey: "commissions.create.commission",
-    validationFields: ["commissionType"],
+    validationFields: ["commissionType", "value"],
   });

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
@@ -1,4 +1,4 @@
-import { Heading, Input, Select } from "@medusajs/ui";
+import { Heading, Input, RadioGroup } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
 import { Combobox } from "../../../../../components/inputs/combobox";
@@ -54,74 +54,93 @@ export const CreateCommissionRuleDetails = () => {
       <div className="flex w-full max-w-[720px] flex-col gap-y-8">
         <Heading>{t("commissions.create.details", "Details")}</Heading>
         <div className="flex flex-col gap-y-4">
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <Form.Field
-            control={form.control}
-            name="title"
-            render={({ field }) => (
-              <Form.Item>
-                <Form.Label>{t("fields.title")}</Form.Label>
-                <Form.Control>
-                  <Input autoComplete="off" {...field} />
-                </Form.Control>
-                <Form.ErrorMessage />
-              </Form.Item>
-            )}
-          />
-          <Form.Field
-            control={form.control}
-            name="code"
-            render={({ field }) => (
-              <Form.Item>
-                <Form.Label>{t("commissions.fields.code", "Code")}</Form.Label>
-                <Form.Control>
-                  <Input autoComplete="off" {...field} />
-                </Form.Control>
-                <Form.ErrorMessage />
-              </Form.Item>
-            )}
-          />
-        </div>
+        <Form.Field
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>{t("fields.title")}</Form.Label>
+              <Form.Control>
+                <Input autoComplete="off" {...field} />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
         <Form.Field
           control={form.control}
           name="scopeType"
-          render={({ field: { onChange, ref, ...field } }) => (
+          render={({ field: { onChange, ...rest } }) => (
             <Form.Item>
               <Form.Label>
                 {t("commissions.fields.scopeType.label", "Type")}
               </Form.Label>
               <Form.Control>
-                <Select {...field} onValueChange={onChange} dir={direction}>
-                  <Select.Trigger ref={ref}>
-                    <Select.Value />
-                  </Select.Trigger>
-                  <Select.Content>
-                    <Select.Item value="store">
-                      {t("commissions.fields.scopeType.store", "Store")}
-                    </Select.Item>
-                    <Select.Item value="product_type">
-                      {t(
-                        "commissions.fields.scopeType.productType",
-                        "Product Type"
-                      )}
-                    </Select.Item>
-                    <Select.Item value="category">
-                      {t("commissions.fields.scopeType.category", "Category")}
-                    </Select.Item>
-                    <Select.Item value="store_product_type">
-                      {t(
-                        "commissions.fields.scopeType.storeProductType",
-                        "Store + Product Type"
-                      )}
-                    </Select.Item>
-                    <Select.Item value="store_category">
-                      {t(
-                        "commissions.fields.scopeType.storeCategory",
-                        "Store + Category"
-                      )}
-                    </Select.Item>
-                  </Select.Content>
-                </Select>
+                <RadioGroup
+                  dir={direction}
+                  onValueChange={onChange}
+                  {...rest}
+                  className="grid grid-cols-1 gap-4 md:grid-cols-2"
+                  data-testid="commission-rule-scope-type-radio-group"
+                >
+                  <RadioGroup.ChoiceBox
+                    value="store"
+                    label={t("commissions.fields.scopeType.store", "Store")}
+                    description={t(
+                      "commissions.fields.scopeType.storeHint",
+                      "Apply to specific stores."
+                    )}
+                    data-testid="commission-rule-scope-type-option-store"
+                  />
+                  <RadioGroup.ChoiceBox
+                    value="product_type"
+                    label={t(
+                      "commissions.fields.scopeType.productType",
+                      "Product Type"
+                    )}
+                    description={t(
+                      "commissions.fields.scopeType.productTypeHint",
+                      "Apply to specific product types."
+                    )}
+                    data-testid="commission-rule-scope-type-option-product-type"
+                  />
+                  <RadioGroup.ChoiceBox
+                    value="category"
+                    label={t(
+                      "commissions.fields.scopeType.category",
+                      "Category"
+                    )}
+                    description={t(
+                      "commissions.fields.scopeType.categoryHint",
+                      "Apply to specific categories."
+                    )}
+                    data-testid="commission-rule-scope-type-option-category"
+                  />
+                  <RadioGroup.ChoiceBox
+                    value="store_product_type"
+                    label={t(
+                      "commissions.fields.scopeType.storeProductType",
+                      "Store + Product Type"
+                    )}
+                    description={t(
+                      "commissions.fields.scopeType.storeProductTypeHint",
+                      "Apply to product types within specific stores."
+                    )}
+                    data-testid="commission-rule-scope-type-option-store-product-type"
+                  />
+                  <RadioGroup.ChoiceBox
+                    value="store_category"
+                    label={t(
+                      "commissions.fields.scopeType.storeCategory",
+                      "Store + Category"
+                    )}
+                    description={t(
+                      "commissions.fields.scopeType.storeCategoryHint",
+                      "Apply to categories within specific stores."
+                    )}
+                    data-testid="commission-rule-scope-type-option-store-category"
+                  />
+                </RadioGroup>
               </Form.Control>
               <Form.ErrorMessage />
             </Form.Item>
@@ -206,6 +225,12 @@ CreateCommissionRuleDetails._tabMeta = defineTabMeta<CreateCommissionRuleSchemaT
   {
     id: "details",
     labelKey: "commissions.create.details",
-    validationFields: ["title", "code", "scopeType"],
+    validationFields: [
+      "title",
+      "scopeType",
+      "stores",
+      "productTypes",
+      "categories",
+    ],
   }
 );

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
@@ -23,13 +23,12 @@ export const CreateCommissionRuleForm = () => {
   const form = useForm<CreateCommissionRuleSchemaType>({
     defaultValues: {
       title: "",
-      code: "",
       scopeType: "store",
       stores: [],
       productTypes: [],
       categories: [],
       commissionType: "percentage",
-      value: 0,
+      value: undefined,
       fixed_values: {},
       include_tax: false,
       include_shipping: false,
@@ -51,7 +50,6 @@ export const CreateCommissionRuleForm = () => {
     await mutateAsync(
       {
         name: values.title,
-        code: values.code,
         type: values.commissionType,
         value: isFixed ? 0 : values.value,
         ...(isFixed
@@ -66,7 +64,7 @@ export const CreateCommissionRuleForm = () => {
         onSuccess: ({ commission_rate }) => {
           toast.success(
             t("commissions.create.successToast", {
-              defaultValue: "Commission rule created",
+              defaultValue: "Commission rule was successfully created.",
             })
           );
           handleSuccess(`/settings/commissions/${commission_rate.id}`);

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
@@ -1,24 +1,64 @@
 import * as zod from "zod";
 
-export const CreateCommissionRuleSchema = zod.object({
-  title: zod.string().min(1),
-  code: zod.string().min(1),
-  scopeType: zod.enum([
-    "store",
-    "product_type",
-    "category",
-    "store_product_type",
-    "store_category",
-  ]),
-  stores: zod.array(zod.string()),
-  productTypes: zod.array(zod.string()),
-  categories: zod.array(zod.string()),
-  commissionType: zod.enum(["percentage", "fixed"]),
-  value: zod.coerce.number().min(0),
-  fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
-  include_tax: zod.boolean(),
-  include_shipping: zod.boolean(),
-});
+import { SCOPE_TYPE_DIMENSIONS } from "../../../common/types";
+
+export const CreateCommissionRuleSchema = zod
+  .object({
+    title: zod.string().min(1, "Please enter a title"),
+    scopeType: zod.enum([
+      "store",
+      "product_type",
+      "category",
+      "store_product_type",
+      "store_category",
+    ]),
+    stores: zod.array(zod.string()),
+    productTypes: zod.array(zod.string()),
+    categories: zod.array(zod.string()),
+    commissionType: zod.enum(["percentage", "fixed"]),
+    value: zod.coerce.number().optional(),
+    fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
+    include_tax: zod.boolean(),
+    include_shipping: zod.boolean(),
+  })
+  .superRefine((data, ctx) => {
+    const dimensions = SCOPE_TYPE_DIMENSIONS[data.scopeType];
+
+    if (dimensions.includes("seller") && data.stores.length === 0) {
+      ctx.addIssue({
+        code: zod.ZodIssueCode.custom,
+        path: ["stores"],
+        message: "Please select at least one store",
+      });
+    }
+    if (dimensions.includes("product_type") && data.productTypes.length === 0) {
+      ctx.addIssue({
+        code: zod.ZodIssueCode.custom,
+        path: ["productTypes"],
+        message: "Please select at least one product type",
+      });
+    }
+    if (
+      dimensions.includes("product_category") &&
+      data.categories.length === 0
+    ) {
+      ctx.addIssue({
+        code: zod.ZodIssueCode.custom,
+        path: ["categories"],
+        message: "Please select at least one category",
+      });
+    }
+    if (
+      data.commissionType === "percentage" &&
+      (data.value === undefined || Number.isNaN(data.value))
+    ) {
+      ctx.addIssue({
+        code: zod.ZodIssueCode.custom,
+        path: ["value"],
+        message: "Please enter a value.",
+      });
+    }
+  });
 
 export type CreateCommissionRuleSchemaType = zod.infer<
   typeof CreateCommissionRuleSchema

--- a/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
@@ -123,7 +123,7 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
 
       toast.success(
         t("commissions.edit.successToast", {
-          defaultValue: "Commission rule updated",
+          defaultValue: "Commission rule was successfully updated.",
         })
       );
       handleSuccess();

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
@@ -1,5 +1,4 @@
 import { PencilSquare, Trash } from "@medusajs/icons";
-import { StatusBadge } from "@medusajs/ui";
 import { keepPreviousData } from "@tanstack/react-query";
 import { createColumnHelper } from "@tanstack/react-table";
 import { useMemo } from "react";
@@ -11,6 +10,7 @@ import {
   TextHeader,
 } from "../../../../../components/table/table-cells/common/text-cell";
 import { _DataTable } from "../../../../../components/table/data-table";
+import { StatusCell } from "../../../../../components/table/table-cells/common/status-cell";
 import { useCommissionRules } from "../../../../../hooks/api/commissions";
 import { useDataTable } from "../../../../../hooks/use-data-table";
 import { useDeleteCommissionRuleAction } from "../../../common/hooks/use-delete-commission-rule-action";
@@ -50,7 +50,10 @@ export const CommissionRulesDataTable = () => {
     }
   );
 
-  const data = (commission_rates ?? []) as unknown as CommissionRate[];
+  const data = useMemo(
+    () => (commission_rates ?? []) as unknown as CommissionRate[],
+    [commission_rates]
+  );
 
   const allRules = useMemo(
     () => data.flatMap((rate) => rate.rules ?? []),
@@ -83,6 +86,13 @@ export const CommissionRulesDataTable = () => {
       queryObject={raw}
       filters={filters}
       navigateTo={(row) => `${row.original.id}`}
+      noRecords={{
+        title: t("commissions.rules.empty.heading", "No commission rules yet"),
+        message: t(
+          "commissions.rules.empty.description",
+          "Create a commission rule to override the global commission for specific stores, product types, or categories."
+        ),
+      }}
       pagination
       search
       orderBy={[
@@ -170,9 +180,7 @@ const useColumns = (names: Record<string, string>) => {
         ),
         cell: ({ getValue }) => {
           const props = getIsActiveProps(getValue(), t);
-          return (
-            <StatusBadge color={props.color}>{props.label}</StatusBadge>
-          );
+          return <StatusCell color={props.color}>{props.label}</StatusCell>;
         },
       }),
       columnHelper.display({

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/use-commission-rules-filters.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/use-commission-rules-filters.tsx
@@ -5,8 +5,8 @@ import { Filter } from "../../../../../components/table/data-table";
 
 /**
  * Filters for the Commission Rules list (Figma "Add filter"): Status
- * (`is_enabled`) and commission Type (`type`). Both map straight to the
- * `/admin/commission-rates` list params.
+ * (`is_enabled`) and rule scope Type (`scope_type`). `scope_type` is a
+ * virtual filter resolved server-side from each rate's rules.
  */
 export const useCommissionRulesFilters = (): Filter[] => {
   const { t } = useTranslation();
@@ -14,18 +14,39 @@ export const useCommissionRulesFilters = (): Filter[] => {
   return useMemo(
     () => [
       {
-        key: "type",
-        label: t("commissions.fields.type.label", "Type"),
+        key: "scope_type",
+        label: t("commissions.fields.scopeType.label", "Type"),
         type: "select",
         multiple: true,
         options: [
           {
-            label: t("commissions.fields.type.percentage", "Percentage"),
-            value: "percentage",
+            label: t("commissions.fields.scopeType.store", "Store"),
+            value: "store",
           },
           {
-            label: t("commissions.fields.type.fixed", "Fixed"),
-            value: "fixed",
+            label: t(
+              "commissions.fields.scopeType.productType",
+              "Product Type"
+            ),
+            value: "product_type",
+          },
+          {
+            label: t("commissions.fields.scopeType.category", "Category"),
+            value: "category",
+          },
+          {
+            label: t(
+              "commissions.fields.scopeType.storeProductType",
+              "Store + Product Type"
+            ),
+            value: "store_product_type",
+          },
+          {
+            label: t(
+              "commissions.fields.scopeType.storeCategory",
+              "Store + Category"
+            ),
+            value: "store_category",
           },
         ],
       },

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/use-commission-rules-query.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/use-commission-rules-query.tsx
@@ -16,10 +16,10 @@ export const useCommissionRulesQuery = ({
   pageSize = 20,
 }: UseCommissionRulesQueryProps = {}) => {
   const queryObject = useQueryParams(
-    ["offset", "q", "order", "is_enabled", "type"],
+    ["offset", "q", "order", "is_enabled", "scope_type"],
     prefix
   );
-  const { offset, q, order, is_enabled, type } = queryObject;
+  const { offset, q, order, is_enabled, scope_type } = queryObject;
 
   const searchParams = {
     limit: pageSize,
@@ -27,7 +27,7 @@ export const useCommissionRulesQuery = ({
     order: order || undefined,
     q: q || undefined,
     is_enabled: is_enabled ? is_enabled === "true" : undefined,
-    type: type ? type.split(",") : undefined,
+    scope_type: scope_type ? scope_type.split(",") : undefined,
   };
 
   return { searchParams, raw: queryObject };

--- a/packages/admin/src/pages/commissions/common/components/commission-value-fields.tsx
+++ b/packages/admin/src/pages/commissions/common/components/commission-value-fields.tsx
@@ -40,7 +40,7 @@ export const CommissionValueFields = <T extends FieldValues = FieldValues>({
               <PercentageInput
                 {...field}
                 value={value}
-                onValueChange={(_v, _n, values) => onChange(values?.float ?? 0)}
+                onValueChange={(_v, _n, values) => onChange(values?.float)}
               />
             </Form.Control>
             <Form.ErrorMessage />

--- a/packages/admin/src/pages/commissions/common/hooks/use-delete-commission-rule-action.tsx
+++ b/packages/admin/src/pages/commissions/common/hooks/use-delete-commission-rule-action.tsx
@@ -15,10 +15,10 @@ export const useDeleteCommissionRuleAction = (rule: {
 
   return async () => {
     const confirmed = await prompt({
-      title: t("general.areYouSure"),
+      title: t("commissions.delete.title", "Delete commission rule"),
       description: t("commissions.delete.description", {
         name: rule.name,
-        defaultValue: `Are you sure you want to delete the commission rule "${rule.name}"?`,
+        defaultValue: `You are about to delete commission rule ${rule.name}. This action cannot be undone.`,
       }),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
@@ -32,7 +32,7 @@ export const useDeleteCommissionRuleAction = (rule: {
       onSuccess: () => {
         toast.success(
           t("commissions.delete.successToast", {
-            defaultValue: "Commission rule deleted",
+            defaultValue: "Commission rule was successfully deleted.",
           })
         );
         navigate("/settings/commissions");

--- a/packages/admin/src/pages/commissions/common/utils.ts
+++ b/packages/admin/src/pages/commissions/common/utils.ts
@@ -161,7 +161,7 @@ export const getIsActiveProps = (isEnabled: boolean, t: TFunction) =>
         label: t("commissions.status.enabled", "Active"),
       }
     : {
-        color: "grey" as const,
+        color: "red" as const,
         label: t("commissions.status.disabled", "Inactive"),
       };
 

--- a/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Heading, Input, Select, toast } from "@medusajs/ui";
+import { Button, Heading, RadioGroup, toast } from "@medusajs/ui";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
@@ -18,14 +18,26 @@ import { useStoreCurrencies } from "../common/hooks/use-store-currencies";
 import { CommissionRate } from "../common/types";
 import { buildValuesPayload, fixedValuesFromRate } from "../common/utils";
 
-const EditGlobalCommissionSchema = zod.object({
-  code: zod.string().min(1),
-  type: zod.enum(["percentage", "fixed"]),
-  value: zod.coerce.number().min(0),
-  fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
-  include_tax: zod.boolean(),
-  include_shipping: zod.boolean(),
-});
+const EditGlobalCommissionSchema = zod
+  .object({
+    type: zod.enum(["percentage", "fixed"]),
+    value: zod.coerce.number().optional(),
+    fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
+    include_tax: zod.boolean(),
+    include_shipping: zod.boolean(),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.type === "percentage" &&
+      (data.value === undefined || Number.isNaN(data.value))
+    ) {
+      ctx.addIssue({
+        code: zod.ZodIssueCode.custom,
+        path: ["value"],
+        message: "Please enter a value.",
+      });
+    }
+  });
 
 const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
   const { t } = useTranslation();
@@ -35,7 +47,6 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
 
   const form = useForm<zod.infer<typeof EditGlobalCommissionSchema>>({
     defaultValues: {
-      code: rate.code,
       type: rate.type,
       value: rate.value,
       fixed_values: fixedValuesFromRate(rate),
@@ -50,7 +61,6 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
   const handleSubmit = form.handleSubmit(async (values) => {
     const isFixed = values.type === "fixed";
     const payload = {
-      code: values.code,
       type: values.type,
       value: isFixed ? 0 : values.value,
       ...(isFixed
@@ -64,7 +74,7 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
       onSuccess: () => {
         toast.success(
           t("commissions.global.edit.successToast", {
-            defaultValue: "Global commission updated",
+            defaultValue: "Global commission was successfully updated.",
           })
         );
         handleSuccess();
@@ -82,43 +92,42 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
           <div className="flex flex-col gap-y-4">
             <Form.Field
               control={form.control}
-              name="code"
-              render={({ field }) => (
-                <Form.Item>
-                  <Form.Label>{t("commissions.fields.code", "Code")}</Form.Label>
-                  <Form.Control>
-                    <Input autoComplete="off" {...field} />
-                  </Form.Control>
-                  <Form.ErrorMessage />
-                </Form.Item>
-              )}
-            />
-            <Form.Field
-              control={form.control}
               name="type"
-              render={({ field: { onChange, ref, ...field } }) => (
+              render={({ field: { onChange, ...rest } }) => (
                 <Form.Item>
                   <Form.Label>
                     {t("commissions.fields.type.label", "Type")}
                   </Form.Label>
                   <Form.Control>
-                    <Select
-                      {...field}
-                      onValueChange={onChange}
+                    <RadioGroup
                       dir={direction}
+                      onValueChange={onChange}
+                      {...rest}
+                      className="grid grid-cols-1 gap-4 md:grid-cols-2"
+                      data-testid="global-commission-type-radio-group"
                     >
-                      <Select.Trigger ref={ref}>
-                        <Select.Value />
-                      </Select.Trigger>
-                      <Select.Content>
-                        <Select.Item value="percentage">
-                          {t("commissions.fields.type.percentage", "Percentage")}
-                        </Select.Item>
-                        <Select.Item value="fixed">
-                          {t("commissions.fields.type.fixed", "Fixed")}
-                        </Select.Item>
-                      </Select.Content>
-                    </Select>
+                      <RadioGroup.ChoiceBox
+                        value="percentage"
+                        label={t(
+                          "commissions.fields.type.percentage",
+                          "Percentage"
+                        )}
+                        description={t(
+                          "commissions.fields.type.percentageHint",
+                          "Charge a percentage of the order total."
+                        )}
+                        data-testid="global-commission-type-option-percentage"
+                      />
+                      <RadioGroup.ChoiceBox
+                        value="fixed"
+                        label={t("commissions.fields.type.fixed", "Fixed")}
+                        description={t(
+                          "commissions.fields.type.fixedHint",
+                          "Charge a fixed amount per order."
+                        )}
+                        data-testid="global-commission-type-option-fixed"
+                      />
+                    </RadioGroup>
                   </Form.Control>
                   <Form.ErrorMessage />
                 </Form.Item>

--- a/packages/core/src/api/admin/commission-rates/route.ts
+++ b/packages/core/src/api/admin/commission-rates/route.ts
@@ -8,24 +8,6 @@ import { HttpTypes } from "@mercurjs/types"
 import { AdminCreateCommissionRateType } from "./validators"
 import { createCommissionRatesWorkflow } from "../../../workflows/commission"
 
-/**
- * Derive a rule's scope type from the set of `reference`s on its rules.
- * Mirrors the admin-side `deriveScopeType` (scope type is not stored).
- */
-const deriveScopeType = (references: string[]): string | null => {
-  const refs = new Set(references)
-  const hasSeller = refs.has("seller")
-  const hasType = refs.has("product_type")
-  const hasCategory = refs.has("product_category")
-
-  if (hasSeller && hasType) return "store_product_type"
-  if (hasSeller && hasCategory) return "store_category"
-  if (hasSeller) return "store"
-  if (hasType) return "product_type"
-  if (hasCategory) return "category"
-  return null
-}
-
 /** Build a unique, URL-safe code from a rate name. */
 const generateCommissionCode = (name: string): string => {
   const slug = name
@@ -43,47 +25,13 @@ export const GET = async (
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  // `scope_type` is a virtual filter derived from each rate's rules; resolve
-  // it to a concrete set of rate ids before running the paginated query.
-  const { scope_type, ...filters } = req.filterableFields as Record<
-    string,
-    unknown
-  > & { scope_type?: string | string[] }
-
-  let scopedIds: string[] | undefined
-  if (scope_type) {
-    const scopeTypes = Array.isArray(scope_type) ? scope_type : [scope_type]
-
-    const { data: allRates } = await query.graph({
-      entity: "commission_rate",
-      fields: ["id", "rules.reference"],
-      filters,
-    })
-
-    scopedIds = allRates
-      .filter((rate: { rules?: { reference: string }[] }) => {
-        const derived = deriveScopeType(
-          (rate.rules ?? []).map((rule) => rule.reference)
-        )
-        return derived !== null && scopeTypes.includes(derived)
-      })
-      .map((rate: { id: string }) => rate.id)
-
-    if (scopedIds.length === 0) {
-      res.json({
-        commission_rates: [],
-        count: 0,
-        offset: req.queryConfig.pagination?.skip ?? 0,
-        limit: req.queryConfig.pagination?.take ?? 0,
-      })
-      return
-    }
-  }
-
+  // The virtual `scope_type` filter (derived from each rate's rules) is
+  // resolved DB-side in CommissionModuleService.listAndCountCommissionRates,
+  // which query.graph delegates to — the route just forwards the filters.
   const { data: commission_rates, metadata } = await query.graph({
     entity: "commission_rate",
     fields: req.queryConfig.fields,
-    filters: scopedIds ? { ...filters, id: scopedIds } : filters,
+    filters: req.filterableFields,
     pagination: req.queryConfig.pagination,
   })
 

--- a/packages/core/src/api/admin/commission-rates/route.ts
+++ b/packages/core/src/api/admin/commission-rates/route.ts
@@ -8,16 +8,82 @@ import { HttpTypes } from "@mercurjs/types"
 import { AdminCreateCommissionRateType } from "./validators"
 import { createCommissionRatesWorkflow } from "../../../workflows/commission"
 
+/**
+ * Derive a rule's scope type from the set of `reference`s on its rules.
+ * Mirrors the admin-side `deriveScopeType` (scope type is not stored).
+ */
+const deriveScopeType = (references: string[]): string | null => {
+  const refs = new Set(references)
+  const hasSeller = refs.has("seller")
+  const hasType = refs.has("product_type")
+  const hasCategory = refs.has("product_category")
+
+  if (hasSeller && hasType) return "store_product_type"
+  if (hasSeller && hasCategory) return "store_category"
+  if (hasSeller) return "store"
+  if (hasType) return "product_type"
+  if (hasCategory) return "category"
+  return null
+}
+
+/** Build a unique, URL-safe code from a rate name. */
+const generateCommissionCode = (name: string): string => {
+  const slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  const suffix = Math.random().toString(36).slice(2, 8)
+  return `${slug || "commission-rule"}-${suffix}`
+}
+
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse<HttpTypes.AdminCommissionRateListResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  // `scope_type` is a virtual filter derived from each rate's rules; resolve
+  // it to a concrete set of rate ids before running the paginated query.
+  const { scope_type, ...filters } = req.filterableFields as Record<
+    string,
+    unknown
+  > & { scope_type?: string | string[] }
+
+  let scopedIds: string[] | undefined
+  if (scope_type) {
+    const scopeTypes = Array.isArray(scope_type) ? scope_type : [scope_type]
+
+    const { data: allRates } = await query.graph({
+      entity: "commission_rate",
+      fields: ["id", "rules.reference"],
+      filters,
+    })
+
+    scopedIds = allRates
+      .filter((rate: { rules?: { reference: string }[] }) => {
+        const derived = deriveScopeType(
+          (rate.rules ?? []).map((rule) => rule.reference)
+        )
+        return derived !== null && scopeTypes.includes(derived)
+      })
+      .map((rate: { id: string }) => rate.id)
+
+    if (scopedIds.length === 0) {
+      res.json({
+        commission_rates: [],
+        count: 0,
+        offset: req.queryConfig.pagination?.skip ?? 0,
+        limit: req.queryConfig.pagination?.take ?? 0,
+      })
+      return
+    }
+  }
+
   const { data: commission_rates, metadata } = await query.graph({
     entity: "commission_rate",
     fields: req.queryConfig.fields,
-    filters: req.filterableFields,
+    filters: scopedIds ? { ...filters, id: scopedIds } : filters,
     pagination: req.queryConfig.pagination,
   })
 
@@ -35,8 +101,11 @@ export const POST = async (
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  const code =
+    req.validatedBody.code ?? generateCommissionCode(req.validatedBody.name)
+
   const { result } = await createCommissionRatesWorkflow(req.scope).run({
-    input: [req.validatedBody],
+    input: [{ ...req.validatedBody, code }],
   })
 
   const {

--- a/packages/core/src/api/admin/commission-rates/route.ts
+++ b/packages/core/src/api/admin/commission-rates/route.ts
@@ -8,17 +8,6 @@ import { HttpTypes } from "@mercurjs/types"
 import { AdminCreateCommissionRateType } from "./validators"
 import { createCommissionRatesWorkflow } from "../../../workflows/commission"
 
-/** Build a unique, URL-safe code from a rate name. */
-const generateCommissionCode = (name: string): string => {
-  const slug = name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-  const suffix = Math.random().toString(36).slice(2, 8)
-  return `${slug || "commission-rule"}-${suffix}`
-}
-
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse<HttpTypes.AdminCommissionRateListResponse>
@@ -49,11 +38,10 @@ export const POST = async (
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  const code =
-    req.validatedBody.code ?? generateCommissionCode(req.validatedBody.name)
-
+  // `code` is auto-generated in CommissionModuleService.createCommissionRates
+  // when omitted, so the body flows straight through.
   const { result } = await createCommissionRatesWorkflow(req.scope).run({
-    input: [{ ...req.validatedBody, code }],
+    input: [req.validatedBody],
   })
 
   const {

--- a/packages/core/src/api/admin/commission-rates/validators.ts
+++ b/packages/core/src/api/admin/commission-rates/validators.ts
@@ -24,6 +24,10 @@ export const AdminGetCommissionRatesParams = createFindParams({
     id: z.union([z.string(), z.array(z.string())]).optional(),
     code: z.union([z.string(), z.array(z.string())]).optional(),
     type: z.union([z.string(), z.array(z.string())]).optional(),
+    // Virtual filter: the rule scope ("store", "product_type", "category",
+    // "store_product_type", "store_category"). Derived from each rate's
+    // linked rules in the route, not a stored column.
+    scope_type: z.union([z.string(), z.array(z.string())]).optional(),
     is_enabled: booleanString().optional(),
     is_default: booleanString().optional(),
     created_at: createOperatorMap().optional(),
@@ -46,7 +50,8 @@ export type AdminCreateCommissionRateType = z.infer<
 >
 export const AdminCreateCommissionRate = z.object({
   name: z.string(),
-  code: z.string(),
+  // Optional: when omitted, the route generates a unique code from the name.
+  code: z.string().optional(),
   type: z.nativeEnum(CommissionRateType),
   value: z.number(),
   currency_code: z.string().nullish(),

--- a/packages/core/src/modules/commission/service.ts
+++ b/packages/core/src/modules/commission/service.ts
@@ -33,6 +33,17 @@ import {
 type CommissionRateEntity = InferEntityType<typeof CommissionRate>
 type CommissionRuleEntity = InferEntityType<typeof CommissionRule>
 
+/** Build a unique, URL-safe code from a rate name. */
+const generateCommissionCode = (name: string): string => {
+  const slug = (name ?? "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  const suffix = Math.random().toString(36).slice(2, 8)
+  return `${slug || "commission-rule"}-${suffix}`
+}
+
 class CommissionModuleService extends MedusaService({
   CommissionRate,
   CommissionRule,
@@ -383,6 +394,28 @@ class CommissionModuleService extends MedusaService({
       true
 
     return where
+  }
+
+  /**
+   * Auto-generate a unique `code` from the rate `name` when one is not
+   * provided, before delegating to the generated create. Accepts a single
+   * payload or an array and preserves the caller's shape.
+   */
+  @InjectManager()
+  // @ts-ignore
+  async createCommissionRates(
+    data: any,
+    @MedusaContext() sharedContext: Context = {}
+  ): Promise<any> {
+    const input = Array.isArray(data) ? data : [data]
+    const withCode = input.map((rate) => ({
+      ...rate,
+      code: rate.code ?? generateCommissionCode(rate.name),
+    }))
+
+    const result = await super.createCommissionRates(withCode, sharedContext)
+
+    return Array.isArray(data) ? result : result[0]
   }
 
   @InjectManager()

--- a/packages/core/src/modules/commission/service.ts
+++ b/packages/core/src/modules/commission/service.ts
@@ -1,6 +1,7 @@
 import {
   Context,
   DAL,
+  FindConfig,
   InferEntityType,
   ModulesSdkTypes,
 } from "@medusajs/framework/types"
@@ -11,6 +12,7 @@ import {
   MedusaContext,
   MedusaService,
 } from "@medusajs/framework/utils"
+import { raw } from "@medusajs/framework/mikro-orm/postgresql"
 
 import {
   CommissionCalculationContext,
@@ -303,6 +305,112 @@ class CommissionModuleService extends MedusaService({
     )
 
     return await this.baseRepository_.serialize<CommissionLineDTO[]>(result)
+  }
+
+  /**
+   * Build a DB-side predicate for the virtual `scope_type` filter (rule
+   * scope: "store", "product_type", "category", "store_product_type",
+   * "store_category"). Scope type is derived from the set of rule
+   * `reference`s rather than stored, so each option maps to an
+   * EXISTS / NOT EXISTS combination on `commission_rule` that mirrors the
+   * admin-side `deriveScopeType`. Multiple selected scopes are OR-ed.
+   */
+  private buildScopeTypeWhere_(
+    scopeTypes: string[]
+  ): ((alias: string) => string) | null {
+    const valid = scopeTypes.filter((scope) =>
+      [
+        "store",
+        "product_type",
+        "category",
+        "store_product_type",
+        "store_category",
+      ].includes(scope)
+    )
+
+    if (!valid.length) {
+      return null
+    }
+
+    return (alias: string) => {
+      const has = (reference: string) =>
+        `EXISTS (SELECT 1 FROM commission_rule cr WHERE cr.commission_rate_id = ${alias}.id AND cr.deleted_at IS NULL AND cr.reference = '${reference}')`
+      const missing = (reference: string) => `NOT ${has(reference)}`
+
+      const conditionFor = (scope: string): string => {
+        switch (scope) {
+          case "store":
+            return `${has("seller")} AND ${missing("product_type")} AND ${missing("product_category")}`
+          case "product_type":
+            return `${has("product_type")} AND ${missing("seller")} AND ${missing("product_category")}`
+          case "category":
+            return `${has("product_category")} AND ${missing("seller")} AND ${missing("product_type")}`
+          case "store_product_type":
+            return `${has("seller")} AND ${has("product_type")}`
+          case "store_category":
+            return `${has("seller")} AND ${has("product_category")} AND ${missing("product_type")}`
+          default:
+            return "1 = 0"
+        }
+      }
+
+      return valid.map((scope) => `(${conditionFor(scope)})`).join(" OR ")
+    }
+  }
+
+  /**
+   * Strip the virtual `scope_type` key and rewrite it into a `raw()`
+   * correlated-subquery predicate so the filtering happens in the database,
+   * not in the route handler.
+   */
+  private applyScopeTypeFilter_(
+    filters: Record<string, unknown> = {}
+  ): Record<string, unknown> {
+    const { scope_type, ...rest } = filters ?? {}
+
+    if (scope_type === undefined || scope_type === null) {
+      return { ...rest }
+    }
+
+    const scopeTypes = (
+      Array.isArray(scope_type) ? scope_type : [scope_type]
+    ) as string[]
+    const predicate = this.buildScopeTypeWhere_(scopeTypes)
+    const where: Record<string, unknown> = { ...rest }
+
+    // No recognised scope type → match nothing rather than ignore the filter.
+    where[raw((alias: string) => (predicate ? predicate(alias) : "1 = 0"))] =
+      true
+
+    return where
+  }
+
+  @InjectManager()
+  // @ts-ignore
+  async listCommissionRates(
+    filters: any = {},
+    config: FindConfig<any> = {},
+    @MedusaContext() sharedContext: Context = {}
+  ) {
+    return await super.listCommissionRates(
+      this.applyScopeTypeFilter_(filters),
+      config,
+      sharedContext
+    )
+  }
+
+  @InjectManager()
+  // @ts-ignore
+  async listAndCountCommissionRates(
+    filters: any = {},
+    config: FindConfig<any> = {},
+    @MedusaContext() sharedContext: Context = {}
+  ) {
+    return await super.listAndCountCommissionRates(
+      this.applyScopeTypeFilter_(filters),
+      config,
+      sharedContext
+    )
   }
 }
 

--- a/packages/types/src/commission/mutations.ts
+++ b/packages/types/src/commission/mutations.ts
@@ -23,7 +23,9 @@ export interface CreateCommissionRateValueDTO {
 // create/update at runtime (same mechanism the legacy `rules` relied on).
 export interface CreateCommissionRateDTO {
   name: string
-  code: string
+  // Optional: the commission module auto-generates a unique code from the
+  // name when one is not provided.
+  code?: string
   type: CommissionRateType
   value: number
   currency_code?: string | null


### PR DESCRIPTION
## Summary
Fixes the commission Admin Panel bugs reported in the current cycle, in one PR:

- **MER-225 — Global Commission**: removed the Code field, switched the type picker to radio buttons, and added a "Please enter a value." validation.
- **MER-226 — Create Rule (Step 1)**: removed Code; added validation for title ("Please enter a title"), stores, product types, and categories; switched the scope-type picker to radio buttons.
- **MER-227 — Create Rule (Step 2)**: switched the commission-type picker to radio buttons; added the "Please enter a value." validation.
- **MER-230 — Commission Rules list**: dedicated empty state; status rendered as a non-badge indicator with **red** for inactive; the "Type" filter now filters by rule **scope type** (Store, Product Type, Category, Store + Product Type, Store + Category) instead of percentage/fixed.
- **MER-231 — Toasts**: standardised the five commission success toasts ("… was successfully …").
- **MER-232 — Delete prompt**: heading "Delete commission rule" + "You are about to delete commission rule {name}. This action cannot be undone."

### Supporting changes
- Commission rate `code` is now **optional on create** and auto-generated (unique) server-side when omitted, so the Code field could be removed from the UI.
- Added a `scope_type` list filter on `/admin/commission-rates`, resolved server-side from each rate's linked rules (combos handled with AND semantics).
- New i18n keys mirrored into `$schema.json`.

## Linear
- [MER-225](https://linear.app/rigbyjs/issue/MER-225) · [MER-226](https://linear.app/rigbyjs/issue/MER-226) · [MER-227](https://linear.app/rigbyjs/issue/MER-227) · [MER-230](https://linear.app/rigbyjs/issue/MER-230) · [MER-231](https://linear.app/rigbyjs/issue/MER-231) · [MER-232](https://linear.app/rigbyjs/issue/MER-232)

## Test plan
- [x] `bun run build`
- [x] `bun run lint` (no new issues in changed files)
- [x] `bun run test:integration:http -- commission-rates/admin/commission-rates.spec.ts` — 24 passed (incl. auto-generated code + `scope_type` filter)
- [ ] Manual: create/edit a global commission and a rule, verify radio pickers, value/title/scope validation, toasts, delete prompt, list empty state, status colour, and scope-type filter.