### PR TITLE
fix(admin): use combobox instead of select for commission type fields

### DIFF
--- a/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Heading, Select, toast } from "@medusajs/ui";
+import { Button, Heading, toast } from "@medusajs/ui";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
@@ -7,9 +7,9 @@ import * as zod from "zod";
 
 import { Form } from "../../../components/common/form";
 import { SwitchBox } from "../../../components/common/switch-box";
+import { Combobox } from "../../../components/inputs/combobox";
 import { RouteDrawer, useRouteModal } from "../../../components/modals";
 import { KeyboundForm } from "../../../components/utilities/keybound-form";
-import { useDocumentDirection } from "../../../hooks/use-document-direction";
 import {
   useCommissionRule,
   useUpdateCommissionRule,
@@ -30,8 +30,12 @@ const EditCommissionSchema = zod.object({
 const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
   const { t } = useTranslation();
   const { handleSuccess } = useRouteModal();
-  const direction = useDocumentDirection();
   const { currencies } = useStoreCurrencies();
+
+  const typeOptions = [
+    { value: "percentage", label: t("commissions.fields.type.percentage") },
+    { value: "fixed", label: t("commissions.fields.type.fixed") },
+  ];
 
   const form = useForm<zod.infer<typeof EditCommissionSchema>>({
     defaultValues: {
@@ -83,28 +87,18 @@ const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
             <Form.Field
               control={form.control}
               name="type"
-              render={({ field: { onChange, ref, ...field } }) => (
+              render={({ field }) => (
                 <Form.Item>
                   <Form.Label>
                     {t("commissions.fields.type.label")}
                   </Form.Label>
                   <Form.Control>
-                    <Select {...field} onValueChange={onChange} dir={direction}>
-                      <Select.Trigger
-                        ref={ref}
-                        data-testid="commission-edit-type-select"
-                      >
-                        <Select.Value />
-                      </Select.Trigger>
-                      <Select.Content>
-                        <Select.Item value="percentage">
-                          {t("commissions.fields.type.percentage")}
-                        </Select.Item>
-                        <Select.Item value="fixed">
-                          {t("commissions.fields.type.fixed")}
-                        </Select.Item>
-                      </Select.Content>
-                    </Select>
+                    <Combobox
+                      {...field}
+                      options={typeOptions}
+                      forceHideInput
+                      data-testid="commission-edit-type-select"
+                    />
                   </Form.Control>
                   <Form.ErrorMessage />
                 </Form.Item>

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-commission.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-commission.tsx
@@ -1,13 +1,13 @@
-import { Heading, Select } from "@medusajs/ui";
+import { Heading } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
 import { Form } from "../../../../../components/common/form";
 import { SwitchBox } from "../../../../../components/common/switch-box";
+import { Combobox } from "../../../../../components/inputs/combobox";
 import {
   defineTabMeta,
   useTabbedForm,
 } from "../../../../../components/tabbed-form";
-import { useDocumentDirection } from "../../../../../hooks/use-document-direction";
 import { CommissionValueFields } from "../../../common/components/commission-value-fields";
 import { useStoreCurrencies } from "../../../common/hooks/use-store-currencies";
 import { CreateCommissionRuleSchemaType } from "./schema";
@@ -15,10 +15,14 @@ import { CreateCommissionRuleSchemaType } from "./schema";
 export const CreateCommissionRuleCommission = () => {
   const { t } = useTranslation();
   const form = useTabbedForm<CreateCommissionRuleSchemaType>();
-  const direction = useDocumentDirection();
   const { currencies } = useStoreCurrencies();
 
   const commissionType = form.watch("commissionType");
+
+  const typeOptions = [
+    { value: "percentage", label: t("commissions.fields.type.percentage") },
+    { value: "fixed", label: t("commissions.fields.type.fixed") },
+  ];
 
   return (
     <div className="flex flex-col items-center p-16">
@@ -28,28 +32,18 @@ export const CreateCommissionRuleCommission = () => {
           <Form.Field
             control={form.control}
             name="commissionType"
-            render={({ field: { onChange, ref, ...field } }) => (
+            render={({ field }) => (
               <Form.Item>
                 <Form.Label>
                   {t("commissions.fields.type.label")}
                 </Form.Label>
                 <Form.Control>
-                  <Select {...field} onValueChange={onChange} dir={direction}>
-                    <Select.Trigger
-                      ref={ref}
-                      data-testid="commission-rule-commission-type-select"
-                    >
-                      <Select.Value />
-                    </Select.Trigger>
-                    <Select.Content>
-                      <Select.Item value="percentage">
-                        {t("commissions.fields.type.percentage")}
-                      </Select.Item>
-                      <Select.Item value="fixed">
-                        {t("commissions.fields.type.fixed")}
-                      </Select.Item>
-                    </Select.Content>
-                  </Select>
+                  <Combobox
+                    {...field}
+                    options={typeOptions}
+                    forceHideInput
+                    data-testid="commission-rule-commission-type-select"
+                  />
                 </Form.Control>
                 <Form.ErrorMessage />
               </Form.Item>

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
@@ -1,4 +1,4 @@
-import { Heading, Input, Select } from "@medusajs/ui";
+import { Heading, Input } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
 import { Combobox } from "../../../../../components/inputs/combobox";
@@ -7,17 +7,32 @@ import { defineTabMeta } from "../../../../../components/tabbed-form";
 import { useTabbedForm } from "../../../../../components/tabbed-form";
 import { useComboboxData } from "../../../../../hooks/use-combobox-data";
 import { sdk } from "../../../../../lib/client";
-import { useDocumentDirection } from "../../../../../hooks/use-document-direction";
 import { SCOPE_TYPE_DIMENSIONS } from "../../../common/types";
 import { CreateCommissionRuleSchemaType } from "./schema";
 
 export const CreateCommissionRuleDetails = () => {
   const { t } = useTranslation();
   const form = useTabbedForm<CreateCommissionRuleSchemaType>();
-  const direction = useDocumentDirection();
 
   const scopeType = form.watch("scopeType");
   const dimensions = SCOPE_TYPE_DIMENSIONS[scopeType];
+
+  const scopeTypeOptions = [
+    { value: "store", label: t("commissions.fields.scopeType.store") },
+    {
+      value: "product_type",
+      label: t("commissions.fields.scopeType.productType"),
+    },
+    { value: "category", label: t("commissions.fields.scopeType.category") },
+    {
+      value: "store_product_type",
+      label: t("commissions.fields.scopeType.storeProductType"),
+    },
+    {
+      value: "store_category",
+      label: t("commissions.fields.scopeType.storeCategory"),
+    },
+  ];
 
   const stores = useComboboxData({
     queryKey: ["commission_stores"],
@@ -70,37 +85,18 @@ export const CreateCommissionRuleDetails = () => {
         <Form.Field
           control={form.control}
           name="scopeType"
-          render={({ field: { onChange, ref, ...field } }) => (
+          render={({ field }) => (
             <Form.Item>
               <Form.Label>
                 {t("commissions.fields.scopeType.label")}
               </Form.Label>
               <Form.Control>
-                <Select {...field} onValueChange={onChange} dir={direction}>
-                  <Select.Trigger
-                    ref={ref}
-                    data-testid="commission-rule-scope-type-select"
-                  >
-                    <Select.Value />
-                  </Select.Trigger>
-                  <Select.Content>
-                    <Select.Item value="store">
-                      {t("commissions.fields.scopeType.store")}
-                    </Select.Item>
-                    <Select.Item value="product_type">
-                      {t("commissions.fields.scopeType.productType")}
-                    </Select.Item>
-                    <Select.Item value="category">
-                      {t("commissions.fields.scopeType.category")}
-                    </Select.Item>
-                    <Select.Item value="store_product_type">
-                      {t("commissions.fields.scopeType.storeProductType")}
-                    </Select.Item>
-                    <Select.Item value="store_category">
-                      {t("commissions.fields.scopeType.storeCategory")}
-                    </Select.Item>
-                  </Select.Content>
-                </Select>
+                <Combobox
+                  {...field}
+                  options={scopeTypeOptions}
+                  forceHideInput
+                  data-testid="commission-rule-scope-type-select"
+                />
               </Form.Control>
               <Form.ErrorMessage />
             </Form.Item>

--- a/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
@@ -1,14 +1,14 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Heading, Input, Select, toast } from "@medusajs/ui";
+import { Button, Heading, Input, toast } from "@medusajs/ui";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
 
 import { Form } from "../../../components/common/form";
 import { SwitchBox } from "../../../components/common/switch-box";
+import { Combobox } from "../../../components/inputs/combobox";
 import { RouteDrawer, useRouteModal } from "../../../components/modals";
 import { KeyboundForm } from "../../../components/utilities/keybound-form";
-import { useDocumentDirection } from "../../../hooks/use-document-direction";
 import {
   useDefaultCommission,
   useUpdateCommissionRule,
@@ -43,8 +43,12 @@ const EditGlobalCommissionSchema = zod
 const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
   const { t } = useTranslation();
   const { handleSuccess } = useRouteModal();
-  const direction = useDocumentDirection();
   const { currencies } = useStoreCurrencies();
+
+  const typeOptions = [
+    { value: "percentage", label: t("commissions.fields.type.percentage") },
+    { value: "fixed", label: t("commissions.fields.type.fixed") },
+  ];
 
   const form = useForm<zod.infer<typeof EditGlobalCommissionSchema>>({
     defaultValues: {
@@ -113,28 +117,18 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
             <Form.Field
               control={form.control}
               name="type"
-              render={({ field: { onChange, ref, ...field } }) => (
+              render={({ field }) => (
                 <Form.Item>
                   <Form.Label>
                     {t("commissions.fields.type.label")}
                   </Form.Label>
                   <Form.Control>
-                    <Select {...field} onValueChange={onChange} dir={direction}>
-                      <Select.Trigger
-                        ref={ref}
-                        data-testid="global-commission-type-select"
-                      >
-                        <Select.Value />
-                      </Select.Trigger>
-                      <Select.Content>
-                        <Select.Item value="percentage">
-                          {t("commissions.fields.type.percentage")}
-                        </Select.Item>
-                        <Select.Item value="fixed">
-                          {t("commissions.fields.type.fixed")}
-                        </Select.Item>
-                      </Select.Content>
-                    </Select>
+                    <Combobox
+                      {...field}
+                      options={typeOptions}
+                      forceHideInput
+                      data-testid="global-commission-type-select"
+                    />
                   </Form.Control>
                   <Form.ErrorMessage />
                 </Form.Item>


### PR DESCRIPTION
## What

Replaces the `@medusajs/ui` `Select` dropdowns in the admin commission forms with the searchable `Combobox` component (the same one used in product-create's organize tab), for consistency with the rest of the admin UI.

## Changed fields

| File | Field |
|------|-------|
| `create-commission-rule-commission.tsx` | **Type** (percentage / fixed) |
| `commission-rule-commission-edit.tsx` | **Type** (percentage / fixed) |
| `global-commission-edit.tsx` | **Type** (percentage / fixed) |
| `create-commission-rule-details.tsx` | **Scope type** (store / product type / category / store+product type / store+category) |

## Details

- Each select is now a `<Combobox>` driven by a static `options` array using the existing `t(...)` labels.
- `forceHideInput` is set since these are small fixed lists (no query/filter), giving a clean dropdown experience.
- Removed the now-unused `Select` import and `useDocumentDirection`/`direction` (the Combobox handles RTL internally).
- The data-driven Comboboxes already present in the details form (stores, product types, categories) are unchanged.

No new type errors introduced (the pre-existing tsc errors in these files are unrelated to this change).