### PR TITLE
feat(store): return cheapest offer price per product variant

### DIFF
--- a/integration-tests/http/product/store/offer-product-price.spec.ts
+++ b/integration-tests/http/product/store/offer-product-price.spec.ts
@@ -1,0 +1,304 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+    IRegionModuleService,
+    ISalesChannelModuleService,
+    MedusaContainer,
+} from "@medusajs/framework/types"
+import {
+    ContainerRegistrationKeys,
+    Modules,
+} from "@medusajs/framework/utils"
+import { MercurModules, SellerStatus } from "@mercurjs/types"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+import {
+    generatePublishableKey,
+    generateStoreHeaders,
+} from "../../../helpers/create-admin-user"
+
+const approveSeller = async (container: MedusaContainer, sellerId: string) => {
+    const sellerModule: any = container.resolve(MercurModules.SELLER)
+    await sellerModule.updateSellers({
+        id: sellerId,
+        status: SellerStatus.OPEN,
+    })
+}
+
+jest.setTimeout(120000)
+
+medusaIntegrationTestRunner({
+    testSuite: ({ getContainer, api }) => {
+        describe("Store - Products cheapest offer price", () => {
+            let appContainer: MedusaContainer
+            let storeHeaders: any
+            let region: any
+            let salesChannel: any
+
+            let seedCounter = 0
+            const seedSellerOffer = async (opts: {
+                email: string
+                name: string
+                offerPrice: number
+                productId?: string
+                variantId?: string
+            }) => {
+                const tag = `s${++seedCounter}${Date.now()}`
+                const result = await createSellerUser(appContainer, {
+                    email: opts.email,
+                    name: opts.name,
+                })
+                await approveSeller(appContainer, (result.seller as any).id)
+                const headers = result.headers
+
+                const stockLocation = (
+                    await api.post(
+                        `/vendor/stock-locations`,
+                        { name: `${opts.name} WH ${tag}` },
+                        headers
+                    )
+                ).data.stock_location
+
+                await api.post(
+                    `/vendor/stock-locations/${stockLocation.id}/sales-channels`,
+                    { add: [salesChannel.id] },
+                    headers
+                )
+
+                let productId = opts.productId
+                let variantId = opts.variantId
+                if (!productId || !variantId) {
+                    const product = (
+                        await api.post(
+                            `/vendor/products`,
+                            {
+                                status: "published",
+                                title: `${opts.name} Product ${tag}`,
+                                variant_attributes: [
+                                    {
+                                        name: `Default ${tag}`,
+                                        type: "multi_select",
+                                        values: ["Default"],
+                                        is_variant_axis: true,
+                                    },
+                                ],
+                                variants: [
+                                    {
+                                        title: "Default",
+                                        sku: `${opts.email}-V-SKU-${tag}`,
+                                        attribute_values: {
+                                            [`Default ${tag}`]: "Default",
+                                        },
+                                    },
+                                ],
+                            },
+                            headers
+                        )
+                    ).data.product
+
+                    await api.post(
+                        `/vendor/sales-channels/${salesChannel.id}/products`,
+                        { add: [product.id] },
+                        headers
+                    )
+
+                    productId = product.id
+                    variantId = product.variants[0].id
+                }
+
+                const shippingProfile = (
+                    await api.post(
+                        `/vendor/shipping-profiles`,
+                        { name: `${opts.name} Profile ${tag}`, type: "default" },
+                        headers
+                    )
+                ).data.shipping_profile
+
+                const offer = (
+                    await api.post(
+                        `/vendor/offers`,
+                        {
+                            sku: `${opts.name.replace(/\s/g, "")}-OFFER-${tag}`,
+                            variant_id: variantId,
+                            shipping_profile_id: shippingProfile.id,
+                            inventory_items: [
+                                {
+                                    title: `${opts.name} Inv ${tag}`,
+                                    required_quantity: 1,
+                                    stock_levels: [
+                                        {
+                                            location_id: stockLocation.id,
+                                            stocked_quantity: 10,
+                                        },
+                                    ],
+                                },
+                            ],
+                            prices: [
+                                { amount: opts.offerPrice, currency_code: "usd" },
+                            ],
+                        },
+                        headers
+                    )
+                ).data.offer
+
+                return {
+                    headers,
+                    sellerId: result.seller.id as string,
+                    productId: productId as string,
+                    variantId: variantId as string,
+                    offer,
+                }
+            }
+
+            beforeAll(async () => {
+                appContainer = getContainer()
+            })
+
+            beforeEach(async () => {
+                const salesChannelModule =
+                    appContainer.resolve<ISalesChannelModuleService>(
+                        Modules.SALES_CHANNEL
+                    )
+                salesChannel = await salesChannelModule.createSalesChannels({
+                    name: "Default Store",
+                })
+
+                const regionModule = appContainer.resolve<IRegionModuleService>(
+                    Modules.REGION
+                )
+                region = await regionModule.createRegions({
+                    name: "Test Region",
+                    currency_code: "usd",
+                    countries: ["us"],
+                })
+
+                const apiKey = await generatePublishableKey(appContainer)
+                storeHeaders = generateStoreHeaders({ publishableKey: apiKey })
+
+                const link = appContainer.resolve(ContainerRegistrationKeys.LINK)
+                await link.create({
+                    [Modules.API_KEY]: { publishable_key_id: apiKey.id },
+                    [Modules.SALES_CHANNEL]: {
+                        sales_channel_id: salesChannel.id,
+                    },
+                })
+            })
+
+            describe("GET /store/products", () => {
+                it("returns the cheapest offer_id and its calculated_price per variant", async () => {
+                    const expensive = await seedSellerOffer({
+                        email: "expensive-prod@test.com",
+                        name: "Expensive",
+                        offerPrice: 5000,
+                    })
+                    const cheap = await seedSellerOffer({
+                        email: "cheap-prod@test.com",
+                        name: "Cheap",
+                        offerPrice: 2000,
+                        productId: expensive.productId,
+                        variantId: expensive.variantId,
+                    })
+
+                    const response = await api.get(
+                        `/store/products?id[]=${expensive.productId}&region_id=${region.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.products).toHaveLength(1)
+                    const variant = response.data.products[0].variants[0]
+                    expect(variant.offer_id).toEqual(cheap.offer.id)
+                    expect(variant.calculated_price.calculated_amount).toEqual(
+                        2000
+                    )
+                    expect(variant.calculated_price.currency_code).toEqual("usd")
+                })
+
+                it("does not compute prices without region_id or an explicit field", async () => {
+                    const seed = await seedSellerOffer({
+                        email: "nogate-prod@test.com",
+                        name: "NoGate",
+                        offerPrice: 1500,
+                    })
+
+                    const response = await api.get(
+                        `/store/products?id[]=${seed.productId}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    const variant = response.data.products[0].variants[0]
+                    expect(variant.offer_id).toBeUndefined()
+                    expect(variant.calculated_price).toBeUndefined()
+                })
+
+                it("prices variants from different products in a single calculatePrices call", async () => {
+                    const seedA = await seedSellerOffer({
+                        email: "batch-prod-a@test.com",
+                        name: "BatchA",
+                        offerPrice: 1000,
+                    })
+                    const seedB = await seedSellerOffer({
+                        email: "batch-prod-b@test.com",
+                        name: "BatchB",
+                        offerPrice: 2000,
+                    })
+
+                    const pricingModule = appContainer.resolve(
+                        Modules.PRICING
+                    ) as any
+                    const spy = jest.spyOn(pricingModule, "calculatePrices")
+                    spy.mockClear()
+
+                    const response = await api.get(
+                        `/store/products?id[]=${seedA.productId}&id[]=${seedB.productId}&region_id=${region.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    expect(response.data.products).toHaveLength(2)
+                    expect(spy).toHaveBeenCalledTimes(1)
+
+                    const byProduct = new Map<string, any>(
+                        response.data.products.map((p: any) => [p.id, p])
+                    )
+                    expect(
+                        byProduct.get(seedA.productId).variants[0].offer_id
+                    ).toEqual(seedA.offer.id)
+                    expect(
+                        byProduct.get(seedB.productId).variants[0].offer_id
+                    ).toEqual(seedB.offer.id)
+
+                    spy.mockRestore()
+                })
+            })
+
+            describe("GET /store/products/:id", () => {
+                it("returns the cheapest offer_id and calculated_price on the detail route", async () => {
+                    const expensive = await seedSellerOffer({
+                        email: "detail-expensive@test.com",
+                        name: "DetailExpensive",
+                        offerPrice: 4000,
+                    })
+                    const cheap = await seedSellerOffer({
+                        email: "detail-cheap@test.com",
+                        name: "DetailCheap",
+                        offerPrice: 1500,
+                        productId: expensive.productId,
+                        variantId: expensive.variantId,
+                    })
+
+                    const response = await api.get(
+                        `/store/products/${expensive.productId}?region_id=${region.id}`,
+                        storeHeaders
+                    )
+
+                    expect(response.status).toEqual(200)
+                    const variant = response.data.product.variants[0]
+                    expect(variant.offer_id).toEqual(cheap.offer.id)
+                    expect(variant.calculated_price.calculated_amount).toEqual(
+                        1500
+                    )
+                })
+            })
+        })
+    },
+})

--- a/packages/core/src/api/store/products/[id]/route.ts
+++ b/packages/core/src/api/store/products/[id]/route.ts
@@ -7,7 +7,11 @@ import {
   MedusaError,
 } from "@medusajs/framework/utils"
 
-import { enrichProductAttributes } from "../../../utils"
+import {
+  enrichProductAttributes,
+  wrapProductVariantsWithOfferPrice,
+} from "../../../utils"
+import { splitComputedVariantFields } from "../helpers"
 
 export const GET = async (req: MedusaStoreRequest, res: MedusaResponse) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
@@ -23,6 +27,13 @@ export const GET = async (req: MedusaStoreRequest, res: MedusaResponse) => {
       `Product with id ${req.params.id} was not found`,
     )
   }
+
+  // `variants.calculated_price` / `variants.offer_id` are computed from the
+  // cheapest offer post-query, not graph columns — strip them before the read.
+  const { fields, withCalculatedPrice } = splitComputedVariantFields(
+    req.queryConfig.fields
+  )
+  req.queryConfig.fields = fields
 
   // region_id / currency_code are consumed by setPricingContext only —
   // the Product entity has neither column, so passing them through
@@ -49,6 +60,10 @@ export const GET = async (req: MedusaStoreRequest, res: MedusaResponse) => {
   }
 
   await enrichProductAttributes(req.scope, [product])
+
+  if (withCalculatedPrice) {
+    await wrapProductVariantsWithOfferPrice(req, [product] as any[])
+  }
 
   res.json({ product })
 }

--- a/packages/core/src/api/store/products/helpers.ts
+++ b/packages/core/src/api/store/products/helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * Splits the virtual offer-pricing fields (`variants.calculated_price[.*]`,
+ * `variants.offer_id`) out of a store-product field set. They are computed
+ * post-query from the cheapest offer, not graph columns, so passing them to
+ * `query.graph` raises `Trying to query by not existing property`.
+ */
+export const splitComputedVariantFields = (fields: string[]) => {
+  const withCalculatedPrice = fields.some(
+    (f) =>
+      f === "variants.calculated_price" ||
+      f.startsWith("variants.calculated_price.") ||
+      f === "variants.offer_id"
+  )
+
+  const filteredFields = fields.filter(
+    (f) =>
+      f !== "variants.calculated_price" &&
+      !f.startsWith("variants.calculated_price.") &&
+      f !== "variants.offer_id"
+  )
+
+  return { fields: filteredFields, withCalculatedPrice }
+}

--- a/packages/core/src/api/store/products/middlewares.ts
+++ b/packages/core/src/api/store/products/middlewares.ts
@@ -1,5 +1,6 @@
 import {
   applyDefaultFilters,
+  authenticate,
   maybeApplyLinkFilter,
   MedusaNextFunction,
   MedusaRequest,
@@ -8,6 +9,11 @@ import {
 } from "@medusajs/framework/http"
 import { isPresent } from "@medusajs/framework/utils"
 import { validateAndTransformQuery } from "@medusajs/framework"
+import {
+  normalizeDataForContext,
+  setPricingContext,
+  setTaxContext,
+} from "@medusajs/medusa/api/utils/middlewares/index"
 
 import { storeProductQueryConfig } from "./query-config"
 import {
@@ -56,6 +62,21 @@ async function applyVisibleSellerIdsFilter(
   next()
 }
 
+/**
+ * Resolve the pricing/tax context consumed by the offer-price wrap. Reuses
+ * Medusa's product-pricing middlewares so the gate matches vanilla
+ * `/store/products`: prices compute only when the client requests
+ * `variants.calculated_price` or passes `region_id`.
+ */
+const pricingMiddlewares = [
+  authenticate("customer", ["session", "bearer"], {
+    allowUnauthenticated: true,
+  }),
+  normalizeDataForContext({ priceFieldPaths: ["variants.calculated_price"] }),
+  setPricingContext({ priceFieldPaths: ["variants.calculated_price"] }),
+  setTaxContext({ priceFieldPaths: ["variants.calculated_price"] }),
+]
+
 export const storeProductsMiddlewares: MiddlewareRoute[] = [
   {
     method: ["GET"],
@@ -72,6 +93,7 @@ export const storeProductsMiddlewares: MiddlewareRoute[] = [
         resourceId: "product_id",
         filterableField: "seller_id",
       }),
+      ...pricingMiddlewares,
     ],
   },
   {
@@ -89,6 +111,7 @@ export const storeProductsMiddlewares: MiddlewareRoute[] = [
         resourceId: "product_id",
         filterableField: "seller_id",
       }),
+      ...pricingMiddlewares,
     ],
   },
 ]

--- a/packages/core/src/api/store/products/route.ts
+++ b/packages/core/src/api/store/products/route.ts
@@ -4,10 +4,21 @@ import {
 } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
-import { enrichProductAttributes } from "../../utils"
+import {
+  enrichProductAttributes,
+  wrapProductVariantsWithOfferPrice,
+} from "../../utils"
+import { splitComputedVariantFields } from "./helpers"
 
 export const GET = async (req: MedusaStoreRequest, res: MedusaResponse) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // `variants.calculated_price` / `variants.offer_id` are computed from the
+  // cheapest offer post-query, not graph columns — strip them before the read.
+  const { fields, withCalculatedPrice } = splitComputedVariantFields(
+    req.queryConfig.fields
+  )
+  req.queryConfig.fields = fields
 
   // region_id / currency_code are consumed by setPricingContext only.
   // The Product entity has neither column, so passing them through to
@@ -27,6 +38,10 @@ export const GET = async (req: MedusaStoreRequest, res: MedusaResponse) => {
   })
 
   await enrichProductAttributes(req.scope, products as any[])
+
+  if (withCalculatedPrice) {
+    await wrapProductVariantsWithOfferPrice(req, products as any[])
+  }
 
   res.json({
     products,

--- a/packages/core/src/api/utils/offers.ts
+++ b/packages/core/src/api/utils/offers.ts
@@ -2,9 +2,20 @@ import {
   AuthenticatedMedusaRequest,
   MedusaNextFunction,
   MedusaResponse,
+  MedusaStoreRequest,
 } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
-import type { MedusaContainer } from "@medusajs/framework/types"
+import {
+  calculateAmountsWithTax,
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import type {
+  ItemTaxLineDTO,
+  MedusaContainer,
+  MedusaPricingContext,
+  TaxableItemDTO,
+  TaxCalculationContext,
+} from "@medusajs/framework/types"
 
 /**
  * Field set pulled for each offer attached by
@@ -170,4 +181,210 @@ export const applyOfferedProductsFilter = async (
   ]
 
   return next()
+}
+
+type StoreRequestWithContext = MedusaStoreRequest<unknown> & {
+  pricingContext?: MedusaPricingContext
+  taxContext?: {
+    taxLineContext?: TaxCalculationContext
+    taxInclusivityContext?: { automaticTaxes: boolean }
+  }
+}
+
+type OfferPriceRow = {
+  id: string
+  variant_id: string
+  product_variant?: { price_set?: { id?: string } | null } | null
+  prices?: { id?: string }[] | null
+}
+
+type PriceableVariant = {
+  id: string
+  offer_id?: string | null
+  calculated_price?: Record<string, unknown> | null
+}
+
+type PriceableProduct = {
+  id?: string
+  variants?: PriceableVariant[] | null
+}
+
+/**
+ * Sets each variant's cheapest offer as `variant.offer_id` + its
+ * `variant.calculated_price`, in place. Offer prices share the variant price
+ * set scoped by an `offer_id` rule, so passing the union of offer ids as the
+ * pricing context lets one batched `calculatePrices` return the lowest matching
+ * price per price set; `offer_id` is recovered from the winning price row via a
+ * `price.id → offer.id` map. Variants without an offer get `null` for both.
+ * No-ops without a pricing context (caller did not request calculated prices).
+ */
+export const wrapProductVariantsWithOfferPrice = async (
+  req: StoreRequestWithContext,
+  products: PriceableProduct[]
+): Promise<void> => {
+  if (!req.pricingContext) {
+    return
+  }
+
+  const variantIds = Array.from(
+    new Set(products.flatMap((p) => (p.variants ?? []).map((v) => v.id)))
+  )
+  if (!variantIds.length) {
+    return
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: offers } = await query.graph({
+    entity: "offer",
+    fields: ["id", "variant_id", "product_variant.price_set.id", "prices.id"],
+    filters: { variant_id: variantIds },
+  })
+  if (!offers.length) {
+    return
+  }
+
+  const priceSetToVariant = new Map<string, string>()
+  const priceIdToOffer = new Map<string, string>()
+  const offerIds: string[] = []
+  const priceSetIds = new Set<string>()
+  for (const offer of offers as OfferPriceRow[]) {
+    const priceSetId = offer.product_variant?.price_set?.id
+    if (!priceSetId) {
+      continue
+    }
+    priceSetIds.add(priceSetId)
+    priceSetToVariant.set(priceSetId, offer.variant_id)
+    offerIds.push(offer.id)
+    for (const price of offer.prices ?? []) {
+      if (price?.id) {
+        priceIdToOffer.set(price.id, offer.id)
+      }
+    }
+  }
+  if (!priceSetIds.size) {
+    return
+  }
+
+  const context: Record<string, unknown> = {
+    ...(req.pricingContext as Record<string, unknown>),
+    offer_id: offerIds,
+  }
+  const pricingModule = req.scope.resolve(Modules.PRICING)
+  const calculated = await pricingModule.calculatePrices(
+    { id: Array.from(priceSetIds) },
+    { context: context as Record<string, string | number> }
+  )
+
+  const byVariant = new Map<
+    string,
+    { offerId: string | null; price: Record<string, unknown> }
+  >()
+  for (const calc of calculated) {
+    const variantId = priceSetToVariant.get(calc.id)
+    if (!variantId) {
+      continue
+    }
+    const winningPriceId =
+      (calc as { calculated_price?: { id?: string | null } }).calculated_price
+        ?.id ?? null
+    byVariant.set(variantId, {
+      offerId: winningPriceId
+        ? priceIdToOffer.get(winningPriceId) ?? null
+        : null,
+      price: calc as unknown as Record<string, unknown>,
+    })
+  }
+
+  for (const product of products) {
+    for (const variant of product.variants ?? []) {
+      const hit = byVariant.get(variant.id)
+      variant.offer_id = hit?.offerId ?? null
+      variant.calculated_price = hit?.price ?? null
+    }
+  }
+
+  await wrapVariantsWithTaxPrices(req, products)
+}
+
+/**
+ * Adds tax-inclusive / tax-exclusive amounts onto each variant's
+ * `calculated_price`, gated on automatic taxes being enabled.
+ */
+const wrapVariantsWithTaxPrices = async (
+  req: StoreRequestWithContext,
+  products: PriceableProduct[]
+): Promise<void> => {
+  if (
+    !req.taxContext?.taxInclusivityContext ||
+    !req.taxContext?.taxLineContext ||
+    !req.taxContext.taxInclusivityContext.automaticTaxes
+  ) {
+    return
+  }
+
+  const items: TaxableItemDTO[] = []
+  for (const product of products) {
+    for (const variant of product.variants ?? []) {
+      const price = variant.calculated_price as
+        | Record<string, unknown>
+        | null
+        | undefined
+      if (!price || !product.id) {
+        continue
+      }
+      items.push({
+        id: variant.id,
+        product_id: product.id,
+        quantity: 1,
+        unit_price: price.calculated_amount as number,
+        currency_code: price.currency_code as string,
+      } as TaxableItemDTO)
+    }
+  }
+  if (!items.length) {
+    return
+  }
+
+  const taxService = req.scope.resolve(Modules.TAX)
+  const taxLines = (await taxService.getTaxLines(
+    items,
+    req.taxContext.taxLineContext
+  )) as unknown as ItemTaxLineDTO[]
+
+  const taxRatesMap = new Map<string, ItemTaxLineDTO[]>()
+  for (const taxLine of taxLines) {
+    const existing = taxRatesMap.get(taxLine.line_item_id) ?? []
+    existing.push(taxLine)
+    taxRatesMap.set(taxLine.line_item_id, existing)
+  }
+
+  for (const product of products) {
+    for (const variant of product.variants ?? []) {
+      const price = variant.calculated_price as Record<string, unknown> | null
+      if (!price) {
+        continue
+      }
+
+      const taxRatesForVariant = taxRatesMap.get(variant.id) || []
+
+      const { priceWithTax, priceWithoutTax } = calculateAmountsWithTax({
+        taxLines: taxRatesForVariant,
+        amount: price.calculated_amount as number,
+        includesTax: price.is_calculated_price_tax_inclusive as boolean,
+      })
+      price.calculated_amount_with_tax = priceWithTax
+      price.calculated_amount_without_tax = priceWithoutTax
+
+      const {
+        priceWithTax: originalPriceWithTax,
+        priceWithoutTax: originalPriceWithoutTax,
+      } = calculateAmountsWithTax({
+        taxLines: taxRatesForVariant,
+        amount: price.original_amount as number,
+        includesTax: price.is_original_price_tax_inclusive as boolean,
+      })
+      price.original_amount_with_tax = originalPriceWithTax
+      price.original_amount_without_tax = originalPriceWithoutTax
+    }
+  }
 }


### PR DESCRIPTION
## What

`GET /store/products` and `GET /store/products/:id` now expose, on each variant:

- `offer_id` — the id of the **cheapest** offer available for that variant (string, or `null` when the variant has no offers)
- `calculated_price` — the calculated price of that cheapest offer (incl. tax-inclusive/exclusive amounts when automatic taxes are enabled)

Closes #973 — https://github.com/mercurjs/mercur/issues/973

## How

In Mercur, variant prices live on **offers** (a shared variant price set scoped by an `offer_id` price rule), not on the variant's native price set — so the storefront product endpoint previously returned no prices at all.

- **Gating mirrors vanilla Medusa.** The route reuses Medusa's own `normalizeDataForContext` / `setPricingContext` / `setTaxContext` middlewares with `priceFieldPaths: ["variants.calculated_price"]`. Prices are computed only when the client requests `variants.calculated_price` **or** passes `region_id` (which auto-expands the calculated-price fields) — exactly like the default `/store/products`. `authenticate("customer", …, { allowUnauthenticated: true })` lets the pricing context pick up customer-group prices while keeping the endpoint public.
- **One batched pricing call.** `wrapProductVariantsWithOfferPrice` fetches the page's offers, then issues a single `calculatePrices` over the variants' price sets with `offer_id: [...all offer ids]` in the context. The pricing engine returns the lowest matching offer price per price set (`ORDER BY amount ASC`); a union `offer_id` array is safe because each offer's price rows belong to a single variant price set. The winning `offer_id` is recovered from the returned `calculated_price.id` via a `price.id → offer.id` map.
- Cheapest is selected across **all** offers on the variant (no seller-visibility filter).
- `splitComputedVariantFields` strips the virtual `variants.calculated_price` / `variants.offer_id` fields before the graph read (they aren't graph columns) and signals when to run the wrap.

## Why a post-query step (not pure `query.graph` context)

Medusa's native product pricing passes a single global `QueryContext` to `query.graph`. That context can't carry a different `offer_id` per variant row, and the relevant offer ids aren't known until after the product query — so the cheapest-offer price is computed in a post-query step against the same pricing engine.

## Tests

New `integration-tests/http/product/store/offer-product-price.spec.ts` (4 passing):
- cheapest `offer_id` + `calculated_price` per variant across two sellers on one variant (list route)
- no prices computed without `region_id` / explicit field (gate off)
- single batched `calculatePrices` call across multiple products
- cheapest offer on the `/:id` detail route

## Verification

- `bun run build` — passes (9/9)
- new integration suite — 4/4 passing
- `oxlint` on changed files — clean