### PR TITLE
fix(cli): detect installed package manager and make basic template npm-compatible

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -6,7 +6,10 @@ import path from "path";
 import { clearRegistryContext } from "@/src/registry/context";
 import { sendTelemetryEvent, setTelemetryEmail, showTelemetryNoticeIfNeeded } from "@/src/telemetry";
 import { setupDatabase, type SetupDatabaseResult } from "@/src/utils/create-db";
-import { getPackageManager } from "@/src/utils/get-package-manager";
+import {
+  resolveProjectPackageManager,
+  type PackageManager,
+} from "@/src/utils/get-package-manager";
 import { handleError } from "@/src/utils/handle-error";
 import { highlighter } from "@/src/utils/highlighter";
 import { logger } from "@/src/utils/logger";
@@ -150,7 +153,7 @@ export const create = new Command()
       });
       downloadSpinner.succeed("Template downloaded successfully.");
 
-      const packageManager = await getPackageManager(projectDir);
+      const packageManager = await resolveProjectPackageManager();
       await setPackageManagerField(projectDir, packageManager);
 
       if (!opts.deps) {
@@ -362,7 +365,7 @@ async function installDeps({
   packageManager,
 }: {
   projectDir: string;
-  packageManager: Awaited<ReturnType<typeof getPackageManager>>;
+  packageManager: PackageManager;
 }): Promise<boolean> {
   let cmd = "npm";
   let args = ["install"];
@@ -397,7 +400,7 @@ async function installDeps({
 
 function successMessage(
   projectDir: string,
-  packageManager: Awaited<ReturnType<typeof getPackageManager>>
+  packageManager: PackageManager
 ): string {
   const relativePath = path.relative(process.cwd(), projectDir);
   const header = (message: string) => kleur.bold(message);
@@ -452,8 +455,16 @@ async function setPackageManagerField(
 ): Promise<void> {
   const packageJsonPath = path.join(projectDir, "package.json");
   const packageJson = await fs.readJSON(packageJsonPath);
-  const { stdout: version } = await execa(packageManager, ["--version"]);
-  packageJson.packageManager = `${packageManager}@${version.trim()}`;
+
+  try {
+    const { stdout: version } = await execa(packageManager, ["--version"]);
+    packageJson.packageManager = `${packageManager}@${version.trim()}`;
+  } catch {
+    // Pin the manager without a version rather than failing project creation
+    // if the version lookup is unavailable for any reason.
+    packageJson.packageManager = packageManager;
+  }
+
   await fs.writeJSON(packageJsonPath, packageJson, { spaces: 2 });
 }
 

--- a/packages/cli/src/utils/get-package-manager.ts
+++ b/packages/cli/src/utils/get-package-manager.ts
@@ -1,22 +1,83 @@
 import { detect } from "@antfu/ni";
+import { execa } from "execa";
+
+export type PackageManager = "yarn" | "pnpm" | "bun" | "npm" | "deno";
+
+const SUPPORTED_PACKAGE_MANAGERS: PackageManager[] = [
+  "bun",
+  "yarn",
+  "pnpm",
+  "deno",
+  "npm",
+];
+
+function normalizePackageManager(
+  value: string | null | undefined,
+): PackageManager | undefined {
+  if (!value) return undefined;
+  return SUPPORTED_PACKAGE_MANAGERS.find((pm) => value.startsWith(pm));
+}
+
+/**
+ * Detect the package manager that invoked the CLI from `npm_config_user_agent`.
+ * This is the most reliable signal for what the user actually has and intends
+ * to use (e.g. `npx`, `bunx`, `pnpm dlx`, `yarn dlx`).
+ */
+export function getPackageManagerFromUserAgent(): PackageManager | undefined {
+  return normalizePackageManager(process.env.npm_config_user_agent);
+}
+
+/**
+ * Check whether a package manager is actually installed and runnable, so we
+ * never hand back a manager that would crash with `spawn <pm> ENOENT`.
+ */
+export async function isPackageManagerInstalled(
+  packageManager: PackageManager,
+): Promise<boolean> {
+  try {
+    await execa(packageManager, ["--version"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export async function getPackageManager(
   targetDir: string,
-): Promise<"yarn" | "pnpm" | "bun" | "npm" | "deno"> {
-  const packageManager = await detect({ programmatic: true, cwd: targetDir });
+): Promise<PackageManager> {
+  const detected = normalizePackageManager(
+    await detect({ programmatic: true, cwd: targetDir }),
+  );
 
-  if (packageManager?.startsWith("bun")) return "bun";
-  if (packageManager?.startsWith("yarn")) return "yarn";
-  if (packageManager?.startsWith("pnpm")) return "pnpm";
-  if (packageManager?.startsWith("deno")) return "deno";
-  if (packageManager?.startsWith("npm")) return "npm";
+  // Respect the project's declared/lockfile package manager, but only if it is
+  // actually installed — otherwise commands like `<pm> --version` blow up.
+  if (detected && (await isPackageManagerInstalled(detected))) {
+    return detected;
+  }
 
-  const userAgent = process.env.npm_config_user_agent || "";
+  const fromUserAgent = getPackageManagerFromUserAgent();
+  if (fromUserAgent && (await isPackageManagerInstalled(fromUserAgent))) {
+    return fromUserAgent;
+  }
 
-  if (userAgent.startsWith("bun")) return "bun";
-  if (userAgent.startsWith("yarn")) return "yarn";
-  if (userAgent.startsWith("pnpm")) return "pnpm";
-  if (userAgent.startsWith("deno")) return "deno";
+  return "npm";
+}
+
+/**
+ * Resolve the package manager to use for a brand-new project.
+ *
+ * Mirrors how the Medusa CLI picks a package manager: detect what the user
+ * invoked the CLI with (`npm_config_user_agent`), verify it is actually
+ * installed, and fall back to npm otherwise. The downloaded template's own
+ * `packageManager` field (e.g. `yarn@4.6.0`) is intentionally ignored — it
+ * reflects the template author's tooling, not the user's environment, and was
+ * the cause of `spawn yarn ENOENT` crashes for users without yarn installed.
+ */
+export async function resolveProjectPackageManager(): Promise<PackageManager> {
+  const fromUserAgent = getPackageManagerFromUserAgent();
+  if (fromUserAgent && (await isPackageManagerInstalled(fromUserAgent))) {
+    return fromUserAgent;
+  }
 
   return "npm";
 }

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -47,7 +47,6 @@
   "engines": {
     "node": ">=20"
   },
-  "packageManager": "yarn@4.6.0",
   "workspaces": [
     "packages/*",
     "apps/*"

--- a/templates/basic/packages/api/jest.config.js
+++ b/templates/basic/packages/api/jest.config.js
@@ -1,4 +1,4 @@
-const { loadEnv } = require("@medusajs/utils");
+const { loadEnv } = require("@medusajs/framework/utils");
 loadEnv("test", process.cwd());
 
 module.exports = {

--- a/templates/basic/packages/api/package.json
+++ b/templates/basic/packages/api/package.json
@@ -42,8 +42,8 @@
     "@mercurjs/cli": "2.2.0-canary.22"
   },
   "devDependencies": {
-    "@acme/admin": "workspace:*",
-    "@acme/vendor": "workspace:*",
+    "@acme/admin": "*",
+    "@acme/vendor": "*",
     "@medusajs/test-utils": "2.13.4",
     "@swc/core": "^1.7.28",
     "@swc/jest": "^0.2.36",


### PR DESCRIPTION
## Problem

`mercurjs create` crashed for users without yarn installed (#1036):

```
Command failed with ENOENT: yarn --version
spawn yarn ENOENT
```

Root cause: `templates/basic/package.json` declared `"packageManager": "yarn@4.6.0"`. The CLI ran `@antfu/ni`'s `detect()` against the freshly downloaded template, which reads that field and returns `yarn` regardless of what the user actually has installed. The CLI then ran `execa("yarn", ["--version"])` → crash.

A second, latent issue: the template used the `workspace:*` protocol, which **npm cannot install** (`EUNSUPPORTEDPROTOCOL`). So even a clean npm fallback would have produced a broken install.

This PR also picks up the remaining open template-manifest items from #976.

## Changes

Mirroring how the Medusa CLI picks a package manager:

- **`get-package-manager.ts`**
  - `getPackageManagerFromUserAgent()` — detect the manager that invoked the CLI via `npm_config_user_agent`.
  - `isPackageManagerInstalled()` — verify a manager is runnable before using it, so we never hand back one that crashes with `spawn <pm> ENOENT`.
  - `resolveProjectPackageManager()` — used by `create`; ignores the template's declared field, prefers the user's manager, falls back to npm.
  - `getPackageManager()` now verifies the detected manager is installed before returning, falling back to user agent → npm.
- **`create.ts`** — use `resolveProjectPackageManager()`; harden `setPackageManagerField` so a version lookup failure no longer aborts project creation.
- **`templates/basic`**
  - remove `packageManager: yarn@4.6.0` (#976 item 2)
  - replace `workspace:*` with `*` so the template installs under npm, yarn, and bun
  - `packages/api/jest.config.js`: import `loadEnv` from `@medusajs/framework/utils` (a declared dependency) instead of the missing `@medusajs/utils`, so `bun run test:integration:http` works on a fresh project (#976 item 1)

## #976 coverage

| # | Item | Status |
|---|------|--------|
| 1 | `jest.config.js` requires `@medusajs/utils` (not a dep) | ✅ fixed here |
| 2 | Root `packageManager` is yarn | ✅ fixed here (field removed) |
| 3 | `@acme/api` exports point to a path codegen never writes | ✅ already aligned in current template (`./.mercur/routes.d.ts`) |
| 4 | `mercurjs add` installs block deps with yarn | ✅ reinforced (detection verifies installed manager + npm fallback) |

## Verification

- npm + `workspace:*` → fails (`EUNSUPPORTEDPROTOCOL`); npm + `*` → succeeds, symlinking the local workspace.
- `@medusajs/framework` (2.13.4) exports the `./utils` subpath, so `@medusajs/framework/utils` resolves and exports `loadEnv`.
- Runtime checks: with yarn absent, `resolveProjectPackageManager()` and `getPackageManager(template)` now return `npm` instead of crashing; installed managers are still respected via user agent.
- `bun run build` (CLI) passes. `bun run typecheck` shows only two pre-existing, unrelated errors (`registry/utils.ts`, `update-files.ts`), confirmed identical on a clean `canary`.

Note: the CLI package has no test runner, so behavior was verified via runtime scripts rather than unit tests.

Closes #1036
Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)