### PR TITLE
ci: gate integration shards behind a fast build/typecheck job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,8 +11,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Fast gate: the build is also our typecheck (core/providers compile with
+  # `tsc`, dashboards with `tsup`), so a PR that doesn't compile fails here in
+  # a couple of minutes — before any of the slow, Postgres/Redis-backed
+  # integration shards spin up. The shards `needs: build` and restore this
+  # job's Turborepo cache, so their own `bun run build` is a cache hit rather
+  # than a 4x-redundant rebuild.
+  build:
+    name: Build (typecheck gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'bun.lockb') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Cache Turborepo
+        uses: actions/cache@v4
+        with:
+          # This key is what the integration shards restore from, so a single
+          # build is shared across all four of them.
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          path: .turbo
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build packages
+        run: bun run build
+
   integration-http:
     name: HTTP integration tests (shard ${{ matrix.shard }}/4)
+    needs: build
     runs-on: ubuntu-latest
     # Shards are balanced by duration (see integration-tests/test-sequencer.js),
     # so this is a safety net against a genuinely hung spec, not the normal
@@ -95,10 +145,11 @@ jobs:
         with:
           path: .turbo
           # Per-shard key so parallel shards don't race to save the same entry;
-          # restore-keys still lets each shard reuse another shard's build cache.
+          # restore-keys falls back to the `build` job's cache
+          # (turbo-${{ github.sha }}), making each shard's `bun run build` a hit.
           key: ${{ runner.os }}-turbo-${{ github.sha }}-${{ matrix.shard }}
           restore-keys: |
-            ${{ runner.os }}-turbo-${{ github.sha }}-
+            ${{ runner.os }}-turbo-${{ github.sha }}
             ${{ runner.os }}-turbo-
 
       - name: Install dependencies


### PR DESCRIPTION
## What

Adds a single `build` job to the integration-tests workflow and makes the four HTTP integration shards `needs: build`.

## Why

`bun run build` is effectively the typecheck (packages compile with `tsc` / `tsup`). Previously each of the four shards built independently, so a PR that doesn't compile would still spin up four Postgres/Redis-backed shards before failing — ~20 min of feedback for a trivial type error.

Now:

- A PR that doesn't compile fails in the `build` gate in ~2–3 min; the slow shards never start.
- The shards restore the `build` job's Turborepo cache (`turbo-${sha}`), so their own `bun run build` is a cache hit instead of a 4x-redundant rebuild.

## Notes

- `all-passed` remains the single aggregate status check for branch protection.
- No need to require the new `Build (typecheck gate)` check separately — the shards already depend on it.