### PR TITLE
fix(admin): relocate commission code field and switch type selectors to selects

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -14800,6 +14800,9 @@
             "value": {
               "type": "string"
             },
+            "status": {
+              "type": "string"
+            },
             "enabled": {
               "type": "string"
             },
@@ -14911,6 +14914,7 @@
           "required": [
             "code",
             "value",
+            "status",
             "enabled",
             "enabledHint",
             "stores",

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3877,6 +3877,7 @@
     "fields": {
       "code": "Code",
       "value": "Value",
+      "status": "Status",
       "enabled": "Enabled",
       "enabledHint": "Enable or disable this commission rule.",
       "stores": "Stores",

--- a/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
@@ -86,7 +86,7 @@ const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
               render={({ field: { onChange, ref, ...field } }) => (
                 <Form.Item>
                   <Form.Label>
-                    {t("commissions.fields.type.label", "Type")}
+                    {t("commissions.fields.type.label")}
                   </Form.Label>
                   <Form.Control>
                     <Select {...field} onValueChange={onChange} dir={direction}>
@@ -98,13 +98,10 @@ const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
                       </Select.Trigger>
                       <Select.Content>
                         <Select.Item value="percentage">
-                          {t(
-                            "commissions.fields.type.percentage",
-                            "Percentage"
-                          )}
+                          {t("commissions.fields.type.percentage")}
                         </Select.Item>
                         <Select.Item value="fixed">
-                          {t("commissions.fields.type.fixed", "Fixed")}
+                          {t("commissions.fields.type.fixed")}
                         </Select.Item>
                       </Select.Content>
                     </Select>
@@ -121,23 +118,14 @@ const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
             <SwitchBox
               control={form.control}
               name="include_tax"
-              label={t("commissions.fields.taxIncluded", "Tax included")}
-              description={t(
-                "commissions.fields.taxIncludedHint",
-                "If checked, commission is calculated on the total including tax."
-              )}
+              label={t("commissions.fields.taxIncluded")}
+              description={t("commissions.fields.taxIncludedHint")}
             />
             <SwitchBox
               control={form.control}
               name="include_shipping"
-              label={t(
-                "commissions.fields.shippingIncluded",
-                "Shipping included"
-              )}
-              description={t(
-                "commissions.fields.shippingIncludedHint",
-                "If checked, commission is calculated on the total including shipping."
-              )}
+              label={t("commissions.fields.shippingIncluded")}
+              description={t("commissions.fields.shippingIncludedHint")}
             />
           </div>
         </RouteDrawer.Body>
@@ -187,11 +175,11 @@ export const CommissionRuleCommissionEdit = () => {
       <RouteDrawer.Header>
         <RouteDrawer.Title asChild>
           <Heading>
-            {t("commissions.commissionEdit.header", "Edit Commission")}
+            {t("commissions.commissionEdit.header")}
           </Heading>
         </RouteDrawer.Title>
         <RouteDrawer.Description className="sr-only">
-          {t("commissions.commissionEdit.header", "Edit Commission")}
+          {t("commissions.commissionEdit.header")}
         </RouteDrawer.Description>
       </RouteDrawer.Header>
       {ready && <EditCommissionForm rule={commission_rate} />}

--- a/packages/admin/src/pages/commissions/commission-rule-create/commission-rule-create.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/commission-rule-create.tsx
@@ -11,12 +11,12 @@ const Root = ({ children }: { children?: ReactNode }) => {
     <RouteFocusModal>
       <RouteFocusModal.Title asChild>
         <span className="sr-only">
-          {t("commissions.create.header", "Create Commission Rule")}
+          {t("commissions.create.header")}
         </span>
       </RouteFocusModal.Title>
       <RouteFocusModal.Description asChild>
         <span className="sr-only">
-          {t("commissions.create.header", "Create Commission Rule")}
+          {t("commissions.create.header")}
         </span>
       </RouteFocusModal.Description>
       {Children.count(children) > 0 ? children : <CreateCommissionRuleForm />}

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-commission.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-commission.tsx
@@ -23,7 +23,7 @@ export const CreateCommissionRuleCommission = () => {
   return (
     <div className="flex flex-col items-center p-16">
       <div className="flex w-full max-w-[720px] flex-col gap-y-8">
-        <Heading>{t("commissions.create.commission", "Commission")}</Heading>
+        <Heading>{t("commissions.create.commission")}</Heading>
         <div className="flex flex-col gap-y-4">
           <Form.Field
             control={form.control}
@@ -31,7 +31,7 @@ export const CreateCommissionRuleCommission = () => {
             render={({ field: { onChange, ref, ...field } }) => (
               <Form.Item>
                 <Form.Label>
-                  {t("commissions.fields.type.label", "Type")}
+                  {t("commissions.fields.type.label")}
                 </Form.Label>
                 <Form.Control>
                   <Select {...field} onValueChange={onChange} dir={direction}>
@@ -43,13 +43,10 @@ export const CreateCommissionRuleCommission = () => {
                     </Select.Trigger>
                     <Select.Content>
                       <Select.Item value="percentage">
-                        {t(
-                          "commissions.fields.type.percentage",
-                          "Percentage"
-                        )}
+                        {t("commissions.fields.type.percentage")}
                       </Select.Item>
                       <Select.Item value="fixed">
-                        {t("commissions.fields.type.fixed", "Fixed")}
+                        {t("commissions.fields.type.fixed")}
                       </Select.Item>
                     </Select.Content>
                   </Select>
@@ -68,23 +65,14 @@ export const CreateCommissionRuleCommission = () => {
           <SwitchBox
             control={form.control}
             name="include_tax"
-            label={t("commissions.fields.taxIncluded", "Tax included")}
-            description={t(
-              "commissions.fields.taxIncludedHint",
-              "If checked, commission is calculated based on the total amount including tax. If unchecked, tax is excluded and goes entirely to the store."
-            )}
+            label={t("commissions.fields.taxIncluded")}
+            description={t("commissions.fields.taxIncludedHint")}
           />
           <SwitchBox
             control={form.control}
             name="include_shipping"
-            label={t(
-              "commissions.fields.shippingIncluded",
-              "Shipping included"
-            )}
-            description={t(
-              "commissions.fields.shippingIncludedHint",
-              "If checked, commission is calculated based on the total amount including shipping. If unchecked, shipping fees go entirely to the store."
-            )}
+            label={t("commissions.fields.shippingIncluded")}
+            description={t("commissions.fields.shippingIncludedHint")}
           />
         </div>
       </div>

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-commission.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-commission.tsx
@@ -1,4 +1,4 @@
-import { Heading, RadioGroup } from "@medusajs/ui";
+import { Heading, Select } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
 import { Form } from "../../../../../components/common/form";
@@ -28,41 +28,31 @@ export const CreateCommissionRuleCommission = () => {
           <Form.Field
             control={form.control}
             name="commissionType"
-            render={({ field: { onChange, ...rest } }) => (
+            render={({ field: { onChange, ref, ...field } }) => (
               <Form.Item>
                 <Form.Label>
                   {t("commissions.fields.type.label", "Type")}
                 </Form.Label>
                 <Form.Control>
-                  <RadioGroup
-                    dir={direction}
-                    onValueChange={onChange}
-                    {...rest}
-                    className="grid grid-cols-1 gap-4 md:grid-cols-2"
-                    data-testid="commission-rule-commission-type-radio-group"
-                  >
-                    <RadioGroup.ChoiceBox
-                      value="percentage"
-                      label={t(
-                        "commissions.fields.type.percentage",
-                        "Percentage"
-                      )}
-                      description={t(
-                        "commissions.fields.type.percentageHint",
-                        "Charge a percentage of the order total."
-                      )}
-                      data-testid="commission-rule-commission-type-option-percentage"
-                    />
-                    <RadioGroup.ChoiceBox
-                      value="fixed"
-                      label={t("commissions.fields.type.fixed", "Fixed")}
-                      description={t(
-                        "commissions.fields.type.fixedHint",
-                        "Charge a fixed amount per order."
-                      )}
-                      data-testid="commission-rule-commission-type-option-fixed"
-                    />
-                  </RadioGroup>
+                  <Select {...field} onValueChange={onChange} dir={direction}>
+                    <Select.Trigger
+                      ref={ref}
+                      data-testid="commission-rule-commission-type-select"
+                    >
+                      <Select.Value />
+                    </Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="percentage">
+                        {t(
+                          "commissions.fields.type.percentage",
+                          "Percentage"
+                        )}
+                      </Select.Item>
+                      <Select.Item value="fixed">
+                        {t("commissions.fields.type.fixed", "Fixed")}
+                      </Select.Item>
+                    </Select.Content>
+                  </Select>
                 </Form.Control>
                 <Form.ErrorMessage />
               </Form.Item>

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
@@ -1,4 +1,4 @@
-import { Heading, Input, RadioGroup } from "@medusajs/ui";
+import { Heading, Input, Select } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
 import { Combobox } from "../../../../../components/inputs/combobox";
@@ -70,77 +70,49 @@ export const CreateCommissionRuleDetails = () => {
         <Form.Field
           control={form.control}
           name="scopeType"
-          render={({ field: { onChange, ...rest } }) => (
+          render={({ field: { onChange, ref, ...field } }) => (
             <Form.Item>
               <Form.Label>
                 {t("commissions.fields.scopeType.label", "Type")}
               </Form.Label>
               <Form.Control>
-                <RadioGroup
-                  dir={direction}
-                  onValueChange={onChange}
-                  {...rest}
-                  className="grid grid-cols-1 gap-4 md:grid-cols-2"
-                  data-testid="commission-rule-scope-type-radio-group"
-                >
-                  <RadioGroup.ChoiceBox
-                    value="store"
-                    label={t("commissions.fields.scopeType.store", "Store")}
-                    description={t(
-                      "commissions.fields.scopeType.storeHint",
-                      "Apply to specific stores."
-                    )}
-                    data-testid="commission-rule-scope-type-option-store"
-                  />
-                  <RadioGroup.ChoiceBox
-                    value="product_type"
-                    label={t(
-                      "commissions.fields.scopeType.productType",
-                      "Product Type"
-                    )}
-                    description={t(
-                      "commissions.fields.scopeType.productTypeHint",
-                      "Apply to specific product types."
-                    )}
-                    data-testid="commission-rule-scope-type-option-product-type"
-                  />
-                  <RadioGroup.ChoiceBox
-                    value="category"
-                    label={t(
-                      "commissions.fields.scopeType.category",
-                      "Category"
-                    )}
-                    description={t(
-                      "commissions.fields.scopeType.categoryHint",
-                      "Apply to specific categories."
-                    )}
-                    data-testid="commission-rule-scope-type-option-category"
-                  />
-                  <RadioGroup.ChoiceBox
-                    value="store_product_type"
-                    label={t(
-                      "commissions.fields.scopeType.storeProductType",
-                      "Store + Product Type"
-                    )}
-                    description={t(
-                      "commissions.fields.scopeType.storeProductTypeHint",
-                      "Apply to product types within specific stores."
-                    )}
-                    data-testid="commission-rule-scope-type-option-store-product-type"
-                  />
-                  <RadioGroup.ChoiceBox
-                    value="store_category"
-                    label={t(
-                      "commissions.fields.scopeType.storeCategory",
-                      "Store + Category"
-                    )}
-                    description={t(
-                      "commissions.fields.scopeType.storeCategoryHint",
-                      "Apply to categories within specific stores."
-                    )}
-                    data-testid="commission-rule-scope-type-option-store-category"
-                  />
-                </RadioGroup>
+                <Select {...field} onValueChange={onChange} dir={direction}>
+                  <Select.Trigger
+                    ref={ref}
+                    data-testid="commission-rule-scope-type-select"
+                  >
+                    <Select.Value />
+                  </Select.Trigger>
+                  <Select.Content>
+                    <Select.Item value="store">
+                      {t("commissions.fields.scopeType.store", "Store")}
+                    </Select.Item>
+                    <Select.Item value="product_type">
+                      {t(
+                        "commissions.fields.scopeType.productType",
+                        "Product Type"
+                      )}
+                    </Select.Item>
+                    <Select.Item value="category">
+                      {t(
+                        "commissions.fields.scopeType.category",
+                        "Category"
+                      )}
+                    </Select.Item>
+                    <Select.Item value="store_product_type">
+                      {t(
+                        "commissions.fields.scopeType.storeProductType",
+                        "Store + Product Type"
+                      )}
+                    </Select.Item>
+                    <Select.Item value="store_category">
+                      {t(
+                        "commissions.fields.scopeType.storeCategory",
+                        "Store + Category"
+                      )}
+                    </Select.Item>
+                  </Select.Content>
+                </Select>
               </Form.Control>
               <Form.ErrorMessage />
             </Form.Item>

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
@@ -52,7 +52,7 @@ export const CreateCommissionRuleDetails = () => {
   return (
     <div className="flex flex-col items-center p-16">
       <div className="flex w-full max-w-[720px] flex-col gap-y-8">
-        <Heading>{t("commissions.create.details", "Details")}</Heading>
+        <Heading>{t("commissions.create.details")}</Heading>
         <div className="flex flex-col gap-y-4">
         <Form.Field
           control={form.control}
@@ -73,7 +73,7 @@ export const CreateCommissionRuleDetails = () => {
           render={({ field: { onChange, ref, ...field } }) => (
             <Form.Item>
               <Form.Label>
-                {t("commissions.fields.scopeType.label", "Type")}
+                {t("commissions.fields.scopeType.label")}
               </Form.Label>
               <Form.Control>
                 <Select {...field} onValueChange={onChange} dir={direction}>
@@ -85,31 +85,19 @@ export const CreateCommissionRuleDetails = () => {
                   </Select.Trigger>
                   <Select.Content>
                     <Select.Item value="store">
-                      {t("commissions.fields.scopeType.store", "Store")}
+                      {t("commissions.fields.scopeType.store")}
                     </Select.Item>
                     <Select.Item value="product_type">
-                      {t(
-                        "commissions.fields.scopeType.productType",
-                        "Product Type"
-                      )}
+                      {t("commissions.fields.scopeType.productType")}
                     </Select.Item>
                     <Select.Item value="category">
-                      {t(
-                        "commissions.fields.scopeType.category",
-                        "Category"
-                      )}
+                      {t("commissions.fields.scopeType.category")}
                     </Select.Item>
                     <Select.Item value="store_product_type">
-                      {t(
-                        "commissions.fields.scopeType.storeProductType",
-                        "Store + Product Type"
-                      )}
+                      {t("commissions.fields.scopeType.storeProductType")}
                     </Select.Item>
                     <Select.Item value="store_category">
-                      {t(
-                        "commissions.fields.scopeType.storeCategory",
-                        "Store + Category"
-                      )}
+                      {t("commissions.fields.scopeType.storeCategory")}
                     </Select.Item>
                   </Select.Content>
                 </Select>
@@ -125,7 +113,7 @@ export const CreateCommissionRuleDetails = () => {
             render={({ field }) => (
               <Form.Item>
                 <Form.Label>
-                  {t("commissions.fields.stores", "Stores")}
+                  {t("commissions.fields.stores")}
                 </Form.Label>
                 <Form.Control>
                   <Combobox
@@ -148,7 +136,7 @@ export const CreateCommissionRuleDetails = () => {
             render={({ field }) => (
               <Form.Item>
                 <Form.Label>
-                  {t("commissions.fields.productTypes", "Product Types")}
+                  {t("commissions.fields.productTypes")}
                 </Form.Label>
                 <Form.Control>
                   <Combobox
@@ -171,7 +159,7 @@ export const CreateCommissionRuleDetails = () => {
             render={({ field }) => (
               <Form.Item>
                 <Form.Label>
-                  {t("commissions.fields.categories", "Categories")}
+                  {t("commissions.fields.categories")}
                 </Form.Label>
                 <Form.Control>
                   <Combobox

--- a/packages/admin/src/pages/commissions/commission-rule-detail/commission-rule-detail.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-detail/commission-rule-detail.tsx
@@ -62,10 +62,6 @@ const ScopeSection = ({ rule }: { rule: CommissionRate }) => {
         </div>
       </div>
       <SectionRow
-        title={t("commissions.fields.code", "Code")}
-        value={rule.code}
-      />
-      <SectionRow
         title={t("commissions.rules.columns.type", "Type")}
         value={getScopeTypeLabel(rule.rules, t)}
       />

--- a/packages/admin/src/pages/commissions/commission-rule-detail/commission-rule-detail.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-detail/commission-rule-detail.tsx
@@ -62,12 +62,12 @@ const ScopeSection = ({ rule }: { rule: CommissionRate }) => {
         </div>
       </div>
       <SectionRow
-        title={t("commissions.rules.columns.type", "Type")}
+        title={t("commissions.rules.columns.type")}
         value={getScopeTypeLabel(rule.rules, t)}
       />
       {stores.length > 0 && (
         <SectionRow
-          title={t("commissions.fields.stores", "Stores")}
+          title={t("commissions.fields.stores")}
           value={getScopeSummary(
             (rule.rules ?? []).filter((r) => r.reference === "seller"),
             names
@@ -76,7 +76,7 @@ const ScopeSection = ({ rule }: { rule: CommissionRate }) => {
       )}
       {productTypes.length > 0 && (
         <SectionRow
-          title={t("commissions.fields.productTypes", "Product Types")}
+          title={t("commissions.fields.productTypes")}
           value={getScopeSummary(
             (rule.rules ?? []).filter((r) => r.reference === "product_type"),
             names
@@ -85,7 +85,7 @@ const ScopeSection = ({ rule }: { rule: CommissionRate }) => {
       )}
       {categories.length > 0 && (
         <SectionRow
-          title={t("commissions.fields.categories", "Categories")}
+          title={t("commissions.fields.categories")}
           value={getScopeSummary(
             (rule.rules ?? []).filter(
               (r) => r.reference === "product_category"
@@ -104,7 +104,7 @@ const CommissionSection = ({ rule }: { rule: CommissionRate }) => {
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
-        <Heading>{t("commissions.create.commission", "Commission")}</Heading>
+        <Heading>{t("commissions.create.commission")}</Heading>
         <ActionMenu
           groups={[
             {
@@ -120,31 +120,31 @@ const CommissionSection = ({ rule }: { rule: CommissionRate }) => {
         />
       </div>
       <SectionRow
-        title={t("commissions.fields.type.label", "Type")}
+        title={t("commissions.fields.type.label")}
         value={
           rule.type === "percentage"
-            ? t("commissions.fields.type.percentage", "Percentage")
-            : t("commissions.fields.type.fixed", "Fixed")
+            ? t("commissions.fields.type.percentage")
+            : t("commissions.fields.type.fixed")
         }
       />
       <SectionRow
-        title={t("commissions.global.value", "Value")}
+        title={t("commissions.global.value")}
         value={formatCommissionValue(rule)}
       />
       <SectionRow
-        title={t("commissions.global.tax", "Tax")}
+        title={t("commissions.global.tax")}
         value={
           rule.include_tax
-            ? t("commissions.global.included", "Included in commission")
-            : t("commissions.global.notIncluded", "Not included")
+            ? t("commissions.global.included")
+            : t("commissions.global.notIncluded")
         }
       />
       <SectionRow
-        title={t("commissions.global.shipping", "Shipping")}
+        title={t("commissions.global.shipping")}
         value={
           rule.include_shipping
-            ? t("commissions.global.included", "Included in commission")
-            : t("commissions.global.notIncluded", "Not included")
+            ? t("commissions.global.included")
+            : t("commissions.global.notIncluded")
         }
       />
     </Container>

--- a/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
@@ -143,7 +143,7 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
               render={({ field: { onChange, ref, ...field } }) => (
                 <Form.Item>
                   <Form.Label>
-                    {t("commissions.fields.status", "Status")}
+                    {t("commissions.fields.status")}
                   </Form.Label>
                   <Form.Control>
                     <Select {...field} onValueChange={onChange} dir={direction}>
@@ -155,10 +155,10 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
                       </Select.Trigger>
                       <Select.Content>
                         <Select.Item value="active">
-                          {t("commissions.status.enabled", "Active")}
+                          {t("commissions.status.enabled")}
                         </Select.Item>
                         <Select.Item value="inactive">
-                          {t("commissions.status.disabled", "Inactive")}
+                          {t("commissions.status.disabled")}
                         </Select.Item>
                       </Select.Content>
                     </Select>
@@ -189,7 +189,7 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
               name="code"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t("commissions.fields.code", "Code")}</Form.Label>
+                  <Form.Label>{t("commissions.fields.code")}</Form.Label>
                   <Form.Control>
                     <Input
                       autoComplete="off"
@@ -207,7 +207,7 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
               render={({ field: { onChange, ref, ...field } }) => (
                 <Form.Item>
                   <Form.Label>
-                    {t("commissions.fields.scopeType.label", "Type")}
+                    {t("commissions.fields.scopeType.label")}
                   </Form.Label>
                   <Form.Control>
                     <Select {...field} onValueChange={onChange} dir={direction}>
@@ -219,31 +219,19 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
                       </Select.Trigger>
                       <Select.Content>
                         <Select.Item value="store">
-                          {t("commissions.fields.scopeType.store", "Store")}
+                          {t("commissions.fields.scopeType.store")}
                         </Select.Item>
                         <Select.Item value="product_type">
-                          {t(
-                            "commissions.fields.scopeType.productType",
-                            "Product Type"
-                          )}
+                          {t("commissions.fields.scopeType.productType")}
                         </Select.Item>
                         <Select.Item value="category">
-                          {t(
-                            "commissions.fields.scopeType.category",
-                            "Category"
-                          )}
+                          {t("commissions.fields.scopeType.category")}
                         </Select.Item>
                         <Select.Item value="store_product_type">
-                          {t(
-                            "commissions.fields.scopeType.storeProductType",
-                            "Store + Product Type"
-                          )}
+                          {t("commissions.fields.scopeType.storeProductType")}
                         </Select.Item>
                         <Select.Item value="store_category">
-                          {t(
-                            "commissions.fields.scopeType.storeCategory",
-                            "Store + Category"
-                          )}
+                          {t("commissions.fields.scopeType.storeCategory")}
                         </Select.Item>
                       </Select.Content>
                     </Select>
@@ -259,7 +247,7 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
                 render={({ field }) => (
                   <Form.Item>
                     <Form.Label>
-                      {t("commissions.fields.stores", "Stores")}
+                      {t("commissions.fields.stores")}
                     </Form.Label>
                     <Form.Control>
                       <Combobox
@@ -282,7 +270,7 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
                 render={({ field }) => (
                   <Form.Item>
                     <Form.Label>
-                      {t("commissions.fields.productTypes", "Product Types")}
+                      {t("commissions.fields.productTypes")}
                     </Form.Label>
                     <Form.Control>
                       <Combobox
@@ -305,7 +293,7 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
                 render={({ field }) => (
                   <Form.Item>
                     <Form.Label>
-                      {t("commissions.fields.categories", "Categories")}
+                      {t("commissions.fields.categories")}
                     </Form.Label>
                     <Form.Control>
                       <Combobox
@@ -369,11 +357,11 @@ export const CommissionRuleEdit = () => {
       <RouteDrawer.Header>
         <RouteDrawer.Title asChild>
           <Heading>
-            {t("commissions.edit.header", "Edit Commission Rule")}
+            {t("commissions.edit.header")}
           </Heading>
         </RouteDrawer.Title>
         <RouteDrawer.Description className="sr-only">
-          {t("commissions.edit.header", "Edit Commission Rule")}
+          {t("commissions.edit.header")}
         </RouteDrawer.Description>
       </RouteDrawer.Header>
       {ready && <EditCommissionRuleForm rule={commission_rate} />}

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-data-table.tsx
@@ -87,13 +87,13 @@ export const CommissionRulesDataTable = () => {
       filters={filters}
       navigateTo={(row) => `${row.original.id}`}
       noRecords={{
-        title: t("commissions.rules.empty.heading", "No commission rules yet"),
+        title: t("commissions.rules.empty.heading"),
         message: t("commissions.rules.empty.description"),
       }}
       pagination
       search
       orderBy={[
-        { key: "name", label: t("commissions.rules.columns.rule", "Rule") },
+        { key: "name", label: t("commissions.rules.columns.rule") },
         { key: "created_at", label: t("fields.createdAt") },
         { key: "updated_at", label: t("fields.updatedAt") },
       ]}
@@ -140,14 +140,14 @@ const useColumns = (names: Record<string, string>) => {
     () => [
       columnHelper.accessor("name", {
         header: () => (
-          <TextHeader text={t("commissions.rules.columns.rule", "Rule")} />
+          <TextHeader text={t("commissions.rules.columns.rule")} />
         ),
         cell: ({ getValue }) => <TextCell text={getValue()} />,
       }),
       columnHelper.display({
         id: "type",
         header: () => (
-          <TextHeader text={t("commissions.rules.columns.type", "Type")} />
+          <TextHeader text={t("commissions.rules.columns.type")} />
         ),
         cell: ({ row }) => (
           <TextCell text={getScopeTypeLabel(row.original.rules, t)} />
@@ -156,7 +156,7 @@ const useColumns = (names: Record<string, string>) => {
       columnHelper.display({
         id: "scope",
         header: () => (
-          <TextHeader text={t("commissions.rules.columns.scope", "Scope")} />
+          <TextHeader text={t("commissions.rules.columns.scope")} />
         ),
         cell: ({ row }) => (
           <TextCell text={getScopeSummary(row.original.rules, names)} />
@@ -165,7 +165,7 @@ const useColumns = (names: Record<string, string>) => {
       columnHelper.display({
         id: "value",
         header: () => (
-          <TextHeader text={t("commissions.rules.columns.value", "Value")} />
+          <TextHeader text={t("commissions.rules.columns.value")} />
         ),
         cell: ({ row }) => (
           <TextCell text={formatCommissionValue(row.original)} />
@@ -173,7 +173,7 @@ const useColumns = (names: Record<string, string>) => {
       }),
       columnHelper.accessor("is_enabled", {
         header: () => (
-          <TextHeader text={t("commissions.rules.columns.status", "Status")} />
+          <TextHeader text={t("commissions.rules.columns.status")} />
         ),
         cell: ({ getValue }) => {
           const props = getIsActiveProps(getValue(), t);

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-header.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/commission-rules-header.tsx
@@ -7,7 +7,7 @@ export const CommissionRulesHeader = () => {
 
   return (
     <div className="flex items-center justify-between px-6 py-4">
-      <Heading>{t("commissions.rules.title", "Commission Rules")}</Heading>
+      <Heading>{t("commissions.rules.title")}</Heading>
       <Button size="small" variant="secondary" asChild>
         <Link to="create">{t("actions.create")}</Link>
       </Button>

--- a/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/use-commission-rules-filters.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/commission-rules-table/use-commission-rules-filters.tsx
@@ -15,49 +15,40 @@ export const useCommissionRulesFilters = (): Filter[] => {
     () => [
       {
         key: "scope_type",
-        label: t("commissions.fields.scopeType.label", "Type"),
+        label: t("commissions.fields.scopeType.label"),
         type: "select",
         multiple: true,
         options: [
           {
-            label: t("commissions.fields.scopeType.store", "Store"),
+            label: t("commissions.fields.scopeType.store"),
             value: "store",
           },
           {
-            label: t(
-              "commissions.fields.scopeType.productType",
-              "Product Type"
-            ),
+            label: t("commissions.fields.scopeType.productType"),
             value: "product_type",
           },
           {
-            label: t("commissions.fields.scopeType.category", "Category"),
+            label: t("commissions.fields.scopeType.category"),
             value: "category",
           },
           {
-            label: t(
-              "commissions.fields.scopeType.storeProductType",
-              "Store + Product Type"
-            ),
+            label: t("commissions.fields.scopeType.storeProductType"),
             value: "store_product_type",
           },
           {
-            label: t(
-              "commissions.fields.scopeType.storeCategory",
-              "Store + Category"
-            ),
+            label: t("commissions.fields.scopeType.storeCategory"),
             value: "store_category",
           },
         ],
       },
       {
         key: "is_enabled",
-        label: t("commissions.fields.status", "Status"),
+        label: t("commissions.fields.status"),
         type: "select",
         options: [
-          { label: t("commissions.status.enabled", "Active"), value: "true" },
+          { label: t("commissions.status.enabled"), value: "true" },
           {
-            label: t("commissions.status.disabled", "Inactive"),
+            label: t("commissions.status.disabled"),
             value: "false",
           },
         ],

--- a/packages/admin/src/pages/commissions/commissions-list/components/global-commission-section/global-commission-section.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/global-commission-section/global-commission-section.tsx
@@ -10,7 +10,6 @@ import { CommissionRate } from "../../../common/types";
 import { formatCommissionValue } from "../../../common/utils";
 
 const GLOBAL_COMMISSION_ROWS = [
-  { key: "code", fallback: "Code" },
   { key: "type", fallback: "Type" },
   { key: "value", fallback: "Value" },
   { key: "tax", fallback: "Tax" },
@@ -56,10 +55,6 @@ export const GlobalCommissionSection = () => {
           ))
         : (
           <>
-            <SectionRow
-              title={t("commissions.global.code", "Code")}
-              value={rate.code}
-            />
             <SectionRow
               title={t("commissions.global.type", "Type")}
               value={

--- a/packages/admin/src/pages/commissions/commissions-list/components/global-commission-section/global-commission-section.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/components/global-commission-section/global-commission-section.tsx
@@ -30,7 +30,7 @@ export const GlobalCommissionSection = () => {
   return (
     <Container className="divide-y p-0" data-testid="global-commission-section">
       <div className="flex items-center justify-between px-6 py-4">
-        <Heading>{t("commissions.global.title", "Global Commission")}</Heading>
+        <Heading>{t("commissions.global.title")}</Heading>
         <ActionMenu
           groups={[
             {
@@ -56,31 +56,31 @@ export const GlobalCommissionSection = () => {
         : (
           <>
             <SectionRow
-              title={t("commissions.global.type", "Type")}
+              title={t("commissions.global.type")}
               value={
                 rate.type === "percentage"
-                  ? t("commissions.fields.type.percentage", "Percentage")
-                  : t("commissions.fields.type.fixed", "Fixed")
+                  ? t("commissions.fields.type.percentage")
+                  : t("commissions.fields.type.fixed")
               }
             />
             <SectionRow
-              title={t("commissions.global.value", "Value")}
+              title={t("commissions.global.value")}
               value={formatCommissionValue(rate)}
             />
             <SectionRow
-              title={t("commissions.global.tax", "Tax")}
+              title={t("commissions.global.tax")}
               value={
                 rate.include_tax
-                  ? t("commissions.global.included", "Included in commission")
-                  : t("commissions.global.notIncluded", "Not included")
+                  ? t("commissions.global.included")
+                  : t("commissions.global.notIncluded")
               }
             />
             <SectionRow
-              title={t("commissions.global.shipping", "Shipping")}
+              title={t("commissions.global.shipping")}
               value={
                 rate.include_shipping
-                  ? t("commissions.global.included", "Included in commission")
-                  : t("commissions.global.notIncluded", "Not included")
+                  ? t("commissions.global.included")
+                  : t("commissions.global.notIncluded")
               }
             />
           </>

--- a/packages/admin/src/pages/commissions/common/components/commission-value-fields.tsx
+++ b/packages/admin/src/pages/commissions/common/components/commission-value-fields.tsx
@@ -35,7 +35,7 @@ export const CommissionValueFields = <T extends FieldValues = FieldValues>({
         name={"value" as never}
         render={({ field: { value, onChange, ...field } }) => (
           <Form.Item>
-            <Form.Label>{t("commissions.fields.value", "Value")}</Form.Label>
+            <Form.Label>{t("commissions.fields.value")}</Form.Label>
             <Form.Control>
               <PercentageInput
                 {...field}
@@ -53,7 +53,7 @@ export const CommissionValueFields = <T extends FieldValues = FieldValues>({
   return (
     <div className="flex flex-col gap-y-2">
       <Label size="small" weight="plus">
-        {t("commissions.fields.value", "Value")}
+        {t("commissions.fields.value")}
       </Label>
       <div className="flex flex-col gap-y-2">
         {currencies.map((code) => (

--- a/packages/admin/src/pages/commissions/common/hooks/use-delete-commission-rule-action.tsx
+++ b/packages/admin/src/pages/commissions/common/hooks/use-delete-commission-rule-action.tsx
@@ -15,7 +15,7 @@ export const useDeleteCommissionRuleAction = (rule: {
 
   return async () => {
     const confirmed = await prompt({
-      title: t("commissions.delete.title", "Delete commission rule"),
+      title: t("commissions.delete.title"),
       description: t("commissions.delete.description", {
         name: rule.name,
         defaultValue: `You are about to delete commission rule ${rule.name}. This action cannot be undone.`,

--- a/packages/admin/src/pages/commissions/common/utils.ts
+++ b/packages/admin/src/pages/commissions/common/utils.ts
@@ -158,11 +158,11 @@ export const getIsActiveProps = (isEnabled: boolean, t: TFunction) =>
   isEnabled
     ? {
         color: "green" as const,
-        label: t("commissions.status.enabled", "Active"),
+        label: t("commissions.status.enabled"),
       }
     : {
         color: "red" as const,
-        label: t("commissions.status.disabled", "Inactive"),
+        label: t("commissions.status.disabled"),
       };
 
 /** Form `fixed_values` map → the API `values[]` payload (one per currency). */

--- a/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Heading, RadioGroup, toast } from "@medusajs/ui";
+import { Button, Heading, Input, Select, toast } from "@medusajs/ui";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
@@ -20,6 +20,7 @@ import { buildValuesPayload, fixedValuesFromRate } from "../common/utils";
 
 const EditGlobalCommissionSchema = zod
   .object({
+    code: zod.string().min(1),
     type: zod.enum(["percentage", "fixed"]),
     value: zod.coerce.number().optional(),
     fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
@@ -47,6 +48,7 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
 
   const form = useForm<zod.infer<typeof EditGlobalCommissionSchema>>({
     defaultValues: {
+      code: rate.code,
       type: rate.type,
       value: rate.value,
       fixed_values: fixedValuesFromRate(rate),
@@ -61,6 +63,7 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
   const handleSubmit = form.handleSubmit(async (values) => {
     const isFixed = values.type === "fixed";
     const payload = {
+      code: values.code,
       type: values.type,
       value: isFixed ? 0 : values.value,
       ...(isFixed
@@ -92,42 +95,49 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
           <div className="flex flex-col gap-y-4">
             <Form.Field
               control={form.control}
+              name="code"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>{t("commissions.fields.code", "Code")}</Form.Label>
+                  <Form.Control>
+                    <Input
+                      autoComplete="off"
+                      data-testid="global-commission-code-input"
+                      {...field}
+                    />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+            <Form.Field
+              control={form.control}
               name="type"
-              render={({ field: { onChange, ...rest } }) => (
+              render={({ field: { onChange, ref, ...field } }) => (
                 <Form.Item>
                   <Form.Label>
                     {t("commissions.fields.type.label", "Type")}
                   </Form.Label>
                   <Form.Control>
-                    <RadioGroup
-                      dir={direction}
-                      onValueChange={onChange}
-                      {...rest}
-                      className="grid grid-cols-1 gap-4 md:grid-cols-2"
-                      data-testid="global-commission-type-radio-group"
-                    >
-                      <RadioGroup.ChoiceBox
-                        value="percentage"
-                        label={t(
-                          "commissions.fields.type.percentage",
-                          "Percentage"
-                        )}
-                        description={t(
-                          "commissions.fields.type.percentageHint",
-                          "Charge a percentage of the order total."
-                        )}
-                        data-testid="global-commission-type-option-percentage"
-                      />
-                      <RadioGroup.ChoiceBox
-                        value="fixed"
-                        label={t("commissions.fields.type.fixed", "Fixed")}
-                        description={t(
-                          "commissions.fields.type.fixedHint",
-                          "Charge a fixed amount per order."
-                        )}
-                        data-testid="global-commission-type-option-fixed"
-                      />
-                    </RadioGroup>
+                    <Select {...field} onValueChange={onChange} dir={direction}>
+                      <Select.Trigger
+                        ref={ref}
+                        data-testid="global-commission-type-select"
+                      >
+                        <Select.Value />
+                      </Select.Trigger>
+                      <Select.Content>
+                        <Select.Item value="percentage">
+                          {t(
+                            "commissions.fields.type.percentage",
+                            "Percentage"
+                          )}
+                        </Select.Item>
+                        <Select.Item value="fixed">
+                          {t("commissions.fields.type.fixed", "Fixed")}
+                        </Select.Item>
+                      </Select.Content>
+                    </Select>
                   </Form.Control>
                   <Form.ErrorMessage />
                 </Form.Item>

--- a/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
@@ -98,7 +98,7 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
               name="code"
               render={({ field }) => (
                 <Form.Item>
-                  <Form.Label>{t("commissions.fields.code", "Code")}</Form.Label>
+                  <Form.Label>{t("commissions.fields.code")}</Form.Label>
                   <Form.Control>
                     <Input
                       autoComplete="off"
@@ -116,7 +116,7 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
               render={({ field: { onChange, ref, ...field } }) => (
                 <Form.Item>
                   <Form.Label>
-                    {t("commissions.fields.type.label", "Type")}
+                    {t("commissions.fields.type.label")}
                   </Form.Label>
                   <Form.Control>
                     <Select {...field} onValueChange={onChange} dir={direction}>
@@ -128,13 +128,10 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
                       </Select.Trigger>
                       <Select.Content>
                         <Select.Item value="percentage">
-                          {t(
-                            "commissions.fields.type.percentage",
-                            "Percentage"
-                          )}
+                          {t("commissions.fields.type.percentage")}
                         </Select.Item>
                         <Select.Item value="fixed">
-                          {t("commissions.fields.type.fixed", "Fixed")}
+                          {t("commissions.fields.type.fixed")}
                         </Select.Item>
                       </Select.Content>
                     </Select>
@@ -151,23 +148,14 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
             <SwitchBox
               control={form.control}
               name="include_tax"
-              label={t("commissions.fields.taxIncluded", "Tax included")}
-              description={t(
-                "commissions.fields.taxIncludedHint",
-                "If checked, commission is calculated on the total including tax. If unchecked, tax is excluded and goes entirely to the store."
-              )}
+              label={t("commissions.fields.taxIncluded")}
+              description={t("commissions.fields.taxIncludedHint")}
             />
             <SwitchBox
               control={form.control}
               name="include_shipping"
-              label={t(
-                "commissions.fields.shippingIncluded",
-                "Shipping included"
-              )}
-              description={t(
-                "commissions.fields.shippingIncludedHint",
-                "If checked, commission is calculated on the total including shipping. If unchecked, shipping fees go entirely to the store."
-              )}
+              label={t("commissions.fields.shippingIncluded")}
+              description={t("commissions.fields.shippingIncludedHint")}
             />
           </div>
         </RouteDrawer.Body>
@@ -205,11 +193,11 @@ export const GlobalCommissionEdit = () => {
       <RouteDrawer.Header>
         <RouteDrawer.Title asChild>
           <Heading>
-            {t("commissions.global.edit.header", "Edit Global Commission")}
+            {t("commissions.global.edit.header")}
           </Heading>
         </RouteDrawer.Title>
         <RouteDrawer.Description className="sr-only">
-          {t("commissions.global.edit.header", "Edit Global Commission")}
+          {t("commissions.global.edit.header")}
         </RouteDrawer.Description>
       </RouteDrawer.Header>
       {ready && <EditGlobalCommissionForm rate={rate} />}


### PR DESCRIPTION
## Summary
- Remove the read-only **Code** row from the Global Commission section and the Commission Rule detail page; add an editable **Code** input to the Global Commission edit form (the rule edit drawer already had one). The code is no longer surfaced as a static value but can still be changed.
- Switch the commission **Type** (Percentage/Fixed) and **scope Type** (Store / Product Type / Category / Store + Product Type / Store + Category) selectors from radio choice boxes to dropdown **Selects**, matching the settings design. Applied to the Global Commission edit drawer and the Create Commission Rule wizard (Details + Commission tabs), consistent with the existing rule-edit Selects.

## Linear
[MER-225](https://linear.app/rigbyjs/issue/MER-225)

## Test plan
- [ ] Global Commission section + Commission Rule detail no longer show a Code row
- [ ] Global Commission edit drawer has an editable Code field that persists on save
- [ ] Type / scope-type fields render as dropdowns and submit correctly in create + edit flows
- [ ] `bun run lint`
- [ ] `bun run build`