### PR TITLE
fix(admin): correct empty attribute values error message

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3117,7 +3117,7 @@
         "type": "Type"
       },
       "fillNameWarning": "Please fill in at least the name field before proceeding to Type configuration.",
-      "possibleValuesRequired": "At least one possible value is required for this type",
+      "possibleValuesRequired": "Please add at least one value",
       "categoriesRequired": "Please select at least one category, or enable the global attribute switch.",
       "successToast": "Attribute \"{{name}}\" was successfully created."
     },

--- a/packages/admin/src/i18n/translations/pl.json
+++ b/packages/admin/src/i18n/translations/pl.json
@@ -3067,7 +3067,7 @@
         "type": "Typ"
       },
       "fillNameWarning": "Wypełnij przynajmniej pole nazwy przed przejściem do konfiguracji typu.",
-      "possibleValuesRequired": "Dla tego typu wymagana jest co najmniej jedna możliwa wartość",
+      "possibleValuesRequired": "Dodaj co najmniej jedną wartość",
       "successToast": "Atrybut \"{{name}}\" został pomyślnie utworzony."
     },
     "edit": {


### PR DESCRIPTION
## Summary
- Updates the create-attribute step 2 validation copy: when no possible values are entered, the error now reads **"Please add at least one value"** (previously "At least one possible value is required for this type").
- Polish translation updated to match.

## Linear
[MER-114](https://linear.app/rigbyjs/issue/MER-114) (addresses comment #3 only)

## Test plan
- [x] `bun run lint`
- [x] `bun run build` (admin package built clean — ESM + DTS)
- [ ] In admin, create a single/multi-select attribute and continue step 2 with no values → error message reads "Please add at least one value"