### PR TITLE
fix(vendor): remove trailing dot from customer group name validation

### DIFF
--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1312,7 +1312,7 @@
     "domain": "Customer Groups",
     "subtitle": "Organize customers into groups. Groups can have different promotions and prices.",
     "validation": {
-      "nameRequired": "Please enter a name."
+      "nameRequired": "Please enter a name"
     },
     "list": {
       "empty": {


### PR DESCRIPTION
## Summary
- Remove the trailing dot from the vendor customer group name validation message (`Please enter a name.` → `Please enter a name`) to match the team's validation copy convention.

## Linear
[MER-221](https://linear.app/rigbyjs/issue/MER-221)

## Test plan
- [ ] In the vendor panel, create/edit a customer group with an empty name and confirm the error reads `Please enter a name` (no trailing dot).