### PR TITLE
fix(vendor): align empty table state height with admin

### DIFF
--- a/packages/vendor/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/vendor/src/components/common/empty-table-content/empty-table-content.tsx
@@ -79,7 +79,7 @@ export const NoRecords = ({
   return (
     <div
       className={clx(
-        "flex h-[150px] w-full flex-col items-center justify-center gap-y-4",
+        "flex h-[400px] w-full flex-col items-center justify-center gap-y-4",
         className
       )}
     >


### PR DESCRIPTION
## Summary
- The vendor `NoRecords` empty state was the only empty state still at `h-[150px]`, leaving it cramped against the section header divider and the bottom border (review feedback on MER-216).
- Admin deliberately bumped its `NoRecords` from `h-[150px]` → `h-[400px]` in #894 (2026-04-28), but vendor never received the same change. Vendor's own `NoResults` is already `h-[400px]`.
- This aligns the vendor `NoRecords` height to `h-[400px]`, matching the admin standard and vendor's `NoResults`. It fixes the customer groups empty state and every other vendor list empty state consistently — one line, no new plumbing.

## Linear
[MER-216](https://linear.app/rigbyjs/issue/MER-216)

## Test plan
- [ ] Open the vendor panel Customer Groups page with no groups; verify the empty state has comfortable top/bottom padding (matching admin)
- [x] `bun run lint`
- [x] `bun run build`