### PR TITLE
fix(vendor): correct offer shipping profile link and use select dropdown

### DIFF
--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/_components/offer-variant-shipping-section.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/_components/offer-variant-shipping-section.tsx
@@ -14,13 +14,6 @@ type OfferShippingData = {
   } | null
 }
 
-/**
- * Sidebar "Shipping Configuration" card of the Offer Variant detail
- * (Figma `40016503:749900`). Mirrors the offer detail's "Associated
- * product" card structure/size: an `Edit` kebab in the header and a
- * Pattern-A card (icon + name/subtitle + chevron) linking to the
- * shipping profile detail page under Settings.
- */
 export const OfferVariantShippingSection = ({
   offer,
 }: {

--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/_components/offer-variant-shipping-section.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/_components/offer-variant-shipping-section.tsx
@@ -50,7 +50,7 @@ export const OfferVariantShippingSection = ({
       {profile?.name ? (
         <div className="txt-small flex flex-col gap-2 px-2 pb-2">
           <Link
-            to={`/settings/shipping-profiles/${profile.id}`}
+            to={`/settings/locations/shipping-profiles/${profile.id}`}
             className="outline-none focus-within:shadow-borders-interactive-with-focus rounded-md [&:hover>div]:bg-ui-bg-component-hover"
             data-testid="offer-variant-shipping-link"
           >

--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/shipping/index.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/shipping/index.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Button, Heading, RadioGroup, toast } from "@medusajs/ui"
+import { Button, Heading, Select, toast } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
@@ -10,6 +10,7 @@ import { RouteDrawer, useRouteModal } from "../../../../../../components/modals"
 import { KeyboundForm } from "../../../../../../components/utilities/keybound-form"
 import { useShippingProfiles } from "../../../../../../hooks/api/shipping-profiles"
 import { useOffer, useUpdateOffer } from "../../../../../../hooks/api/offers"
+import { useDocumentDirection } from "../../../../../../hooks/use-document-direction"
 import { OFFER_VARIANT_DETAIL_FIELDS } from "../../../../common/constants"
 import { OfferDetail } from "../../../../common/types"
 
@@ -17,12 +18,12 @@ const Schema = z.object({ shipping_profile_id: z.string().min(1) })
 type Values = z.infer<typeof Schema>
 
 /**
- * Edit Shipping Configuration drawer — a single shipping-profile choice.
- * Only one profile can be selected, so the options are rendered as radio
- * buttons rather than a checkmark select.
+ * Edit Shipping Configuration drawer — a single shipping-profile choice
+ * rendered as a Select dropdown (Figma `40016693:124647`).
  */
 const EditShippingForm = ({ offer }: { offer: OfferDetail }) => {
   const { t } = useTranslation()
+  const direction = useDocumentDirection()
   const { handleSuccess } = useRouteModal()
   const { shipping_profiles } = useShippingProfiles({ limit: 1000 })
 
@@ -56,24 +57,27 @@ const EditShippingForm = ({ offer }: { offer: OfferDetail }) => {
           <Form.Field
             control={form.control}
             name="shipping_profile_id"
-            render={({ field: { ref: _r, onChange, ...f } }) => (
+            render={({ field: { ref, onChange, ...f } }) => (
               <Form.Item>
                 <Form.Label>{t("offers.fields.shippingProfile")}</Form.Label>
                 <Form.Control>
-                  <RadioGroup
-                    {...f}
-                    onValueChange={onChange}
-                    className="flex flex-col gap-3"
-                  >
-                    {(shipping_profiles ?? []).map((p) => (
-                      <RadioGroup.ChoiceBox
-                        key={p.id}
-                        value={p.id}
-                        label={p.name ?? ""}
-                        description={p.type ?? ""}
+                  <Select {...f} onValueChange={onChange} dir={direction}>
+                    <Select.Trigger
+                      ref={ref}
+                      data-testid="offer-variant-shipping-select"
+                    >
+                      <Select.Value
+                        placeholder={t("offers.fields.shippingProfile")}
                       />
-                    ))}
-                  </RadioGroup>
+                    </Select.Trigger>
+                    <Select.Content>
+                      {(shipping_profiles ?? []).map((p) => (
+                        <Select.Item key={p.id} value={p.id}>
+                          {p.name ?? ""}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select>
                 </Form.Control>
                 <Form.ErrorMessage />
               </Form.Item>

--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/shipping/index.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/shipping/index.tsx
@@ -17,10 +17,6 @@ import { OfferDetail } from "../../../../common/types"
 const Schema = z.object({ shipping_profile_id: z.string().min(1) })
 type Values = z.infer<typeof Schema>
 
-/**
- * Edit Shipping Configuration drawer — a single shipping-profile choice
- * rendered as a Select dropdown (Figma `40016693:124647`).
- */
 const EditShippingForm = ({ offer }: { offer: OfferDetail }) => {
   const { t } = useTranslation()
   const direction = useDocumentDirection()


### PR DESCRIPTION
## Summary
Follow-up to #1026 addressing two review points from Khrystyna that were still unresolved:

1. **404 fix** — The offer variant "Shipping Configuration" card linked to `/settings/shipping-profiles/:id`, but the vendor route is nested under `locations` (`/settings/locations/shipping-profiles/:id`). Clicking the card 404'd. The link now points at the correct route (matching the product shipping-profile section and the list/create flows).
2. **Design match** — The edit drawer rendered shipping profiles as `RadioGroup.ChoiceBox` cards, which did not match the design. Replaced with a single Medusa `Select` dropdown ([Figma `40016693:124647`](https://www.figma.com/design/sYJoh84Owr5tomRjpxG0no/-Mercur-2.0----Vendor-Panel?node-id=40016693-124647)).

## Linear
[MER-178](https://linear.app/rigbyjs/issue/MER-178)

## Test plan
- [ ] Offer variant detail → click the Shipping Configuration card → lands on `/settings/locations/shipping-profiles/:id` (no 404).
- [ ] Kebab → Edit → profiles render as a Select dropdown; selecting one and saving persists.
- [x] `bun run lint`
- [x] `bun run build` (vendor package: ESM + DTS success)