### PR TITLE
fix(admin): add missing yes/no translations for attribute details

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -13596,6 +13596,12 @@
     "fields": {
       "type": "object",
       "properties": {
+        "yes": {
+          "type": "string"
+        },
+        "no": {
+          "type": "string"
+        },
         "amount": {
           "type": "string"
         },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3461,6 +3461,8 @@
     "selectValues": "Select Values"
   },
   "fields": {
+    "yes": "Yes",
+    "no": "No",
     "amount": "Amount",
     "reference": "Reference",
     "reference_id": "Reference ID",


### PR DESCRIPTION
## Summary
- The attribute general section renders `is_filterable` and `is_required` via `t("fields.yes")`/`t("fields.no")`, but those keys were never defined — so the raw translation keys leaked into the UI instead of "Yes"/"No".
- Added `fields.yes` / `fields.no` to `en.json` and the corresponding entries in `$schema.json` (required for the translation-validation test). Other locales fall back to English.

## Linear
[MER-115](https://linear.app/rigbyjs/issue/MER-115)

## Test plan
- [ ] Open an attribute's detail page in the admin panel → Filterable/Required rows show "Yes"/"No" (not `fields.yes`/`fields.no`)
- [ ] `bun run lint`
- [ ] `bun run build`