### PR TITLE
fix(orders): reserve order-edit offer items at a stocked location (MER-211)

### DIFF
--- a/integration-tests/http/order/vendor/order-edit-reservation-multiplier.spec.ts
+++ b/integration-tests/http/order/vendor/order-edit-reservation-multiplier.spec.ts
@@ -62,6 +62,13 @@ medusaIntegrationTestRunner({
                 stocked: number
                 offerPrice: number
                 requiredQuantity?: number
+                // When set, the offer's inventory item gets a SECOND stock
+                // level at a different location, stocked with this many
+                // units. The primary location (`stocked`) is listed first so
+                // it is the inventory item's `location_levels[0]`. Used to
+                // prove confirm reserves where stock actually is, not at the
+                // first level (MER-211).
+                secondaryStocked?: number
             }) => {
                 const requiredQuantity = opts.requiredQuantity ?? 1
 
@@ -181,6 +188,39 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
+                // Optional second stock location, linked to the same sales
+                // channel so checkout can reserve there.
+                let secondaryLocation: any = undefined
+                if (opts.secondaryStocked != null) {
+                    secondaryLocation = (
+                        await api.post(
+                            `/vendor/stock-locations`,
+                            { name: `Warehouse2${tag}` },
+                            headers
+                        )
+                    ).data.stock_location
+                    await api.post(
+                        `/vendor/stock-locations/${secondaryLocation.id}/sales-channels`,
+                        { add: [salesChannel.id] },
+                        headers
+                    )
+                }
+
+                const stockLevels = [
+                    {
+                        location_id: stockLocation.id,
+                        stocked_quantity: opts.stocked,
+                    },
+                    ...(secondaryLocation
+                        ? [
+                              {
+                                  location_id: secondaryLocation.id,
+                                  stocked_quantity: opts.secondaryStocked!,
+                              },
+                          ]
+                        : []),
+                ]
+
                 const offer = (
                     await api.post(
                         `/vendor/offers`,
@@ -192,12 +232,7 @@ medusaIntegrationTestRunner({
                                 {
                                     title: `Inv${tag}`,
                                     required_quantity: requiredQuantity,
-                                    stock_levels: [
-                                        {
-                                            location_id: stockLocation.id,
-                                            stocked_quantity: opts.stocked,
-                                        },
-                                    ],
+                                    stock_levels: stockLevels,
                                 },
                             ],
                             prices: [
@@ -218,8 +253,90 @@ medusaIntegrationTestRunner({
                     variant: product.variants[0],
                     offer,
                     stockLocation,
+                    secondaryLocation,
                     shippingProfile,
                 }
+            }
+
+            // Creates a second product + offer under an already-seeded
+            // seller, reusing its stock location + shipping profile, so an
+            // order edit can add an offer item belonging to the same seller.
+            const addOfferToSeller = async (opts: {
+                headers: any
+                stockLocationId: string
+                shippingProfileId: string
+                stocked: number
+                offerPrice: number
+                requiredQuantity?: number
+            }) => {
+                const requiredQuantity = opts.requiredQuantity ?? 1
+                const tag = `_extra_${Date.now()}_${++prerequisiteCounter}`
+
+                const product = (
+                    await api.post(
+                        `/vendor/products`,
+                        {
+                            status: "published",
+                            title: `Prod${tag}`,
+                            variant_attributes: [
+                                {
+                                    name: `Default${tag}`,
+                                    type: "multi_select",
+                                    values: ["Default"],
+                                    is_variant_axis: true,
+                                },
+                            ],
+                            variants: [
+                                {
+                                    title: "Default",
+                                    sku: `V${tag}`,
+                                    attribute_values: {
+                                        [`Default${tag}`]: "Default",
+                                    },
+                                },
+                            ],
+                        },
+                        opts.headers
+                    )
+                ).data.product
+
+                await api.post(
+                    `/vendor/sales-channels/${salesChannel.id}/products`,
+                    { add: [product.id] },
+                    opts.headers
+                )
+
+                const offer = (
+                    await api.post(
+                        `/vendor/offers`,
+                        {
+                            sku: `OF${tag}`,
+                            variant_id: product.variants[0].id,
+                            shipping_profile_id: opts.shippingProfileId,
+                            inventory_items: [
+                                {
+                                    title: `Inv${tag}`,
+                                    required_quantity: requiredQuantity,
+                                    stock_levels: [
+                                        {
+                                            location_id: opts.stockLocationId,
+                                            stocked_quantity: opts.stocked,
+                                        },
+                                    ],
+                                },
+                            ],
+                            prices: [
+                                {
+                                    amount: opts.offerPrice,
+                                    currency_code: "usd",
+                                },
+                            ],
+                        },
+                        opts.headers
+                    )
+                ).data.offer
+
+                return { product, variant: product.variants[0], offer }
             }
 
             const completeCartCheckout = async (offerId: string) => {
@@ -437,6 +554,140 @@ medusaIntegrationTestRunner({
                 expect(reservations.length).toEqual(1)
                 // new ordered_quantity (2) × required_quantity (3) = 6
                 expect(Number(reservations[0].quantity)).toEqual(6)
+            })
+
+            // Reproduces MER-211: confirming an order edit that ADDS a new
+            // offer item (same seller, same stock location) must not fail
+            // with "Not enough stock available" when stock is sufficient.
+            it("adds a new offer item via order edit and confirms with a correct reservation", async () => {
+                const seed = await seedSellerOfferWithShipping({
+                    email: "edit-add-s1@test.com",
+                    name: "EditAddS1",
+                    stocked: 100,
+                    offerPrice: 2500,
+                    requiredQuantity: 1,
+                })
+
+                const order = await completeCartCheckout(seed.offer.id)
+                expect(order.items.length).toEqual(1)
+
+                // A second offer from the same seller, stocked at the same
+                // location, to be added to the existing order.
+                const extra = await addOfferToSeller({
+                    headers: seed.headers,
+                    stockLocationId: seed.stockLocation.id,
+                    shippingProfileId: seed.shippingProfile.id,
+                    stocked: 100,
+                    offerPrice: 2500,
+                    requiredQuantity: 1,
+                })
+
+                await api.post(
+                    `/vendor/order-edits`,
+                    { order_id: order.id },
+                    seed.headers
+                )
+
+                await api.post(
+                    `/vendor/order-edits/${order.id}/items`,
+                    { items: [{ offer_id: extra.offer.id, quantity: 1 }] },
+                    seed.headers
+                )
+
+                await api.post(
+                    `/vendor/order-edits/${order.id}/request`,
+                    {},
+                    seed.headers
+                )
+
+                // The crux of MER-211: confirm must succeed instead of
+                // 500-ing with "Not enough stock available".
+                const confirmResp = await api.post(
+                    `/vendor/order-edits/${order.id}/confirm`,
+                    {},
+                    seed.headers
+                )
+                expect(confirmResp.status).toEqual(200)
+
+                // The added line item should be present on the order.
+                const query = appContainer.resolve(
+                    ContainerRegistrationKeys.QUERY
+                )
+                const { data: refreshed } = await query.graph({
+                    entity: "order",
+                    fields: ["id", "items.id", "items.variant_id"],
+                    filters: { id: order.id },
+                })
+                expect((refreshed[0] as any).items.length).toEqual(2)
+            })
+
+            // Reproduces MER-211 directly: the offer's inventory item is
+            // stocked at a SECONDARY location while its first stock level
+            // (the primary location) is too small for the bumped quantity.
+            // The old adjustment step reserved blindly at the first level and
+            // failed with "Not enough stock available for item … at location
+            // …"; the fix reserves where stock actually is.
+            it("confirms a qty bump when the first stock level is short but another location has stock", async () => {
+                const seed = await seedSellerOfferWithShipping({
+                    email: "edit-loc-s1@test.com",
+                    name: "EditLocS1",
+                    // Primary location (location_levels[0]) holds just 1 unit —
+                    // enough to place qty 1 but NOT a later bump to 3.
+                    stocked: 1,
+                    // Secondary location holds plenty.
+                    secondaryStocked: 100,
+                    offerPrice: 2500,
+                    requiredQuantity: 1,
+                })
+                expect(seed.secondaryLocation).toBeTruthy()
+
+                const order = await completeCartCheckout(seed.offer.id)
+                const lineItemId = order.items[0].id
+
+                const inventoryService = appContainer.resolve(Modules.INVENTORY)
+                let reservations =
+                    await inventoryService.listReservationItems({
+                        line_item_id: lineItemId,
+                    })
+                expect(reservations.length).toEqual(1)
+                expect(Number(reservations[0].quantity)).toEqual(1)
+
+                // Bump qty 1 → 3. Total need (3) exceeds the primary
+                // location's stock (1), so the reservation must move to / stay
+                // at the location that can satisfy it.
+                await api.post(
+                    `/vendor/order-edits`,
+                    { order_id: order.id },
+                    seed.headers
+                )
+                await api.post(
+                    `/vendor/order-edits/${order.id}/items/item/${lineItemId}`,
+                    { quantity: 3 },
+                    seed.headers
+                )
+                await api.post(
+                    `/vendor/order-edits/${order.id}/request`,
+                    {},
+                    seed.headers
+                )
+
+                const confirmResp = await api.post(
+                    `/vendor/order-edits/${order.id}/confirm`,
+                    {},
+                    seed.headers
+                )
+                expect(confirmResp.status).toEqual(200)
+
+                reservations = await inventoryService.listReservationItems({
+                    line_item_id: lineItemId,
+                })
+                expect(reservations.length).toEqual(1)
+                expect(Number(reservations[0].quantity)).toEqual(3)
+                // The reservation must sit at a location that actually has the
+                // stock — never the short primary location.
+                expect(reservations[0].location_id).toEqual(
+                    seed.secondaryLocation.id
+                )
             })
         })
     },

--- a/packages/core/src/workflows/order/workflows/confirm-order-edit-request.ts
+++ b/packages/core/src/workflows/order/workflows/confirm-order-edit-request.ts
@@ -30,16 +30,45 @@ import { confirmOrderEditRequestWorkflow as baseConfirmOrderEditRequestWorkflow 
  * with an `offer.inventory_item_link`, it computes the target
  * reservation set and replaces the existing one. Items without an
  * offer link are left alone.
+ *
+ * Crucially, each reservation is placed at a stock location that
+ * actually has enough availability — keeping the reservation where it
+ * already lives when possible, otherwise the first location with
+ * sufficient stock. Reserving blindly at the inventory item's first
+ * stock level (the previous behavior) made confirm fail with "Not
+ * enough stock available for item … at location …" whenever that first
+ * level wasn't where the stock was (MER-211).
  */
+
+type OfferLevelRow = {
+  location_id?: string | null
+  stocked_quantity?: number | null
+  reserved_quantity?: number | null
+  raw_stocked_quantity?: { value?: string } | null
+  raw_reserved_quantity?: { value?: string } | null
+}
 
 type OfferLinkRow = {
   required_quantity?: number | null
   inventory_item_id?: string | null
   inventory_item?: {
     id?: string | null
-    location_levels?: Array<{ location_id?: string | null }> | null
+    location_levels?: OfferLevelRow[] | null
   } | null
 }
+
+/**
+ * Available units at a level: stocked − reserved. Prefer the raw
+ * BigNumber values when present so we don't lose precision on large
+ * quantities.
+ */
+const levelAvailable = (lvl: OfferLevelRow): number =>
+  Number(
+    MathBN.sub(
+      lvl.raw_stocked_quantity?.value ?? lvl.stocked_quantity ?? 0,
+      lvl.raw_reserved_quantity?.value ?? lvl.reserved_quantity ?? 0
+    ).toString()
+  )
 
 type CompensationDeleteCreated = {
   type: "delete-created"
@@ -109,13 +138,18 @@ const adjustOrderEditReservationsForOffersStep = createStep(
         continue
       }
 
+      // Normalize each offer link to its inventory item + required qty,
+      // keeping every stock level (with availability) so we can reserve at a
+      // location that actually has stock — not blindly the first level.
       const normalizedLinks = links
         .map((link) => ({
           inventory_item_id:
             link.inventory_item?.id ?? link.inventory_item_id ?? null,
           required_quantity: Number(link.required_quantity ?? 1),
-          location_id:
-            link.inventory_item?.location_levels?.[0]?.location_id ?? null,
+          levels: (link.inventory_item?.location_levels ?? []).filter(
+            (lvl): lvl is OfferLevelRow & { location_id: string } =>
+              !!lvl.location_id
+          ),
         }))
         .filter(
           (
@@ -123,7 +157,7 @@ const adjustOrderEditReservationsForOffersStep = createStep(
           ): l is {
             inventory_item_id: string
             required_quantity: number
-            location_id: string | null
+            levels: Array<OfferLevelRow & { location_id: string }>
           } => !!l.inventory_item_id
         )
 
@@ -131,27 +165,40 @@ const adjustOrderEditReservationsForOffersStep = createStep(
         continue
       }
 
-      const inventoryItemIdsMissingLocation = normalizedLinks
-        .filter((l) => !l.location_id)
+      // For inventory items whose levels didn't come back on the offer link
+      // (e.g. the nested relation wasn't expanded), fall back to the
+      // inventory module so we still know where stock lives and how much is
+      // available there.
+      const inventoryItemIdsMissingLevels = normalizedLinks
+        .filter((l) => l.levels.length === 0)
         .map((l) => l.inventory_item_id)
-      if (inventoryItemIdsMissingLocation.length) {
+      if (inventoryItemIdsMissingLevels.length) {
         const levels = await inventoryService.listInventoryLevels({
-          inventory_item_id: inventoryItemIdsMissingLocation,
+          inventory_item_id: inventoryItemIdsMissingLevels,
         })
-        const firstLocationByItem = new Map<string, string>()
+        const levelsByItem = new Map<
+          string,
+          Array<OfferLevelRow & { location_id: string }>
+        >()
         for (const lvl of levels) {
           const itemId = (lvl as { inventory_item_id: string }).inventory_item_id
-          if (!firstLocationByItem.has(itemId)) {
-            firstLocationByItem.set(
-              itemId,
-              (lvl as { location_id: string }).location_id
-            )
+          const locId = (lvl as { location_id?: string }).location_id
+          if (!locId) {
+            continue
           }
+          const arr = levelsByItem.get(itemId) ?? []
+          arr.push({
+            location_id: locId,
+            stocked_quantity: (lvl as { stocked_quantity?: number })
+              .stocked_quantity,
+            reserved_quantity: (lvl as { reserved_quantity?: number })
+              .reserved_quantity,
+          })
+          levelsByItem.set(itemId, arr)
         }
         for (const link of normalizedLinks) {
-          if (!link.location_id) {
-            link.location_id =
-              firstLocationByItem.get(link.inventory_item_id) ?? null
+          if (link.levels.length === 0) {
+            link.levels = levelsByItem.get(link.inventory_item_id) ?? []
           }
         }
       }
@@ -161,25 +208,59 @@ const adjustOrderEditReservationsForOffersStep = createStep(
           line_item_id: lineItemId,
         })
 
-      const desiredByInventoryItem = new Map<
-        string,
-        { quantity: number; location_id: string | null }
-      >()
-      for (const link of normalizedLinks) {
-        desiredByInventoryItem.set(link.inventory_item_id, {
-          quantity: Number(
-            MathBN.mult(reservationQuantity, link.required_quantity).toString()
-          ),
-          location_id: link.location_id,
-        })
-      }
-
       const existingByInventoryItem = new Map<string, any>()
       for (const r of existingReservations) {
         existingByInventoryItem.set(
           (r as { inventory_item_id: string }).inventory_item_id,
           r
         )
+      }
+
+      // Pick the stock location to reserve `desired` units of an inventory
+      // item at. Deleting this line's existing reservation frees its units
+      // back, so add them back when scoring its current location. Prefer
+      // keeping the reservation where it already sits, then any location
+      // with enough availability, then a best-effort fallback.
+      const pickLocation = (
+        link: { inventory_item_id: string; levels: OfferLevelRow[] },
+        desired: number
+      ): string | null => {
+        const existing = existingByInventoryItem.get(link.inventory_item_id) as
+          | { location_id?: string; quantity?: number }
+          | undefined
+        const existingLoc = existing?.location_id ?? null
+        const existingQty = Number(existing?.quantity ?? 0)
+
+        const adjustedAvailable = (locId: string): number => {
+          const lvl = link.levels.find((l) => l.location_id === locId)
+          const base = lvl ? levelAvailable(lvl) : 0
+          return base + (existingLoc === locId ? existingQty : 0)
+        }
+
+        if (existingLoc && adjustedAvailable(existingLoc) >= desired) {
+          return existingLoc
+        }
+        const fit = link.levels.find(
+          (l) => !!l.location_id && adjustedAvailable(l.location_id) >= desired
+        )
+        if (fit?.location_id) {
+          return fit.location_id
+        }
+        return existingLoc ?? link.levels[0]?.location_id ?? null
+      }
+
+      const desiredByInventoryItem = new Map<
+        string,
+        { quantity: number; location_id: string | null }
+      >()
+      for (const link of normalizedLinks) {
+        const quantity = Number(
+          MathBN.mult(reservationQuantity, link.required_quantity).toString()
+        )
+        desiredByInventoryItem.set(link.inventory_item_id, {
+          quantity,
+          location_id: pickLocation(link, quantity),
+        })
       }
 
       const allMatch =
@@ -203,7 +284,7 @@ const adjustOrderEditReservationsForOffersStep = createStep(
         .map((link) => {
           const desired = desiredByInventoryItem.get(link.inventory_item_id)!
           const locationId =
-            link.location_id ?? inheritedLocation?.location_id ?? null
+            desired.location_id ?? inheritedLocation?.location_id ?? null
           return {
             line_item_id: lineItemId,
             inventory_item_id: link.inventory_item_id,


### PR DESCRIPTION
## Summary
- Confirming an order edit could fail with **"Not enough stock available for item … at location …"** even when stock was sufficient.
- Root cause: the offer-aware reservation adjustment in `confirmOrderEditRequestWorkflow` placed each reservation at the inventory item's **first stock level** (`location_levels[0]`) instead of a location that actually had availability. Any offer item stocked at a non-first location — or whose first level was too small for a bumped quantity — broke confirm.
- Fix: select the reservation location by availability — keep it where it already sits when that still fits (adding back the about-to-be-deleted reservation), otherwise the first location with enough stock. Falls back to the inventory module for items whose levels weren't expanded on the offer link. This mirrors how the checkout flow (`prepareOfferInventoryInput`) already chooses locations.

## Linear
[MER-211](https://linear.app/rigbyjs/issue/MER-211)

## Test plan
- Added integration coverage in `order-edit-reservation-multiplier.spec.ts`:
  - qty bump where the **first** stock level is short but a second location has stock → confirm succeeds and the reservation lands at the stocked location (fails on the old behavior with a 500).
  - adding a new offer item via order edit → confirm returns 200 instead of the stock error.
- [ ] `bun run lint` (core + changed files type-check clean; repo lint is pre-existingly red on unrelated specs)
- [x] `bun run build`
- [ ] `bun run test:integration:http -- order-edit-reservation-multiplier`

> Note: the new integration specs could not be executed in my local worktree because every vendor-product spec there fails at setup with a pre-existing, unrelated `Cannot resolve alias path ""` 500 on `POST /vendor/products` (the known vendor-product default-`*`-fields issue), which also breaks the baseline specs in this file. They are expected to run in CI.