### PR TITLE
feat(offers): add public store offers discovery API

### DIFF
--- a/integration-tests/http/offer/store/store-offers.spec.ts
+++ b/integration-tests/http/offer/store/store-offers.spec.ts
@@ -1,0 +1,401 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+    IRegionModuleService,
+    ISalesChannelModuleService,
+    MedusaContainer,
+} from "@medusajs/framework/types"
+import {
+    ContainerRegistrationKeys,
+    Modules,
+} from "@medusajs/framework/utils"
+import { MercurModules, SellerStatus } from "@mercurjs/types"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+import {
+    generatePublishableKey,
+    generateStoreHeaders,
+} from "../../../helpers/create-admin-user"
+
+const approveSeller = async (container: MedusaContainer, sellerId: string) => {
+    const sellerModule: any = container.resolve(MercurModules.SELLER)
+    await sellerModule.updateSellers({
+        id: sellerId,
+        status: SellerStatus.OPEN,
+    })
+}
+
+jest.setTimeout(120000)
+
+medusaIntegrationTestRunner({
+    testSuite: ({ getContainer, api }) => {
+        describe("Store - Offers", () => {
+            let appContainer: MedusaContainer
+            let storeHeaders: any
+            let region: any
+            let salesChannel: any
+
+            let seedCounter = 0
+            const seedSellerOffer = async (opts: {
+                email: string
+                name: string
+                stocked: number
+                offerPrice: number
+                approve?: boolean
+                published?: boolean
+                required_quantity?: number
+                productId?: string
+                variantId?: string
+                linkLocationToChannel?: boolean
+            }) => {
+                const tag = `s${++seedCounter}${Date.now()}`
+                const result = await createSellerUser(appContainer, {
+                    email: opts.email,
+                    name: opts.name,
+                })
+                if (opts.approve !== false) {
+                    await approveSeller(appContainer, (result.seller as any).id)
+                }
+                const headers = result.headers
+
+                const stockLocation = (
+                    await api.post(
+                        `/vendor/stock-locations`,
+                        { name: `${opts.name} WH ${tag}` },
+                        headers
+                    )
+                ).data.stock_location
+                const stockLocationId = stockLocation.id
+
+                if (opts.linkLocationToChannel !== false) {
+                    await api.post(
+                        `/vendor/stock-locations/${stockLocationId}/sales-channels`,
+                        { add: [salesChannel.id] },
+                        headers
+                    )
+                }
+
+                let productId = opts.productId
+                let variantId = opts.variantId
+                if (!productId || !variantId) {
+                    const product = (
+                        await api.post(
+                            `/vendor/products`,
+                            {
+                                status:
+                                    opts.published === false
+                                        ? "draft"
+                                        : "published",
+                                title: `${opts.name} Product ${tag}`,
+                                variant_attributes: [
+                                    {
+                                        name: `Default ${tag}`,
+                                        type: "multi_select",
+                                        values: ["Default"],
+                                        is_variant_axis: true,
+                                    },
+                                ],
+                                variants: [
+                                    {
+                                        title: "Default",
+                                        sku: `${opts.email}-V-SKU-${tag}`,
+                                        attribute_values: {
+                                            [`Default ${tag}`]: "Default",
+                                        },
+                                    },
+                                ],
+                            },
+                            headers
+                        )
+                    ).data.product
+
+                    await api.post(
+                        `/vendor/sales-channels/${salesChannel.id}/products`,
+                        { add: [product.id] },
+                        headers
+                    )
+
+                    productId = product.id
+                    variantId = product.variants[0].id
+                }
+
+                const shippingProfile = (
+                    await api.post(
+                        `/vendor/shipping-profiles`,
+                        { name: `${opts.name} Profile ${tag}`, type: "default" },
+                        headers
+                    )
+                ).data.shipping_profile
+
+                const offer = (
+                    await api.post(
+                        `/vendor/offers`,
+                        {
+                            sku: `${opts.name.replace(/\s/g, "")}-OFFER-${tag}`,
+                            variant_id: variantId,
+                            shipping_profile_id: shippingProfile.id,
+                            inventory_items: [
+                                {
+                                    title: `${opts.name} Inv ${tag}`,
+                                    required_quantity:
+                                        opts.required_quantity ?? 1,
+                                    stock_levels: [
+                                        {
+                                            location_id: stockLocationId,
+                                            stocked_quantity: opts.stocked,
+                                        },
+                                    ],
+                                },
+                            ],
+                            prices: [
+                                { amount: opts.offerPrice, currency_code: "usd" },
+                            ],
+                        },
+                        headers
+                    )
+                ).data.offer
+
+                return {
+                    headers,
+                    sellerId: result.seller.id as string,
+                    productId: productId as string,
+                    variantId: variantId as string,
+                    offer,
+                }
+            }
+
+            beforeAll(async () => {
+                appContainer = getContainer()
+            })
+
+            beforeEach(async () => {
+                const salesChannelModule =
+                    appContainer.resolve<ISalesChannelModuleService>(
+                        Modules.SALES_CHANNEL
+                    )
+                salesChannel = await salesChannelModule.createSalesChannels({
+                    name: "Default Store",
+                })
+
+                const regionModule = appContainer.resolve<IRegionModuleService>(
+                    Modules.REGION
+                )
+                region = await regionModule.createRegions({
+                    name: "Test Region",
+                    currency_code: "usd",
+                    countries: ["us"],
+                })
+
+                const apiKey = await generatePublishableKey(appContainer)
+                storeHeaders = generateStoreHeaders({ publishableKey: apiKey })
+
+                const link = appContainer.resolve(ContainerRegistrationKeys.LINK)
+                await link.create({
+                    [Modules.API_KEY]: { publishable_key_id: apiKey.id },
+                    [Modules.SALES_CHANNEL]: {
+                        sales_channel_id: salesChannel.id,
+                    },
+                })
+            })
+
+            describe("GET /store/offers", () => {
+                it("returns an open seller's offer for a product with calculated_price", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "happy@test.com",
+                        name: "Happy",
+                        stocked: 10,
+                        offerPrice: 2500,
+                    })
+
+                    const response = await api.get(
+                        `/store/offers?product_id=${seed.productId}&fields=+calculated_price&region_id=${region.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offers).toHaveLength(1)
+                    expect(response.data.offers[0]).toEqual(
+                        expect.objectContaining({
+                            id: seed.offer.id,
+                            product_id: seed.productId,
+                            variant_id: seed.variantId,
+                        })
+                    )
+                    expect(
+                        response.data.offers[0].calculated_price.calculated_amount
+                    ).toEqual(2500)
+                    expect(
+                        response.data.offers[0].calculated_price.currency_code
+                    ).toEqual("usd")
+                })
+
+                it("filters offers by variant_id", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "byvariant@test.com",
+                        name: "ByVariant",
+                        stocked: 5,
+                        offerPrice: 1200,
+                    })
+
+                    const response = await api.get(
+                        `/store/offers?variant_id=${seed.variantId}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offers).toHaveLength(1)
+                    expect(response.data.offers[0].id).toEqual(seed.offer.id)
+                })
+
+                it("returns sibling offers from two sellers on one variant, each with its own price", async () => {
+                    const seedA = await seedSellerOffer({
+                        email: "expensive@test.com",
+                        name: "Expensive",
+                        stocked: 10,
+                        offerPrice: 5000,
+                    })
+                    const seedB = await seedSellerOffer({
+                        email: "cheap@test.com",
+                        name: "Cheap",
+                        stocked: 10,
+                        offerPrice: 2000,
+                        productId: seedA.productId,
+                        variantId: seedA.variantId,
+                    })
+
+                    const response = await api.get(
+                        `/store/offers?variant_id=${seedA.variantId}&fields=+calculated_price&region_id=${region.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offers).toHaveLength(2)
+                    const byId = new Map<string, any>(
+                        response.data.offers.map((o: any) => [o.id, o])
+                    )
+                    expect(
+                        byId.get(seedA.offer.id).calculated_price
+                            .calculated_amount
+                    ).toEqual(5000)
+                    expect(
+                        byId.get(seedB.offer.id).calculated_price
+                            .calculated_amount
+                    ).toEqual(2000)
+                })
+
+                it("excludes offers from sellers that are not open", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "pending@test.com",
+                        name: "Pending",
+                        stocked: 10,
+                        offerPrice: 1000,
+                        approve: false,
+                    })
+
+                    const response = await api.get(
+                        `/store/offers?product_id=${seed.productId}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offers).toHaveLength(0)
+                })
+
+                it("excludes offers on unpublished products", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "draft@test.com",
+                        name: "Draft",
+                        stocked: 10,
+                        offerPrice: 1000,
+                        published: false,
+                    })
+
+                    const response = await api.get(
+                        `/store/offers?product_id=${seed.productId}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offers).toHaveLength(0)
+                })
+
+                it("computes inventory_quantity as floor(stocked / required_quantity)", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "bundle@test.com",
+                        name: "Bundle",
+                        stocked: 7,
+                        offerPrice: 9000,
+                        required_quantity: 3,
+                    })
+
+                    const response = await api.get(
+                        `/store/offers?product_id=${seed.productId}&fields=+inventory_quantity`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offers).toHaveLength(1)
+                    expect(response.data.offers[0].inventory_quantity).toEqual(2)
+                    expect(response.data.offers[0].in_stock).toEqual(true)
+                })
+
+                it("reports zero stock for an offer whose location is not linked to the sales channel", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "wronglocation@test.com",
+                        name: "Wrong",
+                        stocked: 10,
+                        offerPrice: 1234,
+                        linkLocationToChannel: false,
+                    })
+
+                    const response = await api.get(
+                        `/store/offers?product_id=${seed.productId}&fields=+inventory_quantity`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offers).toHaveLength(1)
+                    expect(response.data.offers[0].inventory_quantity).toEqual(0)
+                    expect(response.data.offers[0].in_stock).toEqual(false)
+                })
+            })
+
+            describe("GET /store/offers/:id", () => {
+                it("returns a single open seller's offer", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "single@test.com",
+                        name: "Single",
+                        stocked: 4,
+                        offerPrice: 3300,
+                    })
+
+                    const response = await api.get(
+                        `/store/offers/${seed.offer.id}?fields=+calculated_price&region_id=${region.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offer.id).toEqual(seed.offer.id)
+                    expect(response.data.offer.product_id).toEqual(seed.productId)
+                    expect(
+                        response.data.offer.calculated_price.calculated_amount
+                    ).toEqual(3300)
+                })
+
+                it("404s for an offer whose seller is not open", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "hidden@test.com",
+                        name: "Hidden",
+                        stocked: 4,
+                        offerPrice: 3300,
+                        approve: false,
+                    })
+
+                    const error = await api
+                        .get(`/store/offers/${seed.offer.id}`, storeHeaders)
+                        .catch((e) => e)
+
+                    expect(error.response.status).toEqual(404)
+                })
+            })
+        })
+    },
+})

