### PR TITLE
ci: cache node_modules to avoid repeated ~19min bun installs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,7 +20,10 @@ jobs:
   build:
     name: Build (typecheck gate)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Headroom for the cold-cache case: when the lockfile changes, the
+    # node_modules cache misses and a full `bun install` (~19 min) runs before
+    # the build. On the common path the cache hits and this job is a few minutes.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -54,7 +57,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          # Bun's (default, isolated) linker materialises a ~7k-symlink store
+          # under node_modules/.bun; rebuilding it from the tarball cache costs
+          # ~19 min in CI. This gate job runs first (the shards `needs: build`),
+          # so on a cold lockfile it pays that cost once and saves the tree here;
+          # every shard then restores it under the same key and skips install.
+          # No restore-keys: a fuzzy hit from a different lockfile would leave
+          # node_modules out of sync and we skip install on a hit.
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+            packages/providers/*/node_modules
+            integration-tests/node_modules
+            e2e-tests/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('bun.lock', 'bun.lockb') }}
+
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Build packages
@@ -152,7 +176,24 @@ jobs:
             ${{ runner.os }}-turbo-${{ github.sha }}
             ${{ runner.os }}-turbo-
 
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          # Restores the materialised node_modules saved by the `build` gate
+          # (same lockfile-keyed entry), so each shard skips the ~19-min install
+          # rather than rebuilding bun's symlink store four more times.
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+            packages/providers/*/node_modules
+            integration-tests/node_modules
+            e2e-tests/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('bun.lock', 'bun.lockb') }}
+
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Build packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,11 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Headroom for the rare cold-cache case: when the lockfile changes, the
+    # node_modules cache misses and a full `bun install` (~19 min, see below)
+    # has to run before lint. On the common path the cache hits and this job
+    # finishes in a couple of minutes.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -33,7 +37,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          # Bun's (default, isolated) linker materialises a ~7k-symlink store
+          # under node_modules/.bun; rebuilding it from the tarball cache costs
+          # ~19 min in CI — long enough that `bun install` alone used to blow the
+          # old 20-min lint timeout. Caching the materialised tree keyed on the
+          # exact lockfile turns the lockfile-unchanged case into a fast restore.
+          # No restore-keys: a fuzzy hit from a different lockfile would leave
+          # node_modules out of sync and we skip install on a hit.
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+            packages/providers/*/node_modules
+            integration-tests/node_modules
+            e2e-tests/node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('bun.lock', 'bun.lockb') }}
+
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Run lint


### PR DESCRIPTION
## Problem

On recent pushes, the **Lint** job is cancelled and the integration **shards** spend most of their wall-clock "installing packages" — but it's not lint or the sharding logic. It's `bun install`.

bun's **isolated linker** (the default for this workspace) materialises a ~7,000-symlink store under `node_modules/.bun`. Resolution itself is ~4s; the rest is pure materialisation:

| | Time |
|---|---|
| `bun install --frozen-lockfile`, warm tarball cache (local) | **2m34s** |
| Same step, cold in CI (build gate) | **18m46s** |

That install ran on **every job** — lint + build gate + 4 shards = 6× per push — and on its own exceeded lint's 20-min job timeout, so lint was killed before `oxlint` ever ran.

## Change

- Cache the **materialised `node_modules`** keyed on the exact `bun.lock` hash (no `restore-keys` — a fuzzy hit from a different lockfile would leave `node_modules` out of sync), and **skip `bun install` on a cache hit**.
- The **build gate** runs first (shards `needs: build`), so on a cold lockfile it pays the install cost once and saves the tree; **lint** and the **4 shards** then restore it under the same key.
- Bump the **lint** and **build-gate** `timeout-minutes` 20 → 30 for the cold-lockfile case, where a full install still runs.

Net: on the common path (lockfile unchanged) all six jobs restore `node_modules` in ~1–2 min instead of installing for ~19 min. The slow install now runs once per dependency change and is shared across jobs.

## Notes

- The first run after merge (and any future lockfile change) still pays one ~19-min install to seed the cache — expected.
- The existing `~/.bun/install/cache` (tarball) cache is kept; it speeds up the cold-miss install's download phase.
- Switching bun to the **hoisted** linker would make materialisation ~29× faster, but it changes transitive type resolution and breaks `@mercurjs/core`'s `tsc` build (a different `@types/node` floats to the top), so it was deliberately not done.