### PR TITLE
fix(admin): fix commission rule Type filter error and empty-state copy

### DIFF
--- a/integration-tests/http/commission-rates/admin/commission-rates.spec.ts
+++ b/integration-tests/http/commission-rates/admin/commission-rates.spec.ts
@@ -194,6 +194,77 @@ medusaIntegrationTestRunner({
           expect(comboIds).toContain(comboRate.data.commission_rate.id)
           expect(comboIds).not.toContain(storeRate.data.commission_rate.id)
         })
+
+        it("should filter by multiple scope_type values (comma-joined and array)", async () => {
+          const storeRate = await api.post(
+            `/admin/commission-rates`,
+            {
+              name: "Multi Store Rate",
+              code: "MULTI_STORE",
+              type: "percentage",
+              value: 5,
+              rules: [{ reference: "seller", reference_id: seller.id }],
+            },
+            adminHeaders
+          )
+
+          const categoryRate = await api.post(
+            `/admin/commission-rates`,
+            {
+              name: "Multi Category Rate",
+              code: "MULTI_CATEGORY",
+              type: "percentage",
+              value: 6,
+              rules: [
+                { reference: "product_category", reference_id: "pcat_multi" },
+              ],
+            },
+            adminHeaders
+          )
+
+          const productTypeRate = await api.post(
+            `/admin/commission-rates`,
+            {
+              name: "Multi Product Type Rate",
+              code: "MULTI_PRODUCT_TYPE",
+              type: "percentage",
+              value: 7,
+              rules: [
+                { reference: "product_type", reference_id: "ptyp_multi" },
+              ],
+            },
+            adminHeaders
+          )
+
+          // Comma-joined form (regression: previously emitted invalid SQL
+          // `... OR ... = true` / `1 = 0 = true` and returned 500).
+          const comma = await api.get(
+            `/admin/commission-rates?scope_type=store,category`,
+            adminHeaders
+          )
+
+          expect(comma.status).toEqual(200)
+          const commaIds = comma.data.commission_rates.map((r: any) => r.id)
+          expect(commaIds).toContain(storeRate.data.commission_rate.id)
+          expect(commaIds).toContain(categoryRate.data.commission_rate.id)
+          expect(commaIds).not.toContain(
+            productTypeRate.data.commission_rate.id
+          )
+
+          // Array form (what the typed client serialises a multi-select to).
+          const array = await api.get(
+            `/admin/commission-rates?scope_type[0]=store&scope_type[1]=category`,
+            adminHeaders
+          )
+
+          expect(array.status).toEqual(200)
+          const arrayIds = array.data.commission_rates.map((r: any) => r.id)
+          expect(arrayIds).toContain(storeRate.data.commission_rate.id)
+          expect(arrayIds).toContain(categoryRate.data.commission_rate.id)
+          expect(arrayIds).not.toContain(
+            productTypeRate.data.commission_rate.id
+          )
+        })
       })
 
       describe("POST /admin/commission-rates", () => {

--- a/integration-tests/http/commission-rates/admin/commission-rates.spec.ts
+++ b/integration-tests/http/commission-rates/admin/commission-rates.spec.ts
@@ -236,8 +236,6 @@ medusaIntegrationTestRunner({
             adminHeaders
           )
 
-          // Comma-joined form (regression: previously emitted invalid SQL
-          // `... OR ... = true` / `1 = 0 = true` and returned 500).
           const comma = await api.get(
             `/admin/commission-rates?scope_type=store,category`,
             adminHeaders
@@ -251,7 +249,6 @@ medusaIntegrationTestRunner({
             productTypeRate.data.commission_rate.id
           )
 
-          // Array form (what the typed client serialises a multi-select to).
           const array = await api.get(
             `/admin/commission-rates?scope_type[0]=store&scope_type[1]=category`,
             adminHeaders

--- a/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
@@ -42,7 +42,7 @@ type ActionProps = {
 
 export type NoRecordsProps = {
   title?: string
-  message?: string
+  message?: React.ReactNode
   className?: string
   buttonVariant?: string
   icon?: React.ReactNode

--- a/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
@@ -42,7 +42,7 @@ type ActionProps = {
 
 export type NoRecordsProps = {
   title?: string
-  message?: React.ReactNode
+  message?: string
   className?: string
   buttonVariant?: string
   icon?: React.ReactNode
@@ -91,7 +91,10 @@ export const NoRecords = ({
             {title ?? t("general.noRecordsTitle")}
           </Text>
 
-          <Text size="small" className="text-ui-fg-muted">
+          <Text
+            size="small"
+            className="text-ui-fg-muted whitespace-pre-line text-center"
+          >
             {message ?? t("general.noRecordsMessage")}
           </Text>
         </div>

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3932,7 +3932,7 @@
       },
       "empty": {
         "heading": "No commission rules yet",
-        "description": "Create a commission rule to override the global commission for specific stores, product types, or categories."
+        "description": "Create a commission rule to override the global commission for\nspecific stores, product types, or categories."
       }
     },
     "status": {

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
@@ -88,15 +88,9 @@ export const CommissionRulesDataTable = () => {
       navigateTo={(row) => `${row.original.id}`}
       noRecords={{
         title: t("commissions.rules.empty.heading", "No commission rules yet"),
-        // Render the description preserving its line break so it reads on two
-        // lines ("…global commission for" / "specific stores, product types,
-        // or categories."), matching the empty-state design.
         message: (
           <span className="block whitespace-pre-line text-center">
-            {t(
-              "commissions.rules.empty.description",
-              "Create a commission rule to override the global commission for\nspecific stores, product types, or categories."
-            )}
+            {t("commissions.rules.empty.description")}
           </span>
         ),
       }}

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
@@ -88,11 +88,7 @@ export const CommissionRulesDataTable = () => {
       navigateTo={(row) => `${row.original.id}`}
       noRecords={{
         title: t("commissions.rules.empty.heading", "No commission rules yet"),
-        message: (
-          <span className="block whitespace-pre-line text-center">
-            {t("commissions.rules.empty.description")}
-          </span>
-        ),
+        message: t("commissions.rules.empty.description"),
       }}
       pagination
       search

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
@@ -88,9 +88,16 @@ export const CommissionRulesDataTable = () => {
       navigateTo={(row) => `${row.original.id}`}
       noRecords={{
         title: t("commissions.rules.empty.heading", "No commission rules yet"),
-        message: t(
-          "commissions.rules.empty.description",
-          "Create a commission rule to override the global commission for specific stores, product types, or categories."
+        // Render the description preserving its line break so it reads on two
+        // lines ("…global commission for" / "specific stores, product types,
+        // or categories."), matching the empty-state design.
+        message: (
+          <span className="block whitespace-pre-line text-center">
+            {t(
+              "commissions.rules.empty.description",
+              "Create a commission rule to override the global commission for\nspecific stores, product types, or categories."
+            )}
+          </span>
         ),
       }}
       pagination

--- a/packages/core/src/modules/commission/service.ts
+++ b/packages/core/src/modules/commission/service.ts
@@ -365,12 +365,6 @@ class CommissionModuleService extends MedusaService({
         }
       }
 
-      // Wrap each scope condition AND the OR-combination in parentheses so the
-      // fragment is a single, self-contained boolean expression. MikroORM
-      // serialises a raw filter key as `(<fragment>) = true`, which is only
-      // valid SQL when <fragment> is parenthesised — otherwise a multi-scope
-      // value emits `(a) OR (b) = true` (wrong precedence) and an empty/invalid
-      // value emits `1 = 0 = true` (a syntax error → 500).
       return `(${valid.map((scope) => `(${conditionFor(scope)})`).join(" OR ")})`
     }
   }
@@ -389,11 +383,6 @@ class CommissionModuleService extends MedusaService({
       return { ...rest }
     }
 
-    // The admin "Type" filter is a multi-select. Depending on how the value is
-    // serialised it can arrive as an array (`["store", "category"]`) or as a
-    // single comma-joined string (`"store,category"`); normalise both into a
-    // flat list of trimmed scope tokens so either form filters correctly
-    // instead of being treated as one unknown scope.
     const scopeTypes = (
       Array.isArray(scope_type) ? scope_type : [scope_type]
     )

--- a/packages/core/src/modules/commission/service.ts
+++ b/packages/core/src/modules/commission/service.ts
@@ -365,7 +365,13 @@ class CommissionModuleService extends MedusaService({
         }
       }
 
-      return valid.map((scope) => `(${conditionFor(scope)})`).join(" OR ")
+      // Wrap each scope condition AND the OR-combination in parentheses so the
+      // fragment is a single, self-contained boolean expression. MikroORM
+      // serialises a raw filter key as `(<fragment>) = true`, which is only
+      // valid SQL when <fragment> is parenthesised — otherwise a multi-scope
+      // value emits `(a) OR (b) = true` (wrong precedence) and an empty/invalid
+      // value emits `1 = 0 = true` (a syntax error → 500).
+      return `(${valid.map((scope) => `(${conditionFor(scope)})`).join(" OR ")})`
     }
   }
 
@@ -383,14 +389,22 @@ class CommissionModuleService extends MedusaService({
       return { ...rest }
     }
 
+    // The admin "Type" filter is a multi-select. Depending on how the value is
+    // serialised it can arrive as an array (`["store", "category"]`) or as a
+    // single comma-joined string (`"store,category"`); normalise both into a
+    // flat list of trimmed scope tokens so either form filters correctly
+    // instead of being treated as one unknown scope.
     const scopeTypes = (
       Array.isArray(scope_type) ? scope_type : [scope_type]
-    ) as string[]
+    )
+      .flatMap((value) => String(value).split(","))
+      .map((value) => value.trim())
+      .filter(Boolean)
     const predicate = this.buildScopeTypeWhere_(scopeTypes)
     const where: Record<string, unknown> = { ...rest }
 
     // No recognised scope type → match nothing rather than ignore the filter.
-    where[raw((alias: string) => (predicate ? predicate(alias) : "1 = 0"))] =
+    where[raw((alias: string) => (predicate ? predicate(alias) : "(1 = 0)"))] =
       true
 
     return where


### PR DESCRIPTION
## Summary
- Fix the Commission Rules **Type** filter 500ing the list endpoint. The server-side `scope_type` predicate emitted invalid SQL: an unrecognised/empty value produced `1 = 0 = true` (syntax error) and the multi-value `OR`-chain relied on operator precedence. A comma-joined multi-select value (`scope_type=store,category`) was also treated as a single unknown scope.
- Normalise `scope_type` from both **array** and **comma-joined** forms, and wrap the raw fragment in parentheses so `(<fragment>) = true` is always valid SQL.
- Render the empty-state description on two lines (break after "for") to match the design.

## Linear
[MER-230](https://linear.app/rigbyjs/issue/MER-230)

## Test plan
- [x] Added integration coverage for multiple `scope_type` values (comma-joined and array forms) in `commission-rates.spec.ts` — verifies 200 + correct filtering (previously 500).
- [x] `bun run test:integration:http -- commission-rates` (33 passed)
- [x] `tsc --noEmit` on `core` (clean) and changed `admin` files (no new errors; admin has pre-existing unrelated canary errors)
- [ ] Manual: open Admin → Settings → Commissions, apply the **Type** filter with one and multiple values; confirm no error and correct results
- [ ] Manual: empty Commission Rules list shows the description on two lines