### PR TITLE
fix(vendor): use "Remove customer" heading on customer-group removal prompt

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -5127,6 +5127,9 @@
             "label": {
               "type": "string"
             },
+            "removeTitle": {
+              "type": "string"
+            },
             "remove": {
               "type": "string"
             },
@@ -5213,6 +5216,7 @@
           },
           "required": [
             "label",
+            "removeTitle",
             "remove",
             "removeMany",
             "alreadyAddedTooltip",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1244,6 +1244,7 @@
     },
     "groups": {
       "label": "Customer groups",
+      "removeTitle": "Remove customer",
       "remove": "You are about to remove customer from {{name}} group. This action cannot be undone.",
       "removeMany": "You are about to remove customer from {{groups}} groups. This action cannot be undone.",
       "alreadyAddedTooltip": "The customer is already in this customer group.",

--- a/packages/vendor/src/pages/customers/[id]/_components/customer-group-section/customer-group-section.tsx
+++ b/packages/vendor/src/pages/customers/[id]/_components/customer-group-section/customer-group-section.tsx
@@ -117,7 +117,7 @@ export const CustomerGroupSection = ({
     const isSingle = selectedGroups.length === 1
 
     const res = await prompt({
-      title: t("general.areYouSure"),
+      title: t("customers.groups.removeTitle"),
       description: isSingle
         ? t("customers.groups.remove", { name: names[0] })
         : t("customers.groups.removeMany", { groups: names.join(", ") }),
@@ -209,7 +209,7 @@ const CustomerGroupRowActions = ({
 
   const onRemove = async () => {
     const res = await prompt({
-      title: t("general.areYouSure"),
+      title: t("customers.groups.removeTitle"),
       description: t("customers.groups.remove", {
         name: group.name,
       }),


### PR DESCRIPTION
## Summary
- The customer-group removal confirmation prompt in the vendor panel showed the generic "Are you sure?" title. It now uses a dedicated **"Remove customer"** heading.
- Applied at both call sites in `customer-group-section.tsx` — the bulk "remove selected" command and the per-row action menu.
- Added the `customers.groups.removeTitle` key to the vendor `en.json` translations and `$schema.json`.

## Linear
[MER-209](https://linear.app/rigbyjs/issue/MER-209/customers-vendor-panel-remove-customer-from-group)

## Test plan
- [ ] Vendor panel → Customers → open a customer with group memberships → remove a group (row action and bulk select): the confirmation prompt heading reads "Remove customer" with the existing supporting copy unchanged.