### PR TITLE
fix(admin): localized value validation on commission rule create step 2

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -15059,6 +15059,34 @@
             "disabled"
           ],
           "additionalProperties": false
+        },
+        "validation": {
+          "type": "object",
+          "properties": {
+            "titleRequired": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            },
+            "storesRequired": {
+              "type": "string"
+            },
+            "productTypesRequired": {
+              "type": "string"
+            },
+            "categoriesRequired": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "titleRequired",
+            "value",
+            "storesRequired",
+            "productTypesRequired",
+            "categoriesRequired"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
@@ -15069,7 +15097,8 @@
         "fields",
         "global",
         "rules",
-        "status"
+        "status",
+        "validation"
       ],
       "additionalProperties": false
     },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3939,6 +3939,13 @@
     "status": {
       "enabled": "Active",
       "disabled": "Inactive"
+    },
+    "validation": {
+      "titleRequired": "Please enter a title",
+      "value": "Please enter a value",
+      "storesRequired": "Please select at least one store",
+      "productTypesRequired": "Please select at least one product type",
+      "categoriesRequired": "Please select at least one category"
     }
   },
   "commissionRates": {

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "@medusajs/ui";
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
@@ -11,7 +12,7 @@ import { buildRulesFromScope, buildValuesPayload } from "../../../common/utils";
 import { CreateCommissionRuleCommission } from "./create-commission-rule-commission";
 import { CreateCommissionRuleDetails } from "./create-commission-rule-details";
 import {
-  CreateCommissionRuleSchema,
+  createCommissionRuleSchema,
   CreateCommissionRuleSchemaType,
 } from "./schema";
 
@@ -19,6 +20,11 @@ export const CreateCommissionRuleForm = () => {
   const { t } = useTranslation();
   const { handleSuccess } = useRouteModal();
   const { currencies } = useStoreCurrencies();
+
+  const resolver = useMemo(
+    () => zodResolver(createCommissionRuleSchema(currencies)),
+    [currencies]
+  );
 
   const form = useForm<CreateCommissionRuleSchemaType>({
     defaultValues: {
@@ -33,7 +39,7 @@ export const CreateCommissionRuleForm = () => {
       include_tax: false,
       include_shipping: false,
     },
-    resolver: zodResolver(CreateCommissionRuleSchema),
+    resolver,
   });
 
   const { mutateAsync, isPending } = useCreateCommissionRule();

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
@@ -1,41 +1,45 @@
+import i18n from "i18next";
 import * as zod from "zod";
 
 import { SCOPE_TYPE_DIMENSIONS } from "../../../common/types";
 
-export const CreateCommissionRuleSchema = zod
-  .object({
-    title: zod.string().min(1, "Please enter a title"),
-    scopeType: zod.enum([
-      "store",
-      "product_type",
-      "category",
-      "store_product_type",
-      "store_category",
-    ]),
-    stores: zod.array(zod.string()),
-    productTypes: zod.array(zod.string()),
-    categories: zod.array(zod.string()),
-    commissionType: zod.enum(["percentage", "fixed"]),
-    value: zod.coerce.number().optional(),
-    fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
-    include_tax: zod.boolean(),
-    include_shipping: zod.boolean(),
-  })
-  .superRefine((data, ctx) => {
+const baseCommissionRuleSchema = zod.object({
+  title: zod
+    .string()
+    .min(1, { message: i18n.t("commissions.validation.titleRequired") }),
+  scopeType: zod.enum([
+    "store",
+    "product_type",
+    "category",
+    "store_product_type",
+    "store_category",
+  ]),
+  stores: zod.array(zod.string()),
+  productTypes: zod.array(zod.string()),
+  categories: zod.array(zod.string()),
+  commissionType: zod.enum(["percentage", "fixed"]),
+  value: zod.coerce.number().optional(),
+  fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
+  include_tax: zod.boolean(),
+  include_shipping: zod.boolean(),
+});
+
+export const createCommissionRuleSchema = (currencies: string[] = []) =>
+  baseCommissionRuleSchema.superRefine((data, ctx) => {
     const dimensions = SCOPE_TYPE_DIMENSIONS[data.scopeType];
 
     if (dimensions.includes("seller") && data.stores.length === 0) {
       ctx.addIssue({
         code: zod.ZodIssueCode.custom,
         path: ["stores"],
-        message: "Please select at least one store",
+        message: i18n.t("commissions.validation.storesRequired"),
       });
     }
     if (dimensions.includes("product_type") && data.productTypes.length === 0) {
       ctx.addIssue({
         code: zod.ZodIssueCode.custom,
         path: ["productTypes"],
-        message: "Please select at least one product type",
+        message: i18n.t("commissions.validation.productTypesRequired"),
       });
     }
     if (
@@ -45,21 +49,32 @@ export const CreateCommissionRuleSchema = zod
       ctx.addIssue({
         code: zod.ZodIssueCode.custom,
         path: ["categories"],
-        message: "Please select at least one category",
+        message: i18n.t("commissions.validation.categoriesRequired"),
       });
     }
-    if (
-      data.commissionType === "percentage" &&
-      (data.value === undefined || Number.isNaN(data.value))
-    ) {
-      ctx.addIssue({
-        code: zod.ZodIssueCode.custom,
-        path: ["value"],
-        message: "Please enter a value.",
+
+    if (data.commissionType === "percentage") {
+      if (data.value === undefined || Number.isNaN(data.value)) {
+        ctx.addIssue({
+          code: zod.ZodIssueCode.custom,
+          path: ["value"],
+          message: i18n.t("commissions.validation.value"),
+        });
+      }
+    } else {
+      currencies.forEach((code) => {
+        const amount = data.fixed_values?.[code];
+        if (amount === undefined || Number.isNaN(amount)) {
+          ctx.addIssue({
+            code: zod.ZodIssueCode.custom,
+            path: ["fixed_values", code],
+            message: i18n.t("commissions.validation.value"),
+          });
+        }
       });
     }
   });
 
 export type CreateCommissionRuleSchemaType = zod.infer<
-  typeof CreateCommissionRuleSchema
+  typeof baseCommissionRuleSchema
 >;

--- a/packages/admin/src/pages/commissions/common/components/commission-value-fields.tsx
+++ b/packages/admin/src/pages/commissions/common/components/commission-value-fields.tsx
@@ -68,7 +68,9 @@ export const CommissionValueFields = <T extends FieldValues = FieldValues>({
                     min={0}
                     code={code}
                     symbol={getCurrencySymbol(code)}
-                    onValueChange={(val) => onChange(val ? parseFloat(val) : 0)}
+                    onValueChange={(val) =>
+                    onChange(val ? parseFloat(val) : undefined)
+                  }
                     {...field}
                     value={value ?? ""}
                   />


### PR DESCRIPTION
## What

Fixes the value validation on **create commission rule, step 2** (MER-227, last review comment).

- **Percentage** commissions now require a value, showing `Please enter a value` under the field.
- **Fixed** commissions now validate every store currency (previously had no validation at all), showing `Please enter a value` under each empty currency input.
- Empty currency inputs now register as `undefined` rather than `0`, so validation actually triggers. `buildValuesPayload` already coalesces to `0`, so submitted payloads are unchanged.

## i18n

All validation messages on the create rule schema were moved off hardcoded strings onto i18n keys under a new `commissions.validation` block, added to both `en.json` and `$schema.json` so the key sets stay in sync.

## Notes

- The schema became a `createCommissionRuleSchema(t, currencies)` factory (mirrors the existing `createAttributeSchema(t)` pattern) so it can both localize messages and require a value per active currency.
- The commission tab is the last step, so its Save button runs full schema validation — the per-currency errors surface correctly.
- Out of scope here: the global-commission-edit and rule-edit drawers still use a hardcoded percentage message and lack fixed-value validation.