--- a/integration-tests/http/offer/store/store-offers.spec.ts
+++ b/integration-tests/http/offer/store/store-offers.spec.ts
@@ -281,6 +281,52 @@ medusaIntegrationTestRunner({
                     ).toEqual(2000)
                 })
 
+                it("prices offers on different products in a single calculatePrices call", async () => {
+                    const seedA = await seedSellerOffer({
+                        email: "batch-a@test.com",
+                        name: "BatchA",
+                        stocked: 10,
+                        offerPrice: 1000,
+                    })
+                    const seedB = await seedSellerOffer({
+                        email: "batch-b@test.com",
+                        name: "BatchB",
+                        stocked: 10,
+                        offerPrice: 2000,
+                    })
+
+                    const pricingModule = appContainer.resolve(
+                        Modules.PRICING
+                    ) as any
+                    const spy = jest.spyOn(pricingModule, "calculatePrices")
+                    spy.mockClear()
+
+                    const response = await api.get(
+                        `/store/offers?id[]=${seedA.offer.id}&id[]=${seedB.offer.id}&fields=+calculated_price&region_id=${region.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.offers).toHaveLength(2)
+                    expect(spy).toHaveBeenCalledTimes(1)
+                    const arg = spy.mock.calls[0][0] as { id: string[] }
+                    expect(arg.id).toHaveLength(2)
+
+                    const byId = new Map<string, any>(
+                        response.data.offers.map((o: any) => [o.id, o])
+                    )
+                    expect(
+                        byId.get(seedA.offer.id).calculated_price
+                            .calculated_amount
+                    ).toEqual(1000)
+                    expect(
+                        byId.get(seedB.offer.id).calculated_price
+                            .calculated_amount
+                    ).toEqual(2000)
+
+                    spy.mockRestore()
+                })
+
                 it("excludes offers from sellers that are not open", async () => {
                     const seed = await seedSellerOffer({
                         email: "pending@test.com",

--- a/integration-tests/http/offer/vendor/offer.spec.ts
+++ b/integration-tests/http/offer/vendor/offer.spec.ts
@@ -54,6 +54,7 @@ medusaIntegrationTestRunner({
 
                 return {
                     variant_id: variant.id,
+                    product_id: product.data.product.id,
                     shipping_profile_id:
                         shippingProfile.data.shipping_profile.id,
                     ean,
@@ -100,6 +101,7 @@ medusaIntegrationTestRunner({
                         expect.objectContaining({
                             sku: "SELLER1-SKU-001",
                             variant_id: deps.variant_id,
+                            product_id: deps.product_id,
                             shipping_profile_id: deps.shipping_profile_id,
                             ean: deps.ean,
                             upc: deps.upc,

--- a/packages/core/.mercur/routes.d.ts
+++ b/packages/core/.mercur/routes.d.ts
@@ -578,6 +578,9 @@ export type Routes = {
         sellers: typeof import("../../src/api/store/sellers/route") & {
             $id: typeof import("../../src/api/store/sellers/[id]/route");
         };
+        offers: typeof import("../../src/api/store/offers/route") & {
+            $id: typeof import("../../src/api/store/offers/[id]/route");
+        };
     };
     hooks: {
         payout: typeof import("../../src/api/hooks/payout/route");

--- a/packages/core/src/api/admin/offers/query-config.ts
+++ b/packages/core/src/api/admin/offers/query-config.ts
@@ -2,6 +2,7 @@ export const defaultAdminOfferFields = [
   "id",
   "seller_id",
   "variant_id",
+  "product_id",
   "shipping_profile_id",
   "sku",
   "ean",

--- a/packages/core/src/api/store/middlewares.ts
+++ b/packages/core/src/api/store/middlewares.ts
@@ -1,6 +1,7 @@
 import { MiddlewareRoute } from "@medusajs/medusa"
 
 import { storeCartsMiddlewares } from "./carts/middlewares"
+import { storeOffersMiddlewares } from "./offers/middlewares"
 import { storeOrderGroupsMiddlewares } from "./order-groups/middlewares"
 import { storeProductAttributesMiddlewares } from "./product-attributes/middlewares"
 import { storeProductCategoriesMiddlewares } from "./product-categories/middlewares"
@@ -9,6 +10,7 @@ import { storeSellersMiddlewares } from "./sellers/middlewares"
 
 export const storeMiddlewares: MiddlewareRoute[] = [
   ...storeCartsMiddlewares,
+  ...storeOffersMiddlewares,
   ...storeOrderGroupsMiddlewares,
   ...storeProductAttributesMiddlewares,
   ...storeProductCategoriesMiddlewares,

--- a/packages/core/src/api/store/offers/[id]/route.ts
+++ b/packages/core/src/api/store/offers/[id]/route.ts
@@ -1,0 +1,56 @@
+import {
+  MedusaResponse,
+  MedusaStoreRequest,
+} from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+
+import {
+  splitComputedOfferFields,
+  wrapOffersWithCalculatedPrices,
+  wrapOffersWithInventoryQuantityForSalesChannel,
+  wrapOffersWithTaxPrices,
+} from "../helpers"
+import { StoreGetOfferParamsType } from "../validators"
+
+export const GET = async (
+  req: MedusaStoreRequest<StoreGetOfferParamsType>,
+  res: MedusaResponse
+) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { fields, withCalculatedPrice, withInventoryQuantity } =
+    splitComputedOfferFields(req.queryConfig.fields)
+
+  const {
+    data: [offer],
+  } = await query.graph({
+    entity: "offer",
+    fields: fields,
+    filters: { ...req.filterableFields, id: req.params.id },
+  })
+
+  if (!offer) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Offer with id ${req.params.id} was not found`
+    )
+  }
+
+  const offers = [offer]
+  if (withCalculatedPrice) {
+    await wrapOffersWithCalculatedPrices(
+      req,
+      offers
+    )
+    await wrapOffersWithTaxPrices(req, offers)
+  }
+
+  if (withInventoryQuantity) {
+    await wrapOffersWithInventoryQuantityForSalesChannel(req, offers)
+  }
+
+  res.json({ offer })
+}

