### PR TITLE
fix(vendor): restore breadcrumb on variant details page

### DIFF
--- a/packages/vendor/src/get-route-map.tsx
+++ b/packages/vendor/src/get-route-map.tsx
@@ -1043,11 +1043,16 @@ export function getRouteMap({
                 path: "/products/:product_id/variants/:variant_id",
                 errorElement: <ErrorBoundary />,
                 lazy: async () => {
-                  const { loader } =
+                  const { loader, Breadcrumb } =
                     await import("./pages/product-variants/product-variant-detail");
                   return {
                     Component: Outlet,
                     loader,
+                    handle: {
+                      breadcrumb: (match: UIMatch<any>) => (
+                        <Breadcrumb {...match} />
+                      ),
+                    },
                   };
                 },
                 children: [


### PR DESCRIPTION
## Summary
- The standalone vendor route `/products/:product_id/variants/:variant_id` imported its `loader` but never wired `handle.breadcrumb`, so no breadcrumb rendered on the variant details page (follow-up to #969).
- Wire the already-exported `Breadcrumb` component into the route `handle`, matching the pattern every other detail route already uses (products, orders, offers/variants, etc.).

## Linear
[MER-137](https://linear.app/rigbyjs/issue/MER-137/products-vendor-panel-variant-details)

## Test plan
- [ ] Open a product variant detail page in the vendor panel — the variant title breadcrumb now renders in the shell header.
- [ ] `bun run lint`
- [ ] `bun run build` (vendor builds incl. DTS)