### PR TITLE
fix(admin): show "Please enter a code" validation on commission code field

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -14791,6 +14791,22 @@
           ],
           "additionalProperties": false
         },
+        "validation": {
+          "type": "object",
+          "properties": {
+            "codeRequired": {
+              "type": "string"
+            },
+            "valueRequired": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "codeRequired",
+            "valueRequired"
+          ],
+          "additionalProperties": false
+        },
         "fields": {
           "type": "object",
           "properties": {

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3874,6 +3874,10 @@
       "description": "You are about to delete commission rule {{name}}. This action cannot be undone.",
       "successToast": "Commission rule was successfully deleted."
     },
+    "validation": {
+      "codeRequired": "Please enter a code",
+      "valueRequired": "Please enter a value."
+    },
     "fields": {
       "code": "Code",
       "value": "Value",

--- a/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Heading, Input, Select, toast } from "@medusajs/ui";
+import i18n from "i18next";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
@@ -28,7 +29,9 @@ import {
 const EditCommissionRuleSchema = zod.object({
   status: zod.enum(["active", "inactive"]),
   name: zod.string().min(1),
-  code: zod.string().min(1, "Please enter a code"),
+  code: zod
+    .string()
+    .min(1, { message: i18n.t("commissions.validation.codeRequired") }),
   scopeType: zod.enum([
     "store",
     "product_type",

--- a/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
@@ -28,7 +28,7 @@ import {
 const EditCommissionRuleSchema = zod.object({
   status: zod.enum(["active", "inactive"]),
   name: zod.string().min(1),
-  code: zod.string().min(1),
+  code: zod.string().min(1, "Please enter a code"),
   scopeType: zod.enum([
     "store",
     "product_type",

--- a/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
@@ -20,7 +20,7 @@ import { buildValuesPayload, fixedValuesFromRate } from "../common/utils";
 
 const EditGlobalCommissionSchema = zod
   .object({
-    code: zod.string().min(1),
+    code: zod.string().min(1, "Please enter a code"),
     type: zod.enum(["percentage", "fixed"]),
     value: zod.coerce.number().optional(),
     fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),

--- a/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Heading, Input, toast } from "@medusajs/ui";
+import i18n from "i18next";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
@@ -20,7 +21,9 @@ import { buildValuesPayload, fixedValuesFromRate } from "../common/utils";
 
 const EditGlobalCommissionSchema = zod
   .object({
-    code: zod.string().min(1, "Please enter a code"),
+    code: zod
+      .string()
+      .min(1, { message: i18n.t("commissions.validation.codeRequired") }),
     type: zod.enum(["percentage", "fixed"]),
     value: zod.coerce.number().optional(),
     fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
@@ -35,7 +38,7 @@ const EditGlobalCommissionSchema = zod
       ctx.addIssue({
         code: zod.ZodIssueCode.custom,
         path: ["value"],
-        message: "Please enter a value.",
+        message: i18n.t("commissions.validation.valueRequired"),
       });
     }
   });


### PR DESCRIPTION
## Summary
- The commission `code` field used a bare `min(1)` Zod check with no message, so an empty code surfaced Zod's default string error instead of a friendly message.
- Add `"Please enter a code"` to the `code` validation on both the global commission edit and commission rule edit forms.

## Linear
[MER-225](https://linear.app/rigbyjs/issue/MER-225) — addresses the latest review comment ("Add proper validation for code - Please enter a code").

## Test plan
- [ ] Open a commission rule / global commission edit form, clear the code field, submit → "Please enter a code" appears under the field.
- [ ] `bun run lint`
- [ ] `bun run build`