### PR TITLE
fix: resolve lint and build errors

### DIFF
--- a/packages/admin/src/hooks/api/orders.tsx
+++ b/packages/admin/src/hooks/api/orders.tsx
@@ -14,6 +14,7 @@ import {
   UseMutationOptions,
   useQuery,
   UseQueryOptions,
+  UseQueryResult,
 } from "@tanstack/react-query";
 import { sdk } from "../../lib/client";
 import { queryClient } from "../../lib/query-client";
@@ -327,7 +328,9 @@ export const useOrderCommissionLines = (
     >,
     "queryFn" | "queryKey"
   >
-) => {
+): Omit<UseQueryResult<OrderCommissionLinesResponse, ClientError>, "data"> & {
+  commission_lines: OrderCommissionLine[];
+} => {
   const { data, ...rest } = useQuery({
     queryFn: async () =>
       sdk.admin.orders.$id.commissionLines.query({ $id: id }),

--- a/packages/core/src/api/admin/product-attributes/route.ts
+++ b/packages/core/src/api/admin/product-attributes/route.ts
@@ -7,10 +7,13 @@ import { AdditionalData } from "@medusajs/framework/types"
 import { HttpTypes } from "@mercurjs/types"
 
 import { createProductAttributesWorkflow } from "../../../workflows/product-attribute/workflows/create-product-attributes"
-import { AdminCreateProductAttributeType } from "./validators"
+import {
+  AdminCreateProductAttributeType,
+  AdminGetProductAttributesParamsType,
+} from "./validators"
 
 export const GET = async (
-  req: AuthenticatedMedusaRequest,
+  req: AuthenticatedMedusaRequest<AdminGetProductAttributesParamsType>,
   res: MedusaResponse<HttpTypes.AdminProductAttributeListResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)

--- a/packages/registry/src/messaging/admin/routes/messages/page.tsx
+++ b/packages/registry/src/messaging/admin/routes/messages/page.tsx
@@ -88,7 +88,7 @@ const AdminMessagesPage = () => {
     date_to: "",
   })
 
-  const { conversations, next_cursor, isLoading, isError, error } =
+  const { conversations, isLoading, isError, error } =
     useAdminConversations({ limit: 50, ...searchParams })
 
   useMessagingLayout()

--- a/packages/registry/src/messaging/api/admin/messages/filters/[id]/route.ts
+++ b/packages/registry/src/messaging/api/admin/messages/filters/[id]/route.ts
@@ -2,10 +2,7 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework"
-import { MedusaError } from "@medusajs/framework/utils"
 
-import { MESSAGING_FILTERS_MODULE } from "../../../../../modules/messaging-filters"
-import type MessagingFiltersModuleService from "../../../../../modules/messaging-filters/service"
 import { updateFilterRuleWorkflow } from "../../../../../workflows/messaging-filters/workflows/update-filter-rule"
 import { deleteFilterRuleWorkflow } from "../../../../../workflows/messaging-filters/workflows/delete-filter-rule"
 import { AdminUpdateFilterType } from "../validators"

--- a/packages/registry/src/messaging/api/vendor/messages/[id]/route.ts
+++ b/packages/registry/src/messaging/api/vendor/messages/[id]/route.ts
@@ -70,7 +70,7 @@ export const GET = async (
     // Only include orders that belong to this seller
     buyer_orders = (orders ?? [])
       .filter((o: any) => o.seller?.id === sellerId)
-      .map(({ seller, ...rest }: any) => rest)
+      .map(({ seller: _seller, ...rest }: any) => rest)
   } catch {
     // Continue without enrichment
   }

--- a/packages/registry/src/messaging/modules/messaging-filters/loaders/seed-builtin-rules.ts
+++ b/packages/registry/src/messaging/modules/messaging-filters/loaders/seed-builtin-rules.ts
@@ -32,7 +32,7 @@ export default async function seedBuiltinRules({
 
   for (const rule of BUILTIN_RULES) {
     try {
-      const [existing, count] = await service.listAndCount({
+      const [, count] = await service.listAndCount({
         pattern: rule.pattern,
         is_builtin: true,
       } as any, { take: 1 })

--- a/packages/registry/src/messaging/modules/messaging-redis/service.ts
+++ b/packages/registry/src/messaging/modules/messaging-redis/service.ts
@@ -13,7 +13,7 @@ class MessagingRedisModuleService {
 
   constructor(
     { messagingRedisConnection }: { messagingRedisConnection: Redis | null },
-    options: MessagingRedisModuleOptions
+    _options: MessagingRedisModuleOptions
   ) {
     this.connection_ = messagingRedisConnection
 

--- a/packages/registry/src/messaging/modules/messaging/service.ts
+++ b/packages/registry/src/messaging/modules/messaging/service.ts
@@ -1,6 +1,6 @@
 import { InjectManager, MedusaContext, MedusaService } from "@medusajs/framework/utils"
 import { Context } from "@medusajs/framework/types"
-import { EntityManager, type Knex } from "@medusajs/framework/mikro-orm/knex"
+import { EntityManager } from "@medusajs/framework/mikro-orm/knex"
 
 import { Conversation } from "./models/conversation"
 import { Message } from "./models/message"

--- a/packages/registry/src/messaging/vendor/routes/messages/[id]/page.tsx
+++ b/packages/registry/src/messaging/vendor/routes/messages/[id]/page.tsx
@@ -168,6 +168,7 @@ const VendorConversationDetailPage = () => {
     if (conversation && conversation.unread_count_seller > 0) {
       markRead.mutate()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversation?.id, conversation?.unread_count_seller])
 
   // Scroll to bottom when messages change

--- a/packages/registry/src/messaging/vendor/routes/messages/page.tsx
+++ b/packages/registry/src/messaging/vendor/routes/messages/page.tsx
@@ -42,6 +42,8 @@ const ConversationRow = ({
 
   return (
     <button
+      type="button"
+      aria-label="Open conversation"
       onClick={onClick}
       className={clx(
         "flex w-full items-center gap-3 px-6 py-3 text-left transition-colors hover:bg-ui-bg-base-hover",
@@ -95,7 +97,7 @@ const ConversationRow = ({
 const VendorMessagesPage = () => {
   useMessagingSSE()
   const navigate = useNavigate()
-  const { conversations, next_cursor, isLoading, isError, error } =
+  const { conversations, isLoading, isError, error } =
     useVendorConversations({ limit: 50 })
 
   useMessagingLayout()

--- a/packages/registry/src/messaging/workflows/messaging-filters/steps/invalidate-filter-cache.ts
+++ b/packages/registry/src/messaging/workflows/messaging-filters/steps/invalidate-filter-cache.ts
@@ -2,7 +2,7 @@ import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 
 import { MESSAGING_REDIS_MODULE } from "../../../modules/messaging-redis"
 import type MessagingRedisModuleService from "../../../modules/messaging-redis/service"
-import { invalidateRuleset, recompileFilters } from "../../../modules/messaging-filters/loaders/compile-filters"
+import { recompileFilters } from "../../../modules/messaging-filters/loaders/compile-filters"
 
 export const invalidateFilterCacheStep = createStep(
   "invalidate-filter-cache",

--- a/packages/vendor/src/hooks/api/orders.tsx
+++ b/packages/vendor/src/hooks/api/orders.tsx
@@ -7,6 +7,7 @@ import {
   UseMutationOptions,
   useQuery,
   UseQueryOptions,
+  UseQueryResult,
 } from "@tanstack/react-query";
 import { sdk, fetchQuery } from "../../lib/client";
 import { queryClient } from "../../lib/query-client";
@@ -327,7 +328,9 @@ export const useOrderCommissionLines = (
     >,
     "queryFn" | "queryKey"
   >
-) => {
+): Omit<UseQueryResult<OrderCommissionLinesResponse, ClientError>, "data"> & {
+  commission_lines: OrderCommissionLine[];
+} => {
   const { data, ...rest } = useQuery({
     queryFn: async () =>
       sdk.vendor.orders.$id.commissionLines.query({ $id: id }),


### PR DESCRIPTION
## Summary

Fixes outstanding `bun run lint` and `bun run build` failures so the pipeline is green.

### Lint (`bun run lint`)
All errors were in the `messaging` registry block:
- Removed unused imports/variables (`Knex`, `MedusaError`, `MESSAGING_FILTERS_MODULE`, `MessagingFiltersModuleService`, `invalidateRuleset`, `existing`, `next_cursor` ×2).
- Prefixed intentionally-unused params with `_` (`options`, `seller`).
- Added `type="button"` + `aria-label` to the conversation list button (a11y `control-has-associated-label`).
- Added an `eslint-disable-next-line react-hooks/exhaustive-deps` for the intentional mark-as-read effect.

### Build (`bun run build`)
- `useOrderCommissionLines` (admin + vendor) — added an explicit return-type annotation to fix TS2742 (inferred type could not be named without referencing the core route module).
- `product-attributes` admin `GET` route — typed the request with `AdminGetProductAttributesParamsType` so codegen emits the pagination query params, fixing `attribute-list/loader.ts` (`limit`/`offset` not assignable). These build errors were pre-existing on `canary`, masked by the Turbo build cache.

## Verification
- `bun run lint` — clean
- `bun run build` — all 9 packages successful