### PR TITLE
fix(admin): require code on commission rule create

### DIFF
--- a/integration-tests/http/commission-rates/admin/commission-rates.spec.ts
+++ b/integration-tests/http/commission-rates/admin/commission-rates.spec.ts
@@ -698,7 +698,7 @@ medusaIntegrationTestRunner({
           expect(response.status).toEqual(400)
         })
 
-        it("should auto-generate a unique code when none is provided", async () => {
+        it("should require code field", async () => {
           const response = await api.post(
             `/admin/commission-rates`,
             {
@@ -707,28 +707,9 @@ medusaIntegrationTestRunner({
               value: 10,
             },
             adminHeaders
-          )
+          ).catch((e) => e.response)
 
-          expect(response.status).toEqual(201)
-          expect(response.data.commission_rate.code).toEqual(
-            expect.stringMatching(/^no-code-rate-[a-z0-9]+$/)
-          )
-
-          // A second rate with the same name still gets a distinct code.
-          const second = await api.post(
-            `/admin/commission-rates`,
-            {
-              name: "No Code Rate",
-              type: "percentage",
-              value: 10,
-            },
-            adminHeaders
-          )
-
-          expect(second.status).toEqual(201)
-          expect(second.data.commission_rate.code).not.toEqual(
-            response.data.commission_rate.code
-          )
+          expect(response.status).toEqual(400)
         })
 
         it("should require type field", async () => {

--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -14729,13 +14729,46 @@
             },
             "successToast": {
               "type": "string"
+            },
+            "validation": {
+              "type": "object",
+              "properties": {
+                "titleRequired": {
+                  "type": "string"
+                },
+                "codeRequired": {
+                  "type": "string"
+                },
+                "storesRequired": {
+                  "type": "string"
+                },
+                "productTypesRequired": {
+                  "type": "string"
+                },
+                "categoriesRequired": {
+                  "type": "string"
+                },
+                "valueRequired": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "titleRequired",
+                "codeRequired",
+                "storesRequired",
+                "productTypesRequired",
+                "categoriesRequired",
+                "valueRequired"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
             "header",
             "details",
             "commission",
-            "successToast"
+            "successToast",
+            "validation"
           ],
           "additionalProperties": false
         },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3859,7 +3859,15 @@
       "header": "Create Commission Rule",
       "details": "Details",
       "commission": "Commission",
-      "successToast": "Commission rule was successfully created."
+      "successToast": "Commission rule was successfully created.",
+      "validation": {
+        "titleRequired": "Please enter a title",
+        "codeRequired": "Please enter a code",
+        "storesRequired": "Please select at least one store",
+        "productTypesRequired": "Please select at least one product type",
+        "categoriesRequired": "Please select at least one category",
+        "valueRequired": "Please enter a value."
+      }
     },
     "edit": {
       "header": "Edit Commission Rule",

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
@@ -84,6 +84,23 @@ export const CreateCommissionRuleDetails = () => {
         />
         <Form.Field
           control={form.control}
+          name="code"
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label optional>{t("commissions.fields.code")}</Form.Label>
+              <Form.Control>
+                <Input
+                  autoComplete="off"
+                  data-testid="commission-rule-code-input"
+                  {...field}
+                />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={form.control}
           name="scopeType"
           render={({ field }) => (
             <Form.Item>
@@ -113,11 +130,13 @@ export const CreateCommissionRuleDetails = () => {
                 </Form.Label>
                 <Form.Control>
                   <Combobox
+                    {...field}
+                    value={field.value ?? []}
                     options={stores.options}
-                    fetchNextPage={stores.fetchNextPage}
                     searchValue={stores.searchValue}
                     onSearchValueChange={stores.onSearchValueChange}
-                    {...field}
+                    fetchNextPage={stores.fetchNextPage}
+                    data-testid="commission-rule-stores-input"
                   />
                 </Form.Control>
                 <Form.ErrorMessage />
@@ -136,11 +155,13 @@ export const CreateCommissionRuleDetails = () => {
                 </Form.Label>
                 <Form.Control>
                   <Combobox
+                    {...field}
+                    value={field.value ?? []}
                     options={productTypes.options}
-                    fetchNextPage={productTypes.fetchNextPage}
                     searchValue={productTypes.searchValue}
                     onSearchValueChange={productTypes.onSearchValueChange}
-                    {...field}
+                    fetchNextPage={productTypes.fetchNextPage}
+                    data-testid="commission-rule-product-types-input"
                   />
                 </Form.Control>
                 <Form.ErrorMessage />
@@ -159,11 +180,13 @@ export const CreateCommissionRuleDetails = () => {
                 </Form.Label>
                 <Form.Control>
                   <Combobox
+                    {...field}
+                    value={field.value ?? []}
                     options={categories.options}
-                    fetchNextPage={categories.fetchNextPage}
                     searchValue={categories.searchValue}
                     onSearchValueChange={categories.onSearchValueChange}
-                    {...field}
+                    fetchNextPage={categories.fetchNextPage}
+                    data-testid="commission-rule-categories-input"
                   />
                 </Form.Control>
                 <Form.ErrorMessage />

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-details.tsx
@@ -87,7 +87,7 @@ export const CreateCommissionRuleDetails = () => {
           name="code"
           render={({ field }) => (
             <Form.Item>
-              <Form.Label optional>{t("commissions.fields.code")}</Form.Label>
+              <Form.Label>{t("commissions.fields.code")}</Form.Label>
               <Form.Control>
                 <Input
                   autoComplete="off"
@@ -206,6 +206,7 @@ CreateCommissionRuleDetails._tabMeta = defineTabMeta<CreateCommissionRuleSchemaT
     labelKey: "commissions.create.details",
     validationFields: [
       "title",
+      "code",
       "scopeType",
       "stores",
       "productTypes",

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
@@ -51,7 +51,7 @@ export const CreateCommissionRuleForm = () => {
     await mutateAsync(
       {
         name: values.title,
-        ...(values.code ? { code: values.code } : {}),
+        code: values.code,
         type: values.commissionType,
         value: isFixed ? 0 : values.value,
         ...(isFixed

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
@@ -23,6 +23,7 @@ export const CreateCommissionRuleForm = () => {
   const form = useForm<CreateCommissionRuleSchemaType>({
     defaultValues: {
       title: "",
+      code: "",
       scopeType: "store",
       stores: [],
       productTypes: [],
@@ -50,6 +51,7 @@ export const CreateCommissionRuleForm = () => {
     await mutateAsync(
       {
         name: values.title,
+        ...(values.code ? { code: values.code } : {}),
         type: values.commissionType,
         value: isFixed ? 0 : values.value,
         ...(isFixed

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
@@ -1,11 +1,16 @@
+import i18n from "i18next";
 import * as zod from "zod";
 
 import { SCOPE_TYPE_DIMENSIONS } from "../../../common/types";
 
 export const CreateCommissionRuleSchema = zod
   .object({
-    title: zod.string().min(1, "Please enter a title"),
-    code: zod.string().optional(),
+    title: zod
+      .string()
+      .min(1, { message: i18n.t("commissions.create.validation.titleRequired") }),
+    code: zod
+      .string()
+      .min(1, { message: i18n.t("commissions.create.validation.codeRequired") }),
     scopeType: zod.enum([
       "store",
       "product_type",
@@ -29,14 +34,14 @@ export const CreateCommissionRuleSchema = zod
       ctx.addIssue({
         code: zod.ZodIssueCode.custom,
         path: ["stores"],
-        message: "Please select at least one store",
+        message: i18n.t("commissions.create.validation.storesRequired"),
       });
     }
     if (dimensions.includes("product_type") && data.productTypes.length === 0) {
       ctx.addIssue({
         code: zod.ZodIssueCode.custom,
         path: ["productTypes"],
-        message: "Please select at least one product type",
+        message: i18n.t("commissions.create.validation.productTypesRequired"),
       });
     }
     if (
@@ -46,7 +51,7 @@ export const CreateCommissionRuleSchema = zod
       ctx.addIssue({
         code: zod.ZodIssueCode.custom,
         path: ["categories"],
-        message: "Please select at least one category",
+        message: i18n.t("commissions.create.validation.categoriesRequired"),
       });
     }
     if (
@@ -56,7 +61,7 @@ export const CreateCommissionRuleSchema = zod
       ctx.addIssue({
         code: zod.ZodIssueCode.custom,
         path: ["value"],
-        message: "Please enter a value.",
+        message: i18n.t("commissions.create.validation.valueRequired"),
       });
     }
   });

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
@@ -5,6 +5,7 @@ import { SCOPE_TYPE_DIMENSIONS } from "../../../common/types";
 export const CreateCommissionRuleSchema = zod
   .object({
     title: zod.string().min(1, "Please enter a title"),
+    code: zod.string().optional(),
     scopeType: zod.enum([
       "store",
       "product_type",

--- a/packages/core/src/api/admin/commission-rates/route.ts
+++ b/packages/core/src/api/admin/commission-rates/route.ts
@@ -38,8 +38,6 @@ export const POST = async (
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  // `code` is auto-generated in CommissionModuleService.createCommissionRates
-  // when omitted, so the body flows straight through.
   const { result } = await createCommissionRatesWorkflow(req.scope).run({
     input: [req.validatedBody],
   })

--- a/packages/core/src/api/admin/commission-rates/validators.ts
+++ b/packages/core/src/api/admin/commission-rates/validators.ts
@@ -50,8 +50,7 @@ export type AdminCreateCommissionRateType = z.infer<
 >
 export const AdminCreateCommissionRate = z.object({
   name: z.string(),
-  // Optional: when omitted, the route generates a unique code from the name.
-  code: z.string().optional(),
+  code: z.string().min(1),
   type: z.nativeEnum(CommissionRateType),
   value: z.number(),
   currency_code: z.string().nullish(),


### PR DESCRIPTION
## Summary

The commission rule **code** field had been dropped from the create wizard, leaving creation in a broken state. This restores it as a **required** field on both the admin UI and the backend create validator.

## Changes

**Admin (`commission-rule-create`)**
- Re-add the `code` field to the Details tab (required, validated on the tab).
- Route schema validation messages through i18n (`commissions.create.validation.*`) instead of hardcoded strings; converted the existing title/stores/types/categories/value messages too.
- Align the store / product type / category comboboxes to the `product-create` pattern (`{...field}` first + explicit `value={field.value ?? []}`) so they render as multi-select chip comboboxes.

**Core (`/admin/commission-rates`)**
- `AdminCreateCommissionRate.code` is now required (`z.string().min(1)`).

**Tests**
- `commission-rates.spec.ts`: the create-without-code case now expects `400` (code required).

## Verification

- `bunx tsc -p packages/admin/tsconfig.json --noEmit` — no new errors (pre-existing count unchanged at 679).
- Core type-check clean for `commission-rates`.
- i18n schema/en.json kept in sync (`commissions.create.validation` added to both `en.json` and `$schema.json`).

Refs MER-239