### PR TITLE
fix(registry): make meilisearch block 2.2-ready

### DIFF
--- a/integration-tests/http/meilisearch/store/meilisearch.spec.ts
+++ b/integration-tests/http/meilisearch/store/meilisearch.spec.ts
@@ -147,7 +147,7 @@ medusaIntegrationTestRunner({
           expect(response.data.totalHits).toBe(0)
         })
 
-        it("passes seller.status = 'active' filter to meilisearch (FR-003)", async () => {
+        it("passes seller.status = 'open' filter to meilisearch (FR-003)", async () => {
           mockSearchFn.mockResolvedValueOnce({
             hits: [],
             totalHits: 0,
@@ -165,7 +165,7 @@ medusaIntegrationTestRunner({
           )
 
           const searchOptions = mockSearchFn.mock.calls[0][1]
-          expect(searchOptions.filter).toContain('seller.status = "active"')
+          expect(searchOptions.filter).toContain('seller.status = "open"')
         })
 
         it("includes category filter when provided", async () => {

--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -801,7 +801,7 @@
       "name": "meilisearch",
       "description": "Opt-in Meilisearch search block for multi-vendor marketplaces with real-time seller-aware indexing, seller lifecycle sync, and injection-safe smart filtering.",
       "dependencies": [
-        "meilisearch"
+        "meilisearch@^0.47.0"
       ],
       "registryDependencies": [],
       "docs": "## Prerequisites\n\nInstall and run a Meilisearch instance:\n\n```bash\ndocker run -d -p 7700:7700 getmeili/meilisearch\n```\n\n## Environment Variables\n\nAdd to your `.env` file:\n\n```env\nMEILISEARCH_HOST=http://localhost:7700\nMEILISEARCH_API_KEY=your_master_key_here\n```\n\n## Module Configuration\n\nAdd to your `medusa-config.ts`:\n\n```ts\nexport default defineConfig({\n  modules: [\n    {\n      resolve: './modules/meilisearch',\n      options: {\n        host: process.env.MEILISEARCH_HOST,\n        apiKey: process.env.MEILISEARCH_API_KEY,\n      },\n    },\n  ],\n})\n```\n\n## Middlewares\n\nAdd to your `api/middlewares.ts`:\n\n```ts\nimport { defineMiddlewares } from \"@medusajs/medusa\";\nimport { allMeilisearchMiddlewares } from \"./meilisearch/api/middlewares\";\n\nexport default defineMiddlewares({\n  routes: [...allMeilisearchMiddlewares],\n});\n```\n\n## Initial Sync\n\nAfter starting the server, trigger a full re-index:\n\n```bash\ncurl -X POST http://localhost:9000/admin/meilisearch/sync \\\n  -H \"Authorization: Bearer YOUR_ADMIN_TOKEN\"\n```\n\n## Search\n\n```bash\ncurl -X POST http://localhost:9000/store/meilisearch/products \\\n  -H \"Content-Type: application/json\" \\\n  -H \"x-publishable-api-key: YOUR_KEY\" \\\n  -d '{\"query\": \"shoes\", \"filters\": {\"price_min\": 50, \"price_max\": 200}}'\n```",

--- a/packages/registry/src/meilisearch/PLUGIN.md
+++ b/packages/registry/src/meilisearch/PLUGIN.md
@@ -98,21 +98,33 @@ modules: [
 
 ### Step 3: Register Middlewares
 
-Open your `src/api/middlewares.ts` and add the meilisearch store middlewares:
+Medusa only auto-discovers middlewares from `src/api/middlewares.ts`, and that
+file **must** default-export `defineMiddlewares(...)`. The block ships its routes
+at `src/meilisearch/api/middlewares.ts`, which exports both:
+
+- `allMeilisearchMiddlewares` — the route array, for merging into your own file
+- a `default defineMiddlewares(...)` — usable directly if you have no other
+  middlewares (re-export it from `src/api/middlewares.ts`)
+
+Wire it into your project's `src/api/middlewares.ts`. If the file does not exist
+yet, create it; if it does, merge the routes in — do **not** overwrite it:
 
 ```typescript
 import { defineMiddlewares } from "@medusajs/medusa"
-import { meilisearchStoreMiddlewares } from './store/meilisearch/products/search/middlewares'
+import { allMeilisearchMiddlewares } from './meilisearch/api/middlewares'
 
 export default defineMiddlewares({
   routes: [
     // ... existing routes
-    ...meilisearchStoreMiddlewares,
+    ...allMeilisearchMiddlewares,
   ],
 })
 ```
 
-> **Warning:** The CLI may prompt you to replace your existing `middlewares.ts` file during installation. If you already have middleware routes defined, **do not replace it**. Instead, manually merge the meilisearch middlewares into your existing `defineMiddlewares` call as shown above. Replacing the file removes the `defineMiddlewares` default export, which causes `req.validatedBody` to be `undefined` at runtime.
+> **Warning:** If `src/api/middlewares.ts` ends up exporting a plain array (or
+> loses its `defineMiddlewares` default export), the search route's Zod
+> validation never registers and the handler crashes on `req.validatedBody`
+> being `undefined`.
 
 ### Step 4: Set Environment Variables
 
@@ -190,7 +202,7 @@ Search products. Requires `x-publishable-api-key` header.
       "status": "published",
       "variants": [...],
       "categories": [...],
-      "seller": { "id": "slr_1", "name": "ACME", "handle": "acme", "status": "active" }
+      "seller": { "id": "slr_1", "name": "ACME", "handle": "acme", "status": "open" }
     }
   ],
   "totalHits": 42,
@@ -202,7 +214,7 @@ Search products. Requires `x-publishable-api-key` header.
 }
 ```
 
-**Important:** The `seller.status = "active"` filter is always enforced server-side (FR-003). Suspended seller products never appear in results regardless of what filters the client sends.
+**Important:** The `seller.status = "open"` filter is always enforced server-side (FR-003). Only products from open (visible) sellers ever appear — suspended, terminated, or pending sellers' products are filtered out regardless of what filters the client sends.
 
 **Pagination:** Meilisearch uses 1-based page numbering. Page 1 is the first page of results.
 

--- a/packages/registry/src/meilisearch/__tests__/meilisearch-product.unit.spec.ts
+++ b/packages/registry/src/meilisearch/__tests__/meilisearch-product.unit.spec.ts
@@ -123,12 +123,14 @@ const baseProduct = {
     },
   ],
   variants: [baseVariant],
-  seller: {
-    id: 'sel_1',
-    handle: 'acme-store',
-    name: 'ACME',
-    status: 'active',
-  },
+  sellers: [
+    {
+      id: 'sel_1',
+      handle: 'acme-store',
+      name: 'ACME',
+      status: 'open',
+    },
+  ],
 }
 
 describe('findAndTransformMeilisearchProducts', () => {
@@ -147,7 +149,7 @@ describe('findAndTransformMeilisearchProducts', () => {
 
     const callArgs = container._graph.mock.calls[0][0]
     expect(callArgs.fields).toEqual(
-      expect.arrayContaining(['seller.id', 'seller.handle', 'seller.name', 'seller.status'])
+      expect.arrayContaining(['sellers.id', 'sellers.handle', 'sellers.name', 'sellers.status'])
     )
   })
 
@@ -160,7 +162,32 @@ describe('findAndTransformMeilisearchProducts', () => {
     const doc = result[0]!
     expect(doc.id).toBe('prod_1')
     expect(doc.title).toBe('Running Shoes')
-    expect(doc.seller).toMatchObject({ id: 'sel_1', handle: 'acme-store', status: 'active' })
+    expect(doc.seller).toMatchObject({ id: 'sel_1', handle: 'acme-store', status: 'open' })
+  })
+
+  it('flattens the sellers array (many-to-many link) to a single seller object', async () => {
+    const container = makeContainer([
+      {
+        ...baseProduct,
+        sellers: [
+          { id: 'sel_1', handle: 'acme-store', name: 'ACME', status: 'open' },
+        ],
+      },
+    ]) as any
+
+    const result = await findAndTransformMeilisearchProducts(container, ['prod_1'])
+
+    const doc = result[0]!
+    expect(Array.isArray(doc.seller)).toBe(false)
+    expect(doc.seller).toMatchObject({ id: 'sel_1', status: 'open' })
+  })
+
+  it('sets seller to null when the sellers array is empty', async () => {
+    const container = makeContainer([{ ...baseProduct, sellers: [] }]) as any
+
+    const result = await findAndTransformMeilisearchProducts(container, ['prod_1'])
+
+    expect(result[0]!.seller).toBeNull()
   })
 
   it('flattens options into key/value records', async () => {

--- a/packages/registry/src/meilisearch/__tests__/store-route.unit.spec.ts
+++ b/packages/registry/src/meilisearch/__tests__/store-route.unit.spec.ts
@@ -49,16 +49,16 @@ function makeRequest(body: Record<string, any> = {}, products: any[] = []) {
   return { req, res, mockSearch, mockGraph }
 }
 
-// ─── FR-003: seller.status = "active" is always enforced ─────────────────────
+// ─── FR-003: seller.status = "open" is always enforced ───────────────────────
 
 describe('POST /store/meilisearch/products/search — filter enforcement', () => {
-  it('always sends seller.status = "active" in the filter string (FR-003)', async () => {
+  it('always sends seller.status = "open" in the filter string (FR-003)', async () => {
     const { req, res, mockSearch } = makeRequest({ query: 'shoes' })
 
     await POST(req, res as any)
 
     const searchOptions = mockSearch.mock.calls[0][1] as Record<string, unknown>
-    expect(searchOptions.filter).toContain('seller.status = "active"')
+    expect(searchOptions.filter).toContain('seller.status = "open"')
   })
 
   it('cannot be bypassed even when no other filters are provided', async () => {
@@ -67,7 +67,7 @@ describe('POST /store/meilisearch/products/search — filter enforcement', () =>
     await POST(req, res as any)
 
     const filter = mockSearch.mock.calls[0][1].filter as string
-    expect(filter).toBe('seller.status = "active"')
+    expect(filter).toBe('seller.status = "open"')
   })
 
   it('appends category filter after the mandatory seller filter', async () => {
@@ -78,7 +78,7 @@ describe('POST /store/meilisearch/products/search — filter enforcement', () =>
     await POST(req, res as any)
 
     const filter = mockSearch.mock.calls[0][1].filter as string
-    expect(filter).toMatch(/^seller\.status = "active"/)
+    expect(filter).toMatch(/^seller\.status = "open"/)
     expect(filter).toContain('categories.id IN ["cat_1", "cat_2"]')
   })
 

--- a/packages/registry/src/meilisearch/api/middlewares.ts
+++ b/packages/registry/src/meilisearch/api/middlewares.ts
@@ -1,3 +1,9 @@
+import { defineMiddlewares } from '@medusajs/medusa'
+
 import { meilisearchStoreMiddlewares } from './store/meilisearch/products/search/middlewares'
 
 export const allMeilisearchMiddlewares = [...meilisearchStoreMiddlewares]
+
+export default defineMiddlewares({
+  routes: [...meilisearchStoreMiddlewares],
+})

--- a/packages/registry/src/meilisearch/api/store/meilisearch/products/search/route.ts
+++ b/packages/registry/src/meilisearch/api/store/meilisearch/products/search/route.ts
@@ -23,8 +23,7 @@ export const POST = async (
     customer_group_id,
   } = req.validatedBody
 
-  // Build filter string server-side — seller.status = "active" is always enforced (FR-003)
-  const filterParts: string[] = ['seller.status = "active"']
+  const filterParts: string[] = ['seller.status = "open"']
 
   if (filters?.categories?.length) {
     const ids = filters.categories.map((c) => `"${c}"`).join(', ')
@@ -93,7 +92,7 @@ export const POST = async (
       'collection.*',
       'type.*',
       'tags.*',
-      'seller.*',
+      'sellers.*',
     ],
     filters: { id: productIds },
     ...(Object.keys(contextParams).length > 0 && { context: contextParams }),

--- a/packages/registry/src/meilisearch/modules/meilisearch/service.ts
+++ b/packages/registry/src/meilisearch/modules/meilisearch/service.ts
@@ -89,12 +89,21 @@ class MeilisearchModuleService {
     options: Record<string, unknown>
   ): Promise<MeilisearchSearchResult> {
     const result = await this.productIndex_.search(query, options)
+
+    const pagination = result as Partial<{
+      totalHits: number
+      page: number
+      totalPages: number
+      hitsPerPage: number
+      estimatedTotalHits: number
+    }>
+
     return {
       hits: (result.hits ?? []) as Array<{ id: string }>,
-      totalHits: result.totalHits ?? result.estimatedTotalHits ?? 0,
-      page: result.page ?? 0,
-      totalPages: result.totalPages ?? 0,
-      hitsPerPage: result.hitsPerPage ?? 0,
+      totalHits: pagination.totalHits ?? pagination.estimatedTotalHits ?? 0,
+      page: pagination.page ?? 0,
+      totalPages: pagination.totalPages ?? 0,
+      hitsPerPage: pagination.hitsPerPage ?? 0,
       processingTimeMs: result.processingTimeMs,
       query: result.query,
       facetDistribution: result.facetDistribution,

--- a/packages/registry/src/meilisearch/subscribers/utils/meilisearch-product.ts
+++ b/packages/registry/src/meilisearch/subscribers/utils/meilisearch-product.ts
@@ -84,21 +84,25 @@ export async function findAndTransformMeilisearchProducts(
       'options.*',
       'options.values.*',
       'images.*',
-      'seller.id',
-      'seller.handle',
-      'seller.name',
-      'seller.status',
+      'sellers.id',
+      'sellers.handle',
+      'sellers.name',
+      'sellers.status',
     ],
     filters: ids.length
       ? { id: ids, status: 'published' }
       : { status: 'published' },
   })
 
-  const transformed = products.map((product: any) => ({
-    ...product,
-    options: flattenProductOptions(product.options),
-    variants: (product.variants ?? []).map(flattenVariantOptions),
-  }))
+  const transformed = products.map((product: any) => {
+    const { sellers, ...rest } = product
+    return {
+      ...rest,
+      options: flattenProductOptions(product.options),
+      variants: (product.variants ?? []).map(flattenVariantOptions),
+      seller: Array.isArray(sellers) ? (sellers[0] ?? null) : (sellers ?? null),
+    }
+  })
 
   return z.array(MeilisearchProductValidator).parse(transformed)
 }


### PR DESCRIPTION
## Summary

The `meilisearch` registry block targeted the 2.1.x data model and broke on a 2.2 project in several independent ways. This PR fixes the issues reported in #975.

Refs #975

## What was wrong & what changed

1. **Seller resolution (`product.sellers`, plural many-to-many list).** On 2.2 the `product ↔ seller` link is a many-to-many list, exposed on the product as **`sellers`** (an array, typed `SellerDTO[]` — see `PRODUCT_DETAIL_FIELDS`). The block queried the singular `seller.*`, which resolves to nothing, so every indexed document got a `null` seller and the mandatory `seller.status` filter matched **zero** results. Now the graph queries `sellers.*` and flattens to a single `seller` object on the index document (the Meilisearch document schema stays singular). Hydration in the store route also switched `seller.*` → `sellers.*`.

2. **Seller status filter.** The store route hard-filtered `seller.status = "active"`, which is not a valid `SellerStatus` (`open` / `pending_approval` / `suspended` / `terminated`), so search returned nothing. Now filters on `seller.status = "open"` (the live "visible seller" value).

3. **`middlewares.ts` shape.** The block shipped a plain array, but Medusa requires a default export of `defineMiddlewares({ routes })`, so the search route's Zod validation never registered and the handler crashed on `req.validatedBody` being `undefined`. The file now default-exports `defineMiddlewares(...)` and keeps the named `allMeilisearchMiddlewares` array for merging. `PLUGIN.md` documents the real file placement + merge path.

4. **npm client pin.** `registry.json` dependency changed from `meilisearch` → `meilisearch@^0.47.0`, so the CLI no longer installs an incompatible client (`0.58` throws `MeiliSearch is not a constructor`).

5. **`service.ts` type-check (TS2339).** The client's `SearchResponse` is a union; with loosely-typed options it narrows to the infinite-pagination variant, so `totalHits` / `page` / `totalPages` / `hitsPerPage` aren't on the type and `medusa build` failed. These are now read through an explicit optional view — version-robust across client releases.

> Note: the report's #5 (hard-deleted index orphan reconciliation) is intentionally **not** included here and can be addressed separately.

## Testing

- Registry unit suite extended and green: **57/57** (`packages/registry/src/meilisearch/__tests__`), including new coverage for `sellers` array flattening and empty-sellers → `null` seller.
- `tsc --noEmit` clean on the block source (previously failed with TS2339).
- Store integration spec assertion updated to the corrected `"open"` filter.

### Note on the integration specs

The two suites under `integration-tests/http/meilisearch/` are **not currently wired into the test app** (the block lives in `@mercurjs/registry` and is copied into consumer projects, not loaded by the integration `medusa-config.ts`), so they 404 as-is. The dedicated `test:integration:meilisearch` script also uses a jest flag (`--testPathPattern`) that was removed in the current jest. Both are pre-existing gaps, independent of this fix; wiring the block into the test harness can be done as a follow-up.