--- a/packages/core/src/api/store/offers/helpers.ts
+++ b/packages/core/src/api/store/offers/helpers.ts
@@ -15,18 +15,6 @@ import {
 import { calculateAmountsWithTax } from "@medusajs/framework/utils"
 import { transformAndValidateSalesChannelIds } from "@medusajs/medusa/api/utils/middlewares/index"
 
-/**
- * Post-query enrichers for the store Offer surface. Mirrors Medusa's
- * `store/product-variants/helpers.ts` (`wrapVariantsWithTaxPrices`) and
- * `utils/middlewares/products/variant-inventory-quantity.ts`
- * (`wrapVariantsWithInventoryQuantityForSalesChannel`).
- *
- * Offers can't reuse those directly: an offer doesn't own a price set (it
- * shares the variant's, discriminated by an `offer_id` price rule) and its
- * inventory links to the offer, not the variant. So each helper recomputes
- * the offer-shaped equivalent.
- */
-
 type OfferLocationLevel = {
   location_id: string
   stocked_quantity: number
@@ -57,12 +45,6 @@ type StoreRequestWithContext = MedusaStoreRequest<unknown> & {
   }
 }
 
-/**
- * Attach `offer.calculated_price` using the request's pricing context.
- * Offers share the variant's price set, so the `offer_id` must be added to
- * the context per offer — that means one `calculatePrices` call per offer
- * (page-bounded; candidate for batching later).
- */
 export const wrapOffersWithCalculatedPrices = async (
   req: StoreRequestWithContext,
   offers: EnrichableOffer[]
@@ -96,11 +78,6 @@ export const wrapOffersWithCalculatedPrices = async (
   )
 }
 
-/**
- * Fill the tax-inclusive / tax-exclusive amounts on each offer's
- * `calculated_price`. Direct mirror of `wrapVariantsWithTaxPrices`, keyed on
- * the offer id and using `offer.product_id` for the tax item.
- */
 export const wrapOffersWithTaxPrices = async (
   req: StoreRequestWithContext,
   offers: EnrichableOffer[]
@@ -178,15 +155,6 @@ export const wrapOffersWithTaxPrices = async (
   })
 }
 
-/**
- * Resolve `inventory_quantity` + `in_stock` per offer, scoped to the
- * publishable key's sales channel. Mirrors
- * `wrapVariantsWithInventoryQuantityForSalesChannel`'s channel resolution but
- * computes availability off the offer's own inventory-item link(s):
- * `floor(stocked / required_quantity)`, taking the min across a bundle's
- * items, summing only location levels whose stock location is linked to the
- * channel.
- */
 export const wrapOffersWithInventoryQuantityForSalesChannel = async (
   req: MedusaStoreRequest<unknown>,
   offers: EnrichableOffer[]
@@ -250,12 +218,6 @@ export const wrapOffersWithInventoryQuantityForSalesChannel = async (
   }
 }
 
