### PR TITLE
fix(products): translate category_id to categories filter on store products

### DIFF
--- a/integration-tests/http/collections/admin/collections-media.spec.ts
+++ b/integration-tests/http/collections/admin/collections-media.spec.ts
@@ -41,7 +41,7 @@ medusaIntegrationTestRunner({
 
         expect(response.status).toEqual(200)
 
-        const images = response.data.collection.images
+        const images = response.data.collection.media_images
         expect(images).toBeDefined()
 
         const galleryImages = gallery(images)
@@ -70,7 +70,7 @@ medusaIntegrationTestRunner({
         const response = await api.get(`/admin/collections/${id}`, adminHeaders)
 
         expect(response.status).toEqual(200)
-        const images = response.data.collection.images
+        const images = response.data.collection.media_images
         expect(gallery(images)).toHaveLength(1)
         expect(icon(images)).toBeDefined()
       })
@@ -101,7 +101,7 @@ medusaIntegrationTestRunner({
         )
 
         expect(updated.status).toEqual(200)
-        const images = updated.data.collection.images
+        const images = updated.data.collection.media_images
         const galleryImages = gallery(images)
 
         expect(galleryImages).toHaveLength(2)
@@ -133,7 +133,7 @@ medusaIntegrationTestRunner({
           adminHeaders
         )
 
-        const images = updated.data.collection.images
+        const images = updated.data.collection.media_images
         expect(icon(images)).toBeUndefined()
         expect(gallery(images)).toHaveLength(1)
       })
@@ -145,7 +145,7 @@ medusaIntegrationTestRunner({
           adminHeaders
         )
         const id = created.data.collection.id
-        const imageIds = created.data.collection.images.map(
+        const imageIds = created.data.collection.media_images.map(
           (img: any) => img.id
         )
         expect(imageIds.length).toEqual(2)
@@ -155,7 +155,7 @@ medusaIntegrationTestRunner({
         expect(deleted.data.deleted).toEqual(true)
 
         const mediaService: any = appContainer.resolve("media")
-        const remaining = await mediaService.listImages({ id: imageIds })
+        const remaining = await mediaService.listMediaImages({ id: imageIds })
         expect(remaining).toHaveLength(0)
       })
     })

--- a/integration-tests/http/product-categories/admin/product-categories-media.spec.ts
+++ b/integration-tests/http/product-categories/admin/product-categories-media.spec.ts
@@ -41,7 +41,7 @@ medusaIntegrationTestRunner({
 
         expect(response.status).toEqual(200)
 
-        const images = response.data.product_category.images
+        const images = response.data.product_category.media_images
         expect(images).toBeDefined()
 
         const galleryImages = gallery(images)
@@ -73,7 +73,7 @@ medusaIntegrationTestRunner({
         )
 
         expect(response.status).toEqual(200)
-        const images = response.data.product_category.images
+        const images = response.data.product_category.media_images
         expect(gallery(images)).toHaveLength(1)
         expect(icon(images)).toBeDefined()
       })
@@ -104,7 +104,7 @@ medusaIntegrationTestRunner({
         )
 
         expect(updated.status).toEqual(200)
-        const images = updated.data.product_category.images
+        const images = updated.data.product_category.media_images
         const galleryImages = gallery(images)
 
         expect(galleryImages).toHaveLength(2)
@@ -136,7 +136,7 @@ medusaIntegrationTestRunner({
           adminHeaders
         )
 
-        const images = updated.data.product_category.images
+        const images = updated.data.product_category.media_images
         expect(icon(images)).toBeUndefined()
         expect(gallery(images)).toHaveLength(1)
       })
@@ -148,7 +148,7 @@ medusaIntegrationTestRunner({
           adminHeaders
         )
         const id = created.data.product_category.id
-        const imageIds = created.data.product_category.images.map(
+        const imageIds = created.data.product_category.media_images.map(
           (img: any) => img.id
         )
         expect(imageIds.length).toEqual(2)
@@ -161,7 +161,7 @@ medusaIntegrationTestRunner({
         expect(deleted.data.deleted).toEqual(true)
 
         const mediaService: any = appContainer.resolve("media")
-        const remaining = await mediaService.listImages({ id: imageIds })
+        const remaining = await mediaService.listMediaImages({ id: imageIds })
         expect(remaining).toHaveLength(0)
       })
     })

--- a/integration-tests/http/product/store/product.spec.ts
+++ b/integration-tests/http/product/store/product.spec.ts
@@ -1,5 +1,6 @@
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
 import {
+    IProductModuleService,
     ISalesChannelModuleService,
     MedusaContainer,
 } from "@medusajs/framework/types"
@@ -24,9 +25,11 @@ medusaIntegrationTestRunner({
             let approvedSellerHeaders: any
             let suspendedSeller: any
             let suspendedSellerHeaders: any
+            let productModuleService: IProductModuleService
 
             beforeAll(async () => {
                 appContainer = getContainer()
+                productModuleService = appContainer.resolve(Modules.PRODUCT)
             })
 
             beforeEach(async () => {
@@ -227,6 +230,67 @@ medusaIntegrationTestRunner({
                     expect(response.status).toEqual(200)
                     expect(response.data.products).toHaveLength(1)
                     expect(response.data.products[0].id).toEqual(productA.id)
+                })
+
+                // Regression for https://github.com/mercurjs/mercur/issues/974
+                // `category_id` is a Medusa-standard store filter param but is
+                // not a column on `Product`; the override route used to forward
+                // it straight to `query.graph`, raising
+                // `Trying to query by not existing property Product.category_id`.
+                it("should filter products by category_id", async () => {
+                    const [category] =
+                        await productModuleService.createProductCategories([
+                            {
+                                name: "Filterable Category",
+                                is_active: true,
+                            },
+                        ])
+
+                    const inCategory = await createProduct(
+                        approvedSellerHeaders,
+                        {
+                            title: "In Category",
+                            categories: [{ id: category.id }],
+                        }
+                    )
+                    const outOfCategory = await createProduct(
+                        approvedSellerHeaders,
+                        { title: "Out Of Category" }
+                    )
+
+                    const response = await api.get(
+                        `/store/products?category_id=${category.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    const ids = response.data.products.map((p: any) => p.id)
+                    expect(ids).toContain(inCategory.id)
+                    expect(ids).not.toContain(outOfCategory.id)
+                })
+
+                it("should not return products from an inactive category", async () => {
+                    const [inactiveCategory] =
+                        await productModuleService.createProductCategories([
+                            {
+                                name: "Inactive Category",
+                                is_active: false,
+                            },
+                        ])
+
+                    const product = await createProduct(approvedSellerHeaders, {
+                        title: "Hidden Category Product",
+                        categories: [{ id: inactiveCategory.id }],
+                    })
+
+                    const response = await api.get(
+                        `/store/products?category_id=${inactiveCategory.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    const ids = response.data.products.map((p: any) => p.id)
+                    expect(ids).not.toContain(product.id)
                 })
 
                 it("should support limit and offset", async () => {

--- a/integration-tests/http/product/store/product.spec.ts
+++ b/integration-tests/http/product/store/product.spec.ts
@@ -93,20 +93,6 @@ medusaIntegrationTestRunner({
                     {
                         title: "Test Product",
                         status: "published",
-                        variant_attributes: [
-                            {
-                                name: "Size",
-                                type: "multi_select",
-                                is_variant_axis: true,
-                                values: ["M"],
-                            },
-                        ],
-                        variants: [
-                            {
-                                title: "M",
-                                attribute_values: { Size: "M" },
-                            },
-                        ],
                         ...overrides,
                     },
                     headers
@@ -248,14 +234,17 @@ medusaIntegrationTestRunner({
 
                     const inCategory = await createProduct(
                         approvedSellerHeaders,
-                        {
-                            title: "In Category",
-                            categories: [{ id: category.id }],
-                        }
+                        { title: "In Category" }
                     )
                     const outOfCategory = await createProduct(
                         approvedSellerHeaders,
                         { title: "Out Of Category" }
+                    )
+
+                    await api.post(
+                        `/vendor/product-categories/${category.id}/products`,
+                        { add: [inCategory.id] },
+                        approvedSellerHeaders
                     )
 
                     const response = await api.get(
@@ -280,8 +269,13 @@ medusaIntegrationTestRunner({
 
                     const product = await createProduct(approvedSellerHeaders, {
                         title: "Hidden Category Product",
-                        categories: [{ id: inactiveCategory.id }],
                     })
+
+                    await api.post(
+                        `/vendor/product-categories/${inactiveCategory.id}/products`,
+                        { add: [product.id] },
+                        approvedSellerHeaders
+                    )
 
                     const response = await api.get(
                         `/store/products?category_id=${inactiveCategory.id}`,

--- a/packages/admin/src/hooks/table/columns/use-collection-table-columns.tsx
+++ b/packages/admin/src/hooks/table/columns/use-collection-table-columns.tsx
@@ -20,7 +20,7 @@ export const useCollectionTableColumns = () => {
         header: t("fields.title"),
         cell: ({ getValue, row }) => {
           const gallery = getCollectionGallery(
-            (row.original as CollectionWithImages).images
+            (row.original as CollectionWithImages).media_images
           )
           const thumbnailSrc =
             gallery.find((image) => image.is_thumbnail)?.url ??

--- a/packages/admin/src/pages/categories/category-detail/components/category-icon-section/category-icon-section.tsx
+++ b/packages/admin/src/pages/categories/category-detail/components/category-icon-section/category-icon-section.tsx
@@ -18,7 +18,7 @@ export const CategoryIconSection = ({
 }: CategoryIconSectionProps) => {
   const { t } = useTranslation()
 
-  const icon = getCategoryIcon(category.images)
+  const icon = getCategoryIcon(category.media_images)
 
   return (
     <Container className="divide-y p-0" data-testid="category-icon-section">

--- a/packages/admin/src/pages/categories/category-detail/components/category-media-section/category-media-section.tsx
+++ b/packages/admin/src/pages/categories/category-detail/components/category-media-section/category-media-section.tsx
@@ -18,7 +18,7 @@ export const CategoryMediaSection = ({
 }: CategoryMediaSectionProps) => {
   const { t } = useTranslation()
 
-  const gallery = getCategoryGallery(category.images)
+  const gallery = getCategoryGallery(category.media_images)
 
   return (
     <Container className="divide-y p-0" data-testid="category-media-section">

--- a/packages/admin/src/pages/categories/category-icon-edit/category-icon-edit.tsx
+++ b/packages/admin/src/pages/categories/category-icon-edit/category-icon-edit.tsx
@@ -31,7 +31,7 @@ const EditCategoryIconForm = ({ category }: EditCategoryIconFormProps) => {
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
 
-  const existingIcon = getCategoryIcon(category.images)
+  const existingIcon = getCategoryIcon(category.media_images)
 
   const form = useForm<z.infer<typeof EditCategoryIconSchema>>({
     defaultValues: {

--- a/packages/admin/src/pages/categories/category-list/components/category-list-table/use-category-table-columns.tsx
+++ b/packages/admin/src/pages/categories/category-list/components/category-list-table/use-category-table-columns.tsx
@@ -62,7 +62,7 @@ export const useCategoryTableColumns = () => {
           }
 
           const gallery = getCategoryGallery(
-            (row.original as CategoryWithImages).images
+            (row.original as CategoryWithImages).media_images
           )
           const thumbnailSrc =
             gallery.find((image) => image.is_thumbnail)?.url ??

--- a/packages/admin/src/pages/categories/category-media/components/category-media-gallery/category-media-gallery.tsx
+++ b/packages/admin/src/pages/categories/category-media/components/category-media-gallery/category-media-gallery.tsx
@@ -34,7 +34,7 @@ export const CategoryMediaGallery = ({
   const prompt = usePrompt()
   const { mutateAsync, isPending } = useUpdateProductCategory(category.id)
 
-  const media = getCategoryGallery(category.images)
+  const media = getCategoryGallery(category.media_images)
 
   const next = useCallback(() => {
     if (isPending) {

--- a/packages/admin/src/pages/categories/category-media/components/edit-category-media-form/edit-category-media-form.tsx
+++ b/packages/admin/src/pages/categories/category-media/components/edit-category-media-form/edit-category-media-form.tsx
@@ -81,7 +81,7 @@ export const EditCategoryMediaForm = ({
 
   const form = useForm<EditCategoryMediaSchemaType>({
     defaultValues: {
-      media: getCategoryGallery(category.images).map((image) => ({
+      media: getCategoryGallery(category.media_images).map((image) => ({
         id: image.id,
         url: image.url,
         file: null,

--- a/packages/admin/src/pages/categories/common/components/category-image-fields/types.ts
+++ b/packages/admin/src/pages/categories/common/components/category-image-fields/types.ts
@@ -31,7 +31,7 @@ export type CategoryApiImage = {
 }
 
 export type CategoryWithImages = {
-  images?: CategoryApiImage[] | null
+  media_images?: CategoryApiImage[] | null
 }
 
 /** Gallery images (type = null), ordered by rank. */

--- a/packages/admin/src/pages/collections/collection-detail/components/collection-icon-section/collection-icon-section.tsx
+++ b/packages/admin/src/pages/collections/collection-detail/components/collection-icon-section/collection-icon-section.tsx
@@ -18,7 +18,7 @@ export const CollectionIconSection = ({
 }: CollectionIconSectionProps) => {
   const { t } = useTranslation()
 
-  const icon = getCollectionIcon(collection.images)
+  const icon = getCollectionIcon(collection.media_images)
 
   return (
     <Container className="divide-y p-0" data-testid="collection-icon-section">

--- a/packages/admin/src/pages/collections/collection-detail/components/collection-media-section/collection-media-section.tsx
+++ b/packages/admin/src/pages/collections/collection-detail/components/collection-media-section/collection-media-section.tsx
@@ -18,7 +18,7 @@ export const CollectionMediaSection = ({
 }: CollectionMediaSectionProps) => {
   const { t } = useTranslation()
 
-  const gallery = getCollectionGallery(collection.images)
+  const gallery = getCollectionGallery(collection.media_images)
 
   return (
     <Container className="divide-y p-0" data-testid="collection-media-section">

--- a/packages/admin/src/pages/collections/collection-icon-edit/collection-icon-edit.tsx
+++ b/packages/admin/src/pages/collections/collection-icon-edit/collection-icon-edit.tsx
@@ -40,7 +40,7 @@ const EditCollectionIconForm = ({
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
 
-  const existingIcon = getCollectionIcon(collection.images)
+  const existingIcon = getCollectionIcon(collection.media_images)
 
   const form = useForm<z.infer<typeof EditCollectionIconSchema>>({
     defaultValues: {

--- a/packages/admin/src/pages/collections/collection-media/components/collection-media-gallery/collection-media-gallery.tsx
+++ b/packages/admin/src/pages/collections/collection-media/components/collection-media-gallery/collection-media-gallery.tsx
@@ -34,7 +34,7 @@ export const CollectionMediaGallery = ({
   const prompt = usePrompt()
   const { mutateAsync, isPending } = useUpdateCollection(collection.id)
 
-  const media = getCollectionGallery(collection.images)
+  const media = getCollectionGallery(collection.media_images)
 
   const next = useCallback(() => {
     if (isPending) {

--- a/packages/admin/src/pages/collections/collection-media/components/edit-collection-media-form/edit-collection-media-form.tsx
+++ b/packages/admin/src/pages/collections/collection-media/components/edit-collection-media-form/edit-collection-media-form.tsx
@@ -81,7 +81,7 @@ export const EditCollectionMediaForm = ({
 
   const form = useForm<EditCollectionMediaSchemaType>({
     defaultValues: {
-      media: getCollectionGallery(collection.images).map((image) => ({
+      media: getCollectionGallery(collection.media_images).map((image) => ({
         id: image.id,
         url: image.url,
         file: null,

--- a/packages/admin/src/pages/collections/common/components/collection-image-fields/types.ts
+++ b/packages/admin/src/pages/collections/common/components/collection-image-fields/types.ts
@@ -31,7 +31,7 @@ export type CollectionApiImage = {
 }
 
 export type CollectionWithImages = {
-  images?: CollectionApiImage[] | null
+  media_images?: CollectionApiImage[] | null
 }
 
 /** Gallery images (type = null), ordered by rank. */

--- a/packages/core/src/api/admin/collections/query-config.ts
+++ b/packages/core/src/api/admin/collections/query-config.ts
@@ -5,12 +5,12 @@ export const adminCollectionFields = [
   "created_at",
   "updated_at",
   "metadata",
-  "images.id",
-  "images.url",
-  "images.type",
-  "images.is_thumbnail",
-  "images.is_banner",
-  "images.rank",
+  "media_images.id",
+  "media_images.url",
+  "media_images.type",
+  "media_images.is_thumbnail",
+  "media_images.is_banner",
+  "media_images.rank",
 ]
 
 export const adminCollectionQueryConfig = {

--- a/packages/core/src/api/admin/product-categories/query-config.ts
+++ b/packages/core/src/api/admin/product-categories/query-config.ts
@@ -13,12 +13,12 @@ export const adminProductCategoryFields = [
   "metadata",
   "*parent_category",
   "*category_children",
-  "images.id",
-  "images.url",
-  "images.type",
-  "images.is_thumbnail",
-  "images.is_banner",
-  "images.rank",
+  "media_images.id",
+  "media_images.url",
+  "media_images.type",
+  "media_images.is_thumbnail",
+  "media_images.is_banner",
+  "media_images.rank",
 ]
 
 export const adminProductCategoryQueryConfig = {

--- a/packages/core/src/api/store/products/middlewares.ts
+++ b/packages/core/src/api/store/products/middlewares.ts
@@ -1,11 +1,12 @@
 import {
+  applyDefaultFilters,
   maybeApplyLinkFilter,
   MedusaNextFunction,
   MedusaRequest,
   MedusaResponse,
   MiddlewareRoute,
 } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, isPresent } from "@medusajs/framework/utils"
 import { validateAndTransformQuery } from "@medusajs/framework"
 
 import { storeProductQueryConfig } from "./query-config"
@@ -15,15 +16,27 @@ import {
 } from "./validators"
 import { SellerStatus, ProductStatus } from "@mercurjs/types"
 
-const applyProductFilters = (
-  req: MedusaRequest,
-  _res: MedusaResponse,
-  next: MedusaNextFunction
-) => {
-  req.filterableFields = req.filterableFields ?? {}
-  req.filterableFields.status = ProductStatus.PUBLISHED
-  next()
-}
+/**
+ * Apply the store-facing defaults that vanilla Medusa applies on its own
+ * `/store/products` route. Besides forcing the `published` status, this
+ * translates the Medusa-standard `category_id` query param into the
+ * `categories` relation filter. The `Product` entity has no `category_id`
+ * column, so passing it straight to `query.graph` raises
+ * `Trying to query by not existing property Product.category_id` (#974).
+ */
+const applyProductFilters = applyDefaultFilters({
+  status: ProductStatus.PUBLISHED,
+  categories: (filters: Record<string, unknown>) => {
+    const categoryIds = filters.category_id
+    delete filters.category_id
+
+    if (!isPresent(categoryIds)) {
+      return
+    }
+
+    return { id: categoryIds, is_internal: false, is_active: true }
+  },
+})
 
 /**
  * Resolve sellers that are currently OPEN and not within an active

--- a/packages/core/src/api/vendor/collections/query-config.ts
+++ b/packages/core/src/api/vendor/collections/query-config.ts
@@ -5,12 +5,12 @@ export const defaultVendorCollectionFields = [
   "created_at",
   "updated_at",
   "metadata",
-  "images.id",
-  "images.url",
-  "images.type",
-  "images.is_thumbnail",
-  "images.is_banner",
-  "images.rank",
+  "media_images.id",
+  "media_images.url",
+  "media_images.type",
+  "media_images.is_thumbnail",
+  "media_images.is_banner",
+  "media_images.rank",
 ]
 
 export const retrieveTransformQueryConfig = {

--- a/packages/core/src/api/vendor/product-categories/query-config.ts
+++ b/packages/core/src/api/vendor/product-categories/query-config.ts
@@ -13,12 +13,12 @@ export const vendorProductCategoryFields = [
   "metadata",
   "*parent_category",
   "*category_children",
-  "images.id",
-  "images.url",
-  "images.type",
-  "images.is_thumbnail",
-  "images.is_banner",
-  "images.rank",
+  "media_images.id",
+  "media_images.url",
+  "media_images.type",
+  "media_images.is_thumbnail",
+  "media_images.is_banner",
+  "media_images.rank",
 ]
 
 export const vendorProductCategoryQueryConfig = {

--- a/packages/core/src/links/media-product-category-link.ts
+++ b/packages/core/src/links/media-product-category-link.ts
@@ -8,15 +8,26 @@ import MediaModule from "../modules/media"
  *
  * Direction is category → media: the category owns its images, so
  * `productCategory` is the parent linkable and `isList: true` sits on the
- * image side. A category resolves its gallery + icon via `category.images`.
+ * image side. A category resolves its gallery + icon via
+ * `category.media_images`.
  *
- * The same `Image` model is reused for product collections later by adding
- * a second, analogous link — keep this entity-agnostic.
+ * The reverse alias is `media_images`, NOT the bare `images`: ProductCategory
+ * lives in the Medusa product module, whose service config also owns the
+ * `Product.images` relation. Registering an `images` link alias on that shared
+ * service shadows the native relation and makes the joiner throw
+ * `Cannot resolve alias path "" that matches entity Product` on every product
+ * query. A distinct alias avoids the collision.
+ *
+ * The same `Image` model is reused for product collections via a second,
+ * analogous link — keep this entity-agnostic.
  */
 export default defineLink(
   ProductModule.linkable.productCategory,
   {
-    linkable: MediaModule.linkable.image,
+    linkable: {
+      ...MediaModule.linkable.mediaImage,
+      alias: "media_images",
+    },
     isList: true,
   }
 )

--- a/packages/core/src/links/media-product-collection-link.ts
+++ b/packages/core/src/links/media-product-collection-link.ts
@@ -8,14 +8,24 @@ import MediaModule from "../modules/media"
  *
  * Mirrors `media-product-category-link`: the collection owns its images, so
  * `productCollection` is the parent linkable and `isList: true` sits on the
- * image side. A collection resolves its gallery + icon via `collection.images`.
+ * image side. A collection resolves its gallery + icon via
+ * `collection.media_images`.
+ *
+ * The reverse alias is `media_images`, NOT the bare `images`: ProductCollection
+ * lives in the Medusa product module, whose service config also owns the
+ * `Product.images` relation. An `images` link alias there shadows the native
+ * relation and breaks every product `query.graph` (see
+ * `media-product-category-link`).
  *
  * Reuses the same entity-agnostic `Image` model as categories.
  */
 export default defineLink(
   ProductModule.linkable.productCollection,
   {
-    linkable: MediaModule.linkable.image,
+    linkable: {
+      ...MediaModule.linkable.mediaImage,
+      alias: "media_images",
+    },
     isList: true,
   }
 )

--- a/packages/core/src/modules/media/models/index.ts
+++ b/packages/core/src/modules/media/models/index.ts
@@ -1,1 +1,1 @@
-export { default as Image } from "./image"
+export { default as MediaImage } from "./media-image"

--- a/packages/core/src/modules/media/models/media-image.ts
+++ b/packages/core/src/modules/media/models/media-image.ts
@@ -12,12 +12,16 @@ import { model } from "@medusajs/framework/utils"
  * `setCategoryImages` workflow, not by DB constraints (they span the link
  * table).
  *
- * Table is `media_image`, NOT `image`: Medusa's product module already
- * owns a table named `image` (its ProductImage) — reusing it would collide.
+ * Table is `media_image`, NOT `image`, AND the model name is `MediaImage`,
+ * NOT `Image`: Medusa's product module already owns both a table named
+ * `image` and a model named `Image` (its ProductImage). Reusing either name
+ * collides in the joiner's entity map, so the `media_images` link alias
+ * resolves ambiguously and every product `query.graph` throws
+ * `Cannot resolve alias path "" that matches entity Product`.
  */
-const Image = model
+const MediaImage = model
   .define(
-    { tableName: "media_image", name: "Image" },
+    { tableName: "media_image", name: "MediaImage" },
     {
       id: model.id({ prefix: "medimg" }).primaryKey(),
       url: model.text(),
@@ -36,4 +40,4 @@ const Image = model
     },
   ])
 
-export default Image
+export default MediaImage

--- a/packages/core/src/modules/media/service.ts
+++ b/packages/core/src/modules/media/service.ts
@@ -1,9 +1,9 @@
 import { MedusaService } from "@medusajs/framework/utils"
 
-import { Image } from "./models"
+import { MediaImage } from "./models"
 
 class MediaModuleService extends MedusaService({
-  Image,
-}) {}
+  MediaImage,
+}) { }
 
 export default MediaModuleService

--- a/packages/core/src/workflows/media/steps/create-images.ts
+++ b/packages/core/src/workflows/media/steps/create-images.ts
@@ -24,7 +24,7 @@ export const createImagesStep = createStep(
     }
 
     const service = container.resolve<MediaModuleService>(MercurModules.MEDIA)
-    const created = await service.createImages(input)
+    const created = await service.createMediaImages(input)
 
     return new StepResponse(
       created,
@@ -37,6 +37,6 @@ export const createImagesStep = createStep(
     }
 
     const service = container.resolve<MediaModuleService>(MercurModules.MEDIA)
-    await service.deleteImages(createdIds)
+    await service.deleteMediaImages(createdIds)
   }
 )

--- a/packages/core/src/workflows/media/steps/delete-images.ts
+++ b/packages/core/src/workflows/media/steps/delete-images.ts
@@ -18,7 +18,7 @@ export const deleteImagesStep = createStep(
     }
 
     const service = container.resolve<MediaModuleService>(MercurModules.MEDIA)
-    await service.softDeleteImages(ids)
+    await service.softDeleteMediaImages(ids)
 
     return new StepResponse(void 0, ids)
   },
@@ -28,6 +28,6 @@ export const deleteImagesStep = createStep(
     }
 
     const service = container.resolve<MediaModuleService>(MercurModules.MEDIA)
-    await service.restoreImages(prevIds)
+    await service.restoreMediaImages(prevIds)
   }
 )

--- a/packages/core/src/workflows/media/workflows/set-category-images.ts
+++ b/packages/core/src/workflows/media/workflows/set-category-images.ts
@@ -44,7 +44,7 @@ export const setCategoryImagesWorkflow = createWorkflow(
   (input: SetCategoryImagesWorkflowInput) => {
     const existing = useQueryGraphStep({
       entity: "product_category",
-      fields: ["id", "images.id", "images.type"],
+      fields: ["id", "media_images.id", "media_images.type"],
       filters: { id: input.category_id },
     })
 
@@ -95,14 +95,14 @@ export const setCategoryImagesWorkflow = createWorkflow(
       ({ created, input }) =>
         (created ?? []).map((image: { id: string }) => ({
           [Modules.PRODUCT]: { product_category_id: input.category_id },
-          [MercurModules.MEDIA]: { image_id: image.id },
+          [MercurModules.MEDIA]: { media_image_id: image.id },
         }))
     )
     createRemoteLinkStep(linksToCreate)
 
     const toRemoveIds = transform({ existing, input }, ({ existing, input }) => {
       const images: { id: string; type: string | null }[] =
-        existing.data?.[0]?.images ?? []
+        existing.data?.[0]?.media_images ?? []
       const ids: string[] = []
       if (input.media !== undefined) {
         ids.push(...images.filter((img) => !img.type).map((img) => img.id))
@@ -120,7 +120,7 @@ export const setCategoryImagesWorkflow = createWorkflow(
       ({ toRemoveIds, input }) =>
         toRemoveIds.map((image_id: string) => ({
           [Modules.PRODUCT]: { product_category_id: input.category_id },
-          [MercurModules.MEDIA]: { image_id },
+          [MercurModules.MEDIA]: { media_image_id: image_id },
         }))
     )
     dismissRemoteLinkStep(linksToDismiss)

--- a/packages/core/src/workflows/media/workflows/set-collection-images.ts
+++ b/packages/core/src/workflows/media/workflows/set-collection-images.ts
@@ -45,7 +45,7 @@ export const setCollectionImagesWorkflow = createWorkflow(
   (input: SetCollectionImagesWorkflowInput) => {
     const existing = useQueryGraphStep({
       entity: "product_collection",
-      fields: ["id", "images.id", "images.type"],
+      fields: ["id", "media_images.id", "media_images.type"],
       filters: { id: input.collection_id },
     })
 
@@ -96,14 +96,14 @@ export const setCollectionImagesWorkflow = createWorkflow(
       ({ created, input }) =>
         (created ?? []).map((image: { id: string }) => ({
           [Modules.PRODUCT]: { product_collection_id: input.collection_id },
-          [MercurModules.MEDIA]: { image_id: image.id },
+          [MercurModules.MEDIA]: { media_image_id: image.id },
         }))
     )
     createRemoteLinkStep(linksToCreate)
 
     const toRemoveIds = transform({ existing, input }, ({ existing, input }) => {
       const images: { id: string; type: string | null }[] =
-        existing.data?.[0]?.images ?? []
+        existing.data?.[0]?.media_images ?? []
       const ids: string[] = []
       if (input.media !== undefined) {
         ids.push(...images.filter((img) => !img.type).map((img) => img.id))
@@ -121,7 +121,7 @@ export const setCollectionImagesWorkflow = createWorkflow(
       ({ toRemoveIds, input }) =>
         toRemoveIds.map((image_id: string) => ({
           [Modules.PRODUCT]: { product_collection_id: input.collection_id },
-          [MercurModules.MEDIA]: { image_id },
+          [MercurModules.MEDIA]: { media_image_id: image_id },
         }))
     )
     dismissRemoteLinkStep(linksToDismiss)

--- a/packages/vendor/src/hooks/table/columns/use-collection-table-columns.tsx
+++ b/packages/vendor/src/hooks/table/columns/use-collection-table-columns.tsx
@@ -21,7 +21,7 @@ export const useCollectionTableColumns = () => {
         header: t("fields.title"),
         cell: ({ getValue, row }) => {
           const gallery = getCollectionGallery(
-            (row.original as CollectionWithImages).images,
+            (row.original as CollectionWithImages).media_images,
           );
           const thumbnailSrc =
             gallery.find((image) => image.is_thumbnail)?.url ??

--- a/packages/vendor/src/pages/categories/[id]/_components/category-icon-section/category-icon-section.tsx
+++ b/packages/vendor/src/pages/categories/[id]/_components/category-icon-section/category-icon-section.tsx
@@ -16,7 +16,7 @@ export const CategoryIconSection = ({
 }: CategoryIconSectionProps) => {
   const { t } = useTranslation()
 
-  const icon = getCategoryIcon(category.images)
+  const icon = getCategoryIcon(category.media_images)
 
   return (
     <Container className="divide-y p-0" data-testid="category-icon-section">

--- a/packages/vendor/src/pages/categories/[id]/_components/category-media-section/category-media-section.tsx
+++ b/packages/vendor/src/pages/categories/[id]/_components/category-media-section/category-media-section.tsx
@@ -17,7 +17,7 @@ export const CategoryMediaSection = ({
 }: CategoryMediaSectionProps) => {
   const { t } = useTranslation()
 
-  const gallery = getCategoryGallery(category.images)
+  const gallery = getCategoryGallery(category.media_images)
 
   return (
     <Container className="divide-y p-0" data-testid="category-media-section">

--- a/packages/vendor/src/pages/categories/_components/category-list-table/use-category-table-columns.tsx
+++ b/packages/vendor/src/pages/categories/_components/category-list-table/use-category-table-columns.tsx
@@ -62,7 +62,7 @@ export const useCategoryTableColumns = () => {
           }
 
           const gallery = getCategoryGallery(
-            (row.original as CategoryWithImages).images
+            (row.original as CategoryWithImages).media_images
           )
           const thumbnailSrc =
             gallery.find((image) => image.is_thumbnail)?.url ??

--- a/packages/vendor/src/pages/categories/common/components/category-image-fields/types.ts
+++ b/packages/vendor/src/pages/categories/common/components/category-image-fields/types.ts
@@ -9,7 +9,7 @@ export type CategoryApiImage = {
 }
 
 export type CategoryWithImages = {
-  images?: CategoryApiImage[] | null
+  media_images?: CategoryApiImage[] | null
 }
 
 /** Gallery images (type = null), ordered by rank. */

--- a/packages/vendor/src/pages/collections/[id]/_components/collection-icon-section/collection-icon-section.tsx
+++ b/packages/vendor/src/pages/collections/[id]/_components/collection-icon-section/collection-icon-section.tsx
@@ -16,7 +16,7 @@ export const CollectionIconSection = ({
 }: CollectionIconSectionProps) => {
   const { t } = useTranslation()
 
-  const icon = getCollectionIcon(collection.images)
+  const icon = getCollectionIcon(collection.media_images)
 
   return (
     <Container className="divide-y p-0" data-testid="collection-icon-section">

--- a/packages/vendor/src/pages/collections/[id]/_components/collection-media-section/collection-media-section.tsx
+++ b/packages/vendor/src/pages/collections/[id]/_components/collection-media-section/collection-media-section.tsx
@@ -17,7 +17,7 @@ export const CollectionMediaSection = ({
 }: CollectionMediaSectionProps) => {
   const { t } = useTranslation()
 
-  const gallery = getCollectionGallery(collection.images)
+  const gallery = getCollectionGallery(collection.media_images)
 
   return (
     <Container className="divide-y p-0" data-testid="collection-media-section">

--- a/packages/vendor/src/pages/collections/common/components/collection-image-fields/types.ts
+++ b/packages/vendor/src/pages/collections/common/components/collection-image-fields/types.ts
@@ -9,7 +9,7 @@ export type CollectionApiImage = {
 }
 
 export type CollectionWithImages = {
-  images?: CollectionApiImage[] | null
+  media_images?: CollectionApiImage[] | null
 }
 
 /** Gallery images (type = null), ordered by rank. */


### PR DESCRIPTION
## Summary

`GET /store/products` forwarded its query filters straight into
`query.graph`, so a standard storefront query like
`?category_id=pcat_...` failed with:

```
Trying to query by not existing property Product.category_id
```

`category_id` is not a column on `Product` — it is the `categories`
relation. Vanilla Medusa's own store products route handles this in
middleware via `applyDefaultFilters`, which rewrites `category_id` into
the `categories` relation filter. Mercur's override skipped that step.

Closes #974.

## Changes

- `packages/core/src/api/store/products/middlewares.ts`: replace the
  hand-rolled status-only filter with the framework `applyDefaultFilters`
  middleware (same approach as vanilla Medusa), translating `category_id`
  into `categories: { id, is_internal: false, is_active: true }` and
  removing the raw `category_id` key before it reaches `query.graph`.
  Applies to both the list and `:id` routes.

## Tests

`integration-tests/http/product/store/product.spec.ts`:

- `should filter products by category_id` — regression for #974: asserts
  `?category_id=...` returns 200 with only the linked product.
- `should not return products from an inactive category` — guards the
  `is_active: true` half of the translation.