-/**
- * Strip the computed `calculated_price` / `inventory_quantity` field paths
- * from a query field list (they are not graph fields on `offer`), returning
- * the cleaned list plus which enrichers were requested. Mirrors how
- * `store/product-variants` strips `inventory_quantity` before the graph read.
- */
 export const splitComputedOfferFields = (fields: string[]) => {
   const withCalculatedPrice = fields.some(
     (f) => f === "calculated_price" || f.startsWith("calculated_price.")

--- a/packages/core/src/api/store/offers/helpers.ts
+++ b/packages/core/src/api/store/offers/helpers.ts
@@ -12,7 +12,7 @@ import {
   TaxableItemDTO,
   TaxCalculationContext,
 } from "@medusajs/framework/types"
-import { calculateAmountsWithTax } from "@medusajs/framework/utils"
+import { calculateAmountsWithTax, promiseAll } from "@medusajs/framework/utils"
 import { transformAndValidateSalesChannelIds } from "@medusajs/medusa/api/utils/middlewares/index"
 
 type OfferLocationLevel = {
@@ -54,28 +54,84 @@ export const wrapOffersWithCalculatedPrices = async (
   }
 
   const pricingModule = req.scope.resolve(Modules.PRICING)
+  const baseContext = req.pricingContext as Record<string, unknown>
 
-  await Promise.all(
-    offers.map(async (offer) => {
-      const priceSetId = offer.product_variant?.price_set?.id
-      if (!priceSetId) {
-        return
+  const byPriceSet = new Map<string, EnrichableOffer[]>()
+  for (const offer of offers) {
+    const priceSetId = offer.product_variant?.price_set?.id
+    if (!priceSetId) {
+      continue
+    }
+    const group = byPriceSet.get(priceSetId)
+    if (group) {
+      group.push(offer)
+    } else {
+      byPriceSet.set(priceSetId, [offer])
+    }
+  }
+
+  if (!byPriceSet.size) {
+    return
+  }
+
+  const singletons: { priceSetId: string; offer: EnrichableOffer }[] = []
+  const siblings: { priceSetId: string; offer: EnrichableOffer }[] = []
+  for (const [priceSetId, group] of byPriceSet) {
+    if (group.length === 1) {
+      singletons.push({ priceSetId, offer: group[0] })
+    } else {
+      for (const offer of group) {
+        siblings.push({ priceSetId, offer })
       }
+    }
+  }
 
-      const [calculated] = await pricingModule.calculatePrices(
-        { id: [priceSetId] },
-        {
-          context: {
-            ...(req.pricingContext as Record<string, string | number>),
-            offer_id: offer.id,
-          },
+  const tasks: Promise<void>[] = []
+
+  if (singletons.length) {
+    tasks.push(
+      (async () => {
+        const context: Record<string, unknown> = {
+          ...baseContext,
+          offer_id: singletons.map((s) => s.offer.id),
         }
-      )
+        const calculated = await pricingModule.calculatePrices(
+          { id: singletons.map((s) => s.priceSetId) },
+          { context: context as Record<string, string | number> }
+        )
 
-      offer.calculated_price =
-        (calculated as unknown as Record<string, unknown>) ?? null
-    })
-  )
+        const byPriceSetId = new Map(
+          calculated.map((c) => [
+            c.id,
+            c as unknown as Record<string, unknown>,
+          ])
+        )
+        for (const { priceSetId, offer } of singletons) {
+          offer.calculated_price = byPriceSetId.get(priceSetId) ?? null
+        }
+      })()
+    )
+  }
+
+  for (const { priceSetId, offer } of siblings) {
+    tasks.push(
+      (async () => {
+        const context: Record<string, unknown> = {
+          ...baseContext,
+          offer_id: offer.id,
+        }
+        const [calculated] = await pricingModule.calculatePrices(
+          { id: [priceSetId] },
+          { context: context as Record<string, string | number> }
+        )
+
+        offer.calculated_price =
+          (calculated as unknown as Record<string, unknown>) ?? null
+      })()
+    )
+  }
+
+  await promiseAll(tasks)
 }
 
 export const wrapOffersWithTaxPrices = async (

--- a/packages/core/src/api/store/offers/helpers.ts
+++ b/packages/core/src/api/store/offers/helpers.ts
@@ -1,0 +1,279 @@
+import {
+  MedusaStoreRequest,
+} from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import {
+  ItemTaxLineDTO,
+  MedusaPricingContext,
+  TaxableItemDTO,
+  TaxCalculationContext,
+} from "@medusajs/framework/types"
+import { calculateAmountsWithTax } from "@medusajs/framework/utils"
+import { transformAndValidateSalesChannelIds } from "@medusajs/medusa/api/utils/middlewares/index"
+
+/**
+ * Post-query enrichers for the store Offer surface. Mirrors Medusa's
+ * `store/product-variants/helpers.ts` (`wrapVariantsWithTaxPrices`) and
+ * `utils/middlewares/products/variant-inventory-quantity.ts`
+ * (`wrapVariantsWithInventoryQuantityForSalesChannel`).
+ *
+ * Offers can't reuse those directly: an offer doesn't own a price set (it
+ * shares the variant's, discriminated by an `offer_id` price rule) and its
+ * inventory links to the offer, not the variant. So each helper recomputes
+ * the offer-shaped equivalent.
+ */
+
+type OfferLocationLevel = {
+  location_id: string
+  stocked_quantity: number
+}
+
+type OfferInventoryLink = {
+  required_quantity?: number | null
+  inventory_item?: {
+    location_levels?: OfferLocationLevel[] | null
+  } | null
+}
+
+export type EnrichableOffer = {
+  id: string
+  product_id?: string
+  product_variant?: { price_set?: { id?: string } | null } | null
+  inventory_item_link?: OfferInventoryLink[] | null
+  calculated_price?: Record<string, unknown> | null
+  inventory_quantity?: number | null
+  in_stock?: boolean
+}
+
+type StoreRequestWithContext = MedusaStoreRequest<unknown> & {
+  pricingContext?: MedusaPricingContext
+  taxContext?: {
+    taxLineContext?: TaxCalculationContext
+    taxInclusivityContext?: { automaticTaxes: boolean }
+  }
+}
+
+/**
+ * Attach `offer.calculated_price` using the request's pricing context.
+ * Offers share the variant's price set, so the `offer_id` must be added to
+ * the context per offer — that means one `calculatePrices` call per offer
+ * (page-bounded; candidate for batching later).
+ */
+export const wrapOffersWithCalculatedPrices = async (
+  req: StoreRequestWithContext,
+  offers: EnrichableOffer[]
+): Promise<void> => {
+  if (!req.pricingContext || !offers?.length) {
+    return
+  }
+
+  const pricingModule = req.scope.resolve(Modules.PRICING)
+
+  await Promise.all(
+    offers.map(async (offer) => {
+      const priceSetId = offer.product_variant?.price_set?.id
+      if (!priceSetId) {
+        return
+      }
+
+      const [calculated] = await pricingModule.calculatePrices(
+        { id: [priceSetId] },
+        {
+          context: {
+            ...(req.pricingContext as Record<string, string | number>),
+            offer_id: offer.id,
+          },
+        }
+      )
+
+      offer.calculated_price =
+        (calculated as unknown as Record<string, unknown>) ?? null
+    })
+  )
+}
+
+/**
+ * Fill the tax-inclusive / tax-exclusive amounts on each offer's
+ * `calculated_price`. Direct mirror of `wrapVariantsWithTaxPrices`, keyed on
+ * the offer id and using `offer.product_id` for the tax item.
+ */
+export const wrapOffersWithTaxPrices = async (
+  req: StoreRequestWithContext,
+  offers: EnrichableOffer[]
+): Promise<void> => {
+  if (
+    !req.taxContext?.taxInclusivityContext ||
+    !req.taxContext?.taxLineContext ||
+    !offers?.length
+  ) {
+    return
+  }
+
+  const items = offers
+    .map((offer) => {
+      const price = offer.calculated_price as
+        | Record<string, unknown>
+        | null
+        | undefined
+      if (!price || !offer.product_id) {
+        return undefined
+      }
+      return {
+        id: offer.id,
+        product_id: offer.product_id,
+        quantity: 1,
+        unit_price: price.calculated_amount as number,
+        currency_code: price.currency_code as string,
+      }
+    })
+    .filter((item) => !!item) as TaxableItemDTO[]
+
+  if (!items.length) {
+    return
+  }
+
+  const taxService = req.scope.resolve(Modules.TAX)
+  const taxLines = (await taxService.getTaxLines(
+    items,
+    req.taxContext.taxLineContext
+  )) as unknown as ItemTaxLineDTO[]
+
+  const taxRatesMap = new Map<string, ItemTaxLineDTO[]>()
+  taxLines.forEach((taxLine) => {
+    const existing = taxRatesMap.get(taxLine.line_item_id) ?? []
+    existing.push(taxLine)
+    taxRatesMap.set(taxLine.line_item_id, existing)
+  })
+
+  offers.forEach((offer) => {
+    const price = offer.calculated_price as Record<string, unknown> | null
+    if (!price) {
+      return
+    }
+
+    const taxRatesForOffer = taxRatesMap.get(offer.id) || []
+
+    const { priceWithTax, priceWithoutTax } = calculateAmountsWithTax({
+      taxLines: taxRatesForOffer,
+      amount: price.calculated_amount as number,
+      includesTax: price.is_calculated_price_tax_inclusive as boolean,
+    })
+    price.calculated_amount_with_tax = priceWithTax
+    price.calculated_amount_without_tax = priceWithoutTax
+
+    const {
+      priceWithTax: originalPriceWithTax,
+      priceWithoutTax: originalPriceWithoutTax,
+    } = calculateAmountsWithTax({
+      taxLines: taxRatesForOffer,
+      amount: price.original_amount as number,
+      includesTax: price.is_original_price_tax_inclusive as boolean,
+    })
+    price.original_amount_with_tax = originalPriceWithTax
+    price.original_amount_without_tax = originalPriceWithoutTax
+  })
+}
+
+/**
+ * Resolve `inventory_quantity` + `in_stock` per offer, scoped to the
+ * publishable key's sales channel. Mirrors
+ * `wrapVariantsWithInventoryQuantityForSalesChannel`'s channel resolution but
+ * computes availability off the offer's own inventory-item link(s):
+ * `floor(stocked / required_quantity)`, taking the min across a bundle's
+ * items, summing only location levels whose stock location is linked to the
+ * channel.
+ */
+export const wrapOffersWithInventoryQuantityForSalesChannel = async (
+  req: MedusaStoreRequest<unknown>,
+  offers: EnrichableOffer[]
+): Promise<void> => {
+  if (!offers?.length) {
+    return
+  }
+
+  const salesChannelIds = transformAndValidateSalesChannelIds(req)
+  const publishableApiKeySalesChannelIds =
+    req.publishable_key_context?.sales_channel_ids ?? []
+
+  let channelToUse: string
+  if (publishableApiKeySalesChannelIds.length === 1) {
+    channelToUse = publishableApiKeySalesChannelIds[0]
+  } else if (salesChannelIds.length === 1) {
+    channelToUse = salesChannelIds[0]
+  } else {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Inventory availability cannot be calculated in the given context. Either provide a single sales channel id or configure a single sales channel in the publishable key`
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: channels } = await query.graph({
+    entity: "sales_channel",
+    fields: ["stock_locations.id"],
+    filters: { id: channelToUse },
+  })
+
+  const channelLocationIds = new Set<string>(
+    (channels[0]?.stock_locations ?? [])
+      .map((l: { id?: string }) => l.id)
+      .filter((id: string | undefined): id is string => Boolean(id))
+  )
+
+  for (const offer of offers) {
+    const links = offer.inventory_item_link ?? []
+    if (!links.length) {
+      offer.inventory_quantity = 0
+      offer.in_stock = false
+      continue
+    }
+
+    let offerAvailability = Number.POSITIVE_INFINITY
+    for (const link of links) {
+      const requiredQuantity = link.required_quantity ?? 1
+      const levels = link.inventory_item?.location_levels ?? []
+      const stocked = levels
+        .filter((level) => channelLocationIds.has(level.location_id))
+        .reduce((sum, level) => sum + (level.stocked_quantity ?? 0), 0)
+      const itemAvailability =
+        requiredQuantity > 0 ? Math.floor(stocked / requiredQuantity) : 0
+      offerAvailability = Math.min(offerAvailability, itemAvailability)
+    }
+
+    const quantity = Number.isFinite(offerAvailability) ? offerAvailability : 0
+    offer.inventory_quantity = quantity
+    offer.in_stock = quantity > 0
+  }
+}
+
+/**
+ * Strip the computed `calculated_price` / `inventory_quantity` field paths
+ * from a query field list (they are not graph fields on `offer`), returning
+ * the cleaned list plus which enrichers were requested. Mirrors how
+ * `store/product-variants` strips `inventory_quantity` before the graph read.
+ */
+export const splitComputedOfferFields = (fields: string[]) => {
+  const withCalculatedPrice = fields.some(
+    (f) => f === "calculated_price" || f.startsWith("calculated_price.")
+  )
+  const withInventoryQuantity = fields.includes("inventory_quantity")
+  const withInStock = fields.includes("in_stock")
+
+  const filteredFields = fields.filter(
+    (f) =>
+      f !== "calculated_price" &&
+      !f.startsWith("calculated_price.") &&
+      f !== "inventory_quantity" &&
+      f !== "in_stock"
+  )
+
+  return {
+    fields: filteredFields,
+    withCalculatedPrice,
+    withInventoryQuantity: withInventoryQuantity || withInStock,
+  }
+}

--- a/packages/core/src/api/store/offers/middlewares.ts
+++ b/packages/core/src/api/store/offers/middlewares.ts
@@ -19,11 +19,6 @@ import { storeOfferQueryConfig } from "./query-config"
 import { StoreGetOfferParams, StoreGetOffersParams } from "./validators"
 import { resolveVisibleSellerIds } from "../../utils/sellers"
 
-/**
- * Constrain the offer query to offers owned by sellers currently visible to
- * the storefront (status OPEN, not closed). `offer.seller_id` is a column, so
- * we filter it directly — no link translation needed.
- */
 async function applyVisibleSellerIdsFilter(
   req: MedusaRequest,
   _res: MedusaResponse,
@@ -34,12 +29,6 @@ async function applyVisibleSellerIdsFilter(
   next()
 }
 
-/**
- * Restrict offers to those on PUBLISHED products. `query.graph` can't filter
- * offers by the cross-module `product` link relation (only select it), so we
- * resolve the published product ids and constrain the offer's `product_id`
- * column directly — intersecting with any incoming `product_id` filter.
- */
 async function applyPublishedProductFilter(
   req: MedusaRequest,
   _res: MedusaResponse,
@@ -76,7 +65,6 @@ const offerMiddlewares = [
     allowUnauthenticated: true,
   }),
   applyVisibleSellerIdsFilter,
-  // Only surface offers on published products.
   applyPublishedProductFilter,
   ...pricingMiddlewares,
   clearFiltersByKey(["region_id", "country_code", "province", "cart_id"]),

--- a/packages/core/src/api/store/offers/middlewares.ts
+++ b/packages/core/src/api/store/offers/middlewares.ts
@@ -1,0 +1,108 @@
+import {
+  authenticate,
+  clearFiltersByKey,
+  MedusaNextFunction,
+  MedusaRequest,
+  MedusaResponse,
+  MiddlewareRoute,
+} from "@medusajs/framework/http"
+import { validateAndTransformQuery } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ProductStatus } from "@mercurjs/types"
+import {
+  normalizeDataForContext,
+  setPricingContext,
+  setTaxContext,
+} from "@medusajs/medusa/api/utils/middlewares/index"
+
+import { storeOfferQueryConfig } from "./query-config"
+import { StoreGetOfferParams, StoreGetOffersParams } from "./validators"
+import { resolveVisibleSellerIds } from "../../utils/sellers"
+
+/**
+ * Constrain the offer query to offers owned by sellers currently visible to
+ * the storefront (status OPEN, not closed). `offer.seller_id` is a column, so
+ * we filter it directly — no link translation needed.
+ */
+async function applyVisibleSellerIdsFilter(
+  req: MedusaRequest,
+  _res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  req.filterableFields ??= {}
+  req.filterableFields.seller_id = await resolveVisibleSellerIds(req.scope)
+  next()
+}
+
+/**
+ * Restrict offers to those on PUBLISHED products. `query.graph` can't filter
+ * offers by the cross-module `product` link relation (only select it), so we
+ * resolve the published product ids and constrain the offer's `product_id`
+ * column directly — intersecting with any incoming `product_id` filter.
+ */
+async function applyPublishedProductFilter(
+  req: MedusaRequest,
+  _res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  req.filterableFields ??= {}
+  const requested = req.filterableFields.product_id as
+    | string
+    | string[]
+    | undefined
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: products } = await query.graph({
+    entity: "product",
+    fields: ["id"],
+    filters: {
+      status: ProductStatus.PUBLISHED,
+      ...(requested ? { id: requested } : {}),
+    },
+  })
+
+  req.filterableFields.product_id = products.map((p: { id: string }) => p.id)
+  next()
+}
+
+const pricingMiddlewares = [
+  normalizeDataForContext({ priceFieldPaths: ["calculated_price"] }),
+  setPricingContext({ priceFieldPaths: ["calculated_price"] }),
+  setTaxContext({ priceFieldPaths: ["calculated_price"] }),
+]
+
+const offerMiddlewares = [
+  authenticate("customer", ["session", "bearer"], {
+    allowUnauthenticated: true,
+  }),
+  applyVisibleSellerIdsFilter,
+  // Only surface offers on published products.
+  applyPublishedProductFilter,
+  ...pricingMiddlewares,
+  clearFiltersByKey(["region_id", "country_code", "province", "cart_id"]),
+]
+
+export const storeOffersMiddlewares: MiddlewareRoute[] = [
+  {
+    method: ["GET"],
+    matcher: "/store/offers",
+    middlewares: [
+      validateAndTransformQuery(
+        StoreGetOffersParams,
+        storeOfferQueryConfig.list
+      ),
+      ...offerMiddlewares,
+    ],
+  },
+  {
+    method: ["GET"],
+    matcher: "/store/offers/:id",
+    middlewares: [
+      validateAndTransformQuery(
+        StoreGetOfferParams,
+        storeOfferQueryConfig.retrieve
+      ),
+      ...offerMiddlewares,
+    ],
+  },
+]

--- a/packages/core/src/api/store/offers/query-config.ts
+++ b/packages/core/src/api/store/offers/query-config.ts
@@ -1,15 +1,3 @@
-/**
- * Public, store-facing projection of an offer. A subset of
- * `defaultVendorOfferFields` (no `created_by`), plus the variant's
- * `price_set.id` (needed to resolve `calculated_price`) and the offer's
- * inventory-item link location levels (needed to resolve
- * `inventory_quantity` per sales channel).
- *
- * `calculated_price` and `inventory_quantity` are NOT graph fields — they
- * are computed post-query by the wrap helpers in `./helpers`. Consumers opt
- * in by requesting them via `?fields=...`; the route strips them before the
- * graph read.
- */
 export const defaultStoreOfferFields = [
   "id",
   "seller_id",

--- a/packages/core/src/api/store/offers/query-config.ts
+++ b/packages/core/src/api/store/offers/query-config.ts
@@ -1,0 +1,59 @@
+/**
+ * Public, store-facing projection of an offer. A subset of
+ * `defaultVendorOfferFields` (no `created_by`), plus the variant's
+ * `price_set.id` (needed to resolve `calculated_price`) and the offer's
+ * inventory-item link location levels (needed to resolve
+ * `inventory_quantity` per sales channel).
+ *
+ * `calculated_price` and `inventory_quantity` are NOT graph fields — they
+ * are computed post-query by the wrap helpers in `./helpers`. Consumers opt
+ * in by requesting them via `?fields=...`; the route strips them before the
+ * graph read.
+ */
+export const defaultStoreOfferFields = [
+  "id",
+  "seller_id",
+  "variant_id",
+  "product_id",
+  "shipping_profile_id",
+  "sku",
+  "ean",
+  "upc",
+  "metadata",
+  "created_at",
+  "updated_at",
+  "seller.id",
+  "seller.name",
+  "seller.handle",
+  "product_variant.id",
+  "product_variant.title",
+  "product_variant.sku",
+  "product_variant.price_set.id",
+  "shipping_profile.id",
+  "shipping_profile.name",
+  "prices.id",
+  "prices.amount",
+  "prices.currency_code",
+  "prices.min_quantity",
+  "prices.max_quantity",
+  "inventory_item_link.id",
+  "inventory_item_link.required_quantity",
+  "inventory_item_link.inventory_item_id",
+  "inventory_item_link.inventory_item.id",
+  "inventory_item_link.inventory_item.sku",
+  "inventory_item_link.inventory_item.location_levels.id",
+  "inventory_item_link.inventory_item.location_levels.location_id",
+  "inventory_item_link.inventory_item.location_levels.stocked_quantity",
+]
+
+export const storeOfferQueryConfig = {
+  list: {
+    defaults: defaultStoreOfferFields,
+    defaultLimit: 50,
+    isList: true,
+  },
+  retrieve: {
+    defaults: defaultStoreOfferFields,
+    isList: false,
+  },
+}

--- a/packages/core/src/api/store/offers/route.ts
+++ b/packages/core/src/api/store/offers/route.ts
@@ -1,0 +1,49 @@
+import {
+  MedusaResponse,
+  MedusaStoreRequest,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  splitComputedOfferFields,
+  wrapOffersWithCalculatedPrices,
+  wrapOffersWithInventoryQuantityForSalesChannel,
+  wrapOffersWithTaxPrices,
+} from "./helpers"
+import { StoreGetOffersParamsType } from "./validators"
+
+export const GET = async (
+  req: MedusaStoreRequest<StoreGetOffersParamsType>,
+  res: MedusaResponse
+) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { fields, withCalculatedPrice, withInventoryQuantity } =
+    splitComputedOfferFields(req.queryConfig.fields)
+
+  const { data: offers, metadata } = await query.graph({
+    entity: "offer",
+    fields: fields,
+    filters: req.filterableFields,
+    pagination: req.queryConfig.pagination,
+  })
+
+  if (withCalculatedPrice) {
+    await wrapOffersWithCalculatedPrices(
+      req,
+      offers
+    )
+    await wrapOffersWithTaxPrices(req, offers)
+  }
+
+  if (withInventoryQuantity) {
+    await wrapOffersWithInventoryQuantityForSalesChannel(req, offers)
+  }
+
+  res.json({
+    offers,
+    count: metadata?.count ?? 0,
+    offset: metadata?.skip ?? 0,
+    limit: metadata?.take ?? 0,
+  })
+}

--- a/packages/core/src/api/store/offers/validators.ts
+++ b/packages/core/src/api/store/offers/validators.ts
@@ -1,0 +1,43 @@
+import { z } from "zod"
+import {
+  createFindParams,
+  createOperatorMap,
+  createSelectParams,
+} from "@medusajs/medusa/api/utils/validators"
+
+/**
+ * Pricing/tax context fields, mirroring Medusa's
+ * `store/product-variants` validators. They drive `req.pricingContext` /
+ * `req.taxContext` (via the reused Medusa pricing middlewares) and are
+ * stripped before the offer graph read — the `offer` entity has none of
+ * these columns.
+ */
+const StoreOfferContextFields = z.object({
+  region_id: z.string().optional(),
+  country_code: z.string().optional(),
+  province: z.string().optional(),
+  cart_id: z.string().optional(),
+})
+
+const StoreOfferFilterFields = z.object({
+  q: z.string().optional(),
+  id: z.union([z.string(), z.array(z.string())]).optional(),
+  product_id: z.union([z.string(), z.array(z.string())]).optional(),
+  variant_id: z.union([z.string(), z.array(z.string())]).optional(),
+  seller_id: z.union([z.string(), z.array(z.string())]).optional(),
+  sku: z.union([z.string(), z.array(z.string())]).optional(),
+  created_at: createOperatorMap().optional(),
+  updated_at: createOperatorMap().optional(),
+})
+
+export type StoreGetOfferParamsType = z.infer<typeof StoreGetOfferParams>
+export const StoreGetOfferParams =
+  createSelectParams().merge(StoreOfferContextFields)
+
+export type StoreGetOffersParamsType = z.infer<typeof StoreGetOffersParams>
+export const StoreGetOffersParams = createFindParams({
+  offset: 0,
+  limit: 50,
+})
+  .merge(StoreOfferContextFields)
+  .merge(StoreOfferFilterFields)

--- a/packages/core/src/api/store/offers/validators.ts
+++ b/packages/core/src/api/store/offers/validators.ts
@@ -5,13 +5,6 @@ import {
   createSelectParams,
 } from "@medusajs/medusa/api/utils/validators"
 
-/**
- * Pricing/tax context fields, mirroring Medusa's
- * `store/product-variants` validators. They drive `req.pricingContext` /
- * `req.taxContext` (via the reused Medusa pricing middlewares) and are
- * stripped before the offer graph read — the `offer` entity has none of
- * these columns.
- */
 const StoreOfferContextFields = z.object({
   region_id: z.string().optional(),
   country_code: z.string().optional(),

--- a/packages/core/src/api/store/products/middlewares.ts
+++ b/packages/core/src/api/store/products/middlewares.ts
@@ -6,7 +6,7 @@ import {
   MedusaResponse,
   MiddlewareRoute,
 } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, isPresent } from "@medusajs/framework/utils"
+import { isPresent } from "@medusajs/framework/utils"
 import { validateAndTransformQuery } from "@medusajs/framework"
 
 import { storeProductQueryConfig } from "./query-config"
@@ -14,7 +14,8 @@ import {
   StoreGetProductParams,
   StoreGetProductsParams,
 } from "./validators"
-import { SellerStatus, ProductStatus } from "@mercurjs/types"
+import { ProductStatus } from "@mercurjs/types"
+import { resolveVisibleSellerIds } from "../../utils/sellers"
 
 /**
  * Apply the store-facing defaults that vanilla Medusa applies on its own
@@ -49,25 +50,8 @@ async function applyVisibleSellerIdsFilter(
   _res: MedusaResponse,
   next: MedusaNextFunction
 ) {
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-  const now = new Date()
-
-  const { data: visibleSellers } = await query.graph({
-    entity: "seller",
-    fields: ["id"],
-    filters: {
-      status: SellerStatus.OPEN,
-      $and: [
-        { $or: [{ closed_from: null }, { closed_from: { $gt: now } }] },
-        { $or: [{ closed_to: null }, { closed_to: { $lt: now } }] },
-      ],
-    },
-  })
-
   req.filterableFields ??= {}
-  req.filterableFields.seller_id = visibleSellers.map(
-    (s: { id: string }) => s.id
-  )
+  req.filterableFields.seller_id = await resolveVisibleSellerIds(req.scope)
 
   next()
 }

--- a/packages/core/src/api/utils/sellers.ts
+++ b/packages/core/src/api/utils/sellers.ts
@@ -1,0 +1,29 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { SellerStatus } from "@mercurjs/types"
+
+/**
+ * Resolve the ids of sellers that are currently visible to the storefront:
+ * status `OPEN` and not inside an active closure window. Shared by the store
+ * product and offer surfaces so both apply the exact same visibility rule.
+ */
+export const resolveVisibleSellerIds = async (
+  scope: MedusaContainer
+): Promise<string[]> => {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const now = new Date()
+
+  const { data: visibleSellers } = await query.graph({
+    entity: "seller",
+    fields: ["id"],
+    filters: {
+      status: SellerStatus.OPEN,
+      $and: [
+        { $or: [{ closed_from: null }, { closed_from: { $gt: now } }] },
+        { $or: [{ closed_to: null }, { closed_to: { $lt: now } }] },
+      ],
+    },
+  })
+
+  return visibleSellers.map((s: { id: string }) => s.id)
+}

--- a/packages/core/src/api/utils/sellers.ts
+++ b/packages/core/src/api/utils/sellers.ts
@@ -2,11 +2,6 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
 import { SellerStatus } from "@mercurjs/types"
 
-/**
- * Resolve the ids of sellers that are currently visible to the storefront:
- * status `OPEN` and not inside an active closure window. Shared by the store
- * product and offer surfaces so both apply the exact same visibility rule.
- */
 export const resolveVisibleSellerIds = async (
   scope: MedusaContainer
 ): Promise<string[]> => {

--- a/packages/core/src/api/vendor/offers/query-config.ts
+++ b/packages/core/src/api/vendor/offers/query-config.ts
@@ -2,6 +2,7 @@ export const defaultVendorOfferFields = [
   "id",
   "seller_id",
   "variant_id",
+  "product_id",
   "shipping_profile_id",
   "sku",
   "ean",

--- a/packages/core/src/links/offer-product-link.ts
+++ b/packages/core/src/links/offer-product-link.ts
@@ -1,0 +1,14 @@
+import { defineLink } from "@medusajs/framework/utils"
+import ProductModule from "@medusajs/medusa/product"
+import OfferModule from "../modules/offer"
+
+export default defineLink(
+  {
+    linkable: OfferModule.linkable.offer,
+    field: "product_id",
+  },
+  ProductModule.linkable.product,
+  {
+    readOnly: true,
+  }
+)

--- a/packages/core/src/modules/offer/migrations/Migration20260622000000.ts
+++ b/packages/core/src/modules/offer/migrations/Migration20260622000000.ts
@@ -2,10 +2,6 @@ import { Migration } from "@medusajs/framework/mikro-orm/migrations"
 
 export class Migration20260622000000 extends Migration {
   override async up(): Promise<void> {
-    // Module migrations are schema-isolated and run in no guaranteed
-    // cross-module order, so a variant→product backfill can't live here
-    // (it would reference the product module's `product_variant` table).
-    // New offers always set `product_id` in `createOffersWorkflow`.
     this.addSql(
       `ALTER TABLE "offer" ADD COLUMN IF NOT EXISTS "product_id" text NOT NULL DEFAULT '';`,
     )

--- a/packages/core/src/modules/offer/migrations/Migration20260622000000.ts
+++ b/packages/core/src/modules/offer/migrations/Migration20260622000000.ts
@@ -1,0 +1,23 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations"
+
+export class Migration20260622000000 extends Migration {
+  override async up(): Promise<void> {
+    // Module migrations are schema-isolated and run in no guaranteed
+    // cross-module order, so a variant→product backfill can't live here
+    // (it would reference the product module's `product_variant` table).
+    // New offers always set `product_id` in `createOffersWorkflow`.
+    this.addSql(
+      `ALTER TABLE "offer" ADD COLUMN IF NOT EXISTS "product_id" text NOT NULL DEFAULT '';`,
+    )
+    this.addSql(
+      `CREATE INDEX IF NOT EXISTS "IDX_offer_product_id" ON "offer" ("product_id") WHERE deleted_at IS NULL;`,
+    )
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`DROP INDEX IF EXISTS "IDX_offer_product_id";`)
+    this.addSql(
+      `ALTER TABLE "offer" DROP COLUMN IF EXISTS "product_id";`,
+    )
+  }
+}

--- a/packages/core/src/modules/offer/models/offer.ts
+++ b/packages/core/src/modules/offer/models/offer.ts
@@ -5,6 +5,7 @@ const Offer = model
     id: model.id({ prefix: "offer" }).primaryKey(),
     seller_id: model.text(),
     variant_id: model.text(),
+    product_id: model.text(),
     shipping_profile_id: model.text(),
     sku: model.text().searchable(),
     ean: model.text().searchable().nullable(),
@@ -22,6 +23,11 @@ const Offer = model
     {
       name: "IDX_offer_variant_id",
       on: ["variant_id"],
+      where: "deleted_at IS NULL",
+    },
+    {
+      name: "IDX_offer_product_id",
+      on: ["product_id"],
       where: "deleted_at IS NULL",
     },
     {

--- a/packages/core/src/workflows/offer/workflows/create-offers.ts
+++ b/packages/core/src/workflows/offer/workflows/create-offers.ts
@@ -120,7 +120,7 @@ export const createOffersWorkflow: ReturnWorkflow<
 
     const { data: variants } = useQueryGraphStep({
       entity: "product_variant",
-      fields: ["id", "ean", "upc", "price_set.id"],
+      fields: ["id", "ean", "upc", "price_set.id", "product.id"],
       filters: { id: variantIds },
     }).config({ name: "get-variants" })
 
@@ -143,6 +143,7 @@ export const createOffersWorkflow: ReturnWorkflow<
           return {
             seller_id: offer.seller_id,
             variant_id: offer.variant_id,
+            product_id: variant.product?.id,
             shipping_profile_id: offer.shipping_profile_id,
             sku: offer.sku,
             ean: offer.ean ?? variant.ean ?? null,

--- a/packages/types/src/offer/common.ts
+++ b/packages/types/src/offer/common.ts
@@ -45,6 +45,7 @@ export interface OfferDTO {
   id: string
   seller_id: string
   variant_id: string
+  product_id: string
   shipping_profile_id: string
   sku: string
   ean: string | null

--- a/packages/types/src/offer/mutations.ts
+++ b/packages/types/src/offer/mutations.ts
@@ -79,6 +79,7 @@ export interface CreateOfferDTO {
 export interface CreateOfferRowDTO {
   seller_id: string
   variant_id: string
+  product_id: string
   shipping_profile_id: string
   sku: string
   ean: string | null


### PR DESCRIPTION
## Summary

Fixes #972. On 2.2 the storefront checkout contract was **unsatisfiable with public endpoints**: `POST /store/carts/:id/line-items` requires an `offer_id`, but no Store API exposed offers — `GET /store/products` returns variants without offers and every offer route lived under `/vendor/*` (seller-scoped auth). A storefront had no way to discover which `offer_id` to add to the cart.

This adds a public read surface for offers plus a first-class `product_id` on the Offer.

## What's included

**`GET /store/offers` (+ `/store/offers/:id`)** — modeled on Medusa's `/store/product-variants`:
- Filter by `product_id`, `variant_id`, `id`, `seller_id`, `sku`.
- Opt-in `calculated_price` via region/currency pricing context (reuses Medusa's `normalizeDataForContext` / `setPricingContext` / `setTaxContext` middlewares).
- Opt-in `inventory_quantity` + `in_stock`, scoped to the publishable key's sales channel.
- Only surfaces offers from **OPEN** sellers on **published** products.

Because offers don't own a price set (they share the variant's, discriminated by an `offer_id` price rule), `calculated_price` is computed post-query via `pricingModule.calculatePrices(..., { context: { ...pricingContext, offer_id } })`, structured as Medusa-style `wrapOffersWith*` helpers mirroring `store/product-variants/helpers.ts`.

**`product_id` on the Offer model** — derived from the variant's product in `createOffersWorkflow`, with an `offer ↔ product` link, so product filtering is a direct column lookup. (The module migration only adds the column; cross-module backfill SQL can't run in a schema-isolated module migration. New offers always set it.)

## Testing

- New suite `integration-tests/http/offer/store/store-offers.spec.ts` — 9 tests: calculated_price, `variant_id` filter, sibling offers from two sellers, non-open seller excluded, draft product excluded, inventory math, sales-channel scoping, retrieve + 404.
- Extended the vendor offer spec to assert `product_id`.
- Full offer suite: **44 passed**, 0 failures (1 unrelated suite remains the deferred SPEC-007 skip).
- `bun run build` green across all packages (route map regenerated).

## API

```
GET /store/offers?product_id=prod_123&fields=+calculated_price&region_id=reg_123
GET /store/offers?variant_id=variant_123&fields=+inventory_quantity
GET /store/offers/offer_123?fields=+calculated_price&region_id=reg_123
```