### PR TITLE
fix(vendor): show full breadcrumb trail on variant details page

### DIFF
--- a/packages/vendor/src/get-route-map.tsx
+++ b/packages/vendor/src/get-route-map.tsx
@@ -181,6 +181,49 @@ export function getRouteMap({
                           },
                         ],
                       },
+                      {
+                        path: "variants/:variant_id",
+                        lazy: async () => {
+                          const { loader, Breadcrumb } =
+                            await import(
+                              "./pages/product-variants/product-variant-detail"
+                            )
+                          return {
+                            Component: Outlet,
+                            loader,
+                            handle: {
+                              breadcrumb: (match: UIMatch<any>) => (
+                                <Breadcrumb {...match} />
+                              ),
+                            },
+                          }
+                        },
+                        children: [
+                          {
+                            path: "",
+                            lazy: () =>
+                              import(
+                                "./pages/product-variants/product-variant-detail"
+                              ),
+                            children: [
+                              {
+                                path: "edit",
+                                lazy: () =>
+                                  import(
+                                    "./pages/product-variants/product-variant-edit"
+                                  ),
+                              },
+                              {
+                                path: "media",
+                                lazy: () =>
+                                  import(
+                                    "./pages/product-variants/product-variant-detail/media"
+                                  ),
+                              },
+                            ],
+                          },
+                        ],
+                      },
                     ],
                   },
                 ],
@@ -1037,46 +1080,6 @@ export function getRouteMap({
               //   path: "/reservations",
               //   ...
               // },
-
-              // PRODUCT VARIANTS (standalone routes)
-              {
-                path: "/products/:product_id/variants/:variant_id",
-                errorElement: <ErrorBoundary />,
-                lazy: async () => {
-                  const { loader, Breadcrumb } =
-                    await import("./pages/product-variants/product-variant-detail");
-                  return {
-                    Component: Outlet,
-                    loader,
-                    handle: {
-                      breadcrumb: (match: UIMatch<any>) => (
-                        <Breadcrumb {...match} />
-                      ),
-                    },
-                  };
-                },
-                children: [
-                  {
-                    path: "",
-                    lazy: () =>
-                      import("./pages/product-variants/product-variant-detail"),
-                    children: [
-                      {
-                        path: "edit",
-                        lazy: () =>
-                          import("./pages/product-variants/product-variant-edit"),
-                      },
-                      {
-                        path: "media",
-                        lazy: () =>
-                          import(
-                            "./pages/product-variants/product-variant-detail/media"
-                          ),
-                      },
-                    ],
-                  },
-                ],
-              },
             ],
             customMainRoutes,
           ),

--- a/packages/vendor/src/pages/product-variants/product-variant-detail/breadcrumb.tsx
+++ b/packages/vendor/src/pages/product-variants/product-variant-detail/breadcrumb.tsx
@@ -8,15 +8,16 @@ type ProductVariantDetailBreadcrumbProps =
 export const ProductVariantDetailBreadcrumb = (
   props: ProductVariantDetailBreadcrumbProps
 ) => {
-  const { product_id, variant_id } = props.params || {}
+  const { id, product_id, variant_id } = props.params || {}
+  const productId = id || product_id
 
   const { variant } = useProductVariant(
-    product_id!,
+    productId!,
     variant_id!,
     {},
     {
       initialData: props.data,
-      enabled: Boolean(product_id) && Boolean(variant_id),
+      enabled: Boolean(productId) && Boolean(variant_id),
     }
   )
   if (!variant) {

--- a/packages/vendor/src/pages/product-variants/product-variant-detail/loader.ts
+++ b/packages/vendor/src/pages/product-variants/product-variant-detail/loader.ts
@@ -22,7 +22,7 @@ const variantDetailQuery = (productId: string, variantId: string) => ({
 export const variantLoader = async ({
   params,
 }: LoaderFunctionArgs): Promise<any> => {
-  const productId = params.product_id
+  const productId = params.id || params.product_id
   const variantId = params.variant_id
 
   const query = variantDetailQuery(productId!, variantId!)

--- a/packages/vendor/src/pages/product-variants/product-variant-detail/media/index.tsx
+++ b/packages/vendor/src/pages/product-variants/product-variant-detail/media/index.tsx
@@ -1,4 +1,4 @@
-// Route: /products/:product_id/variants/:variant_id/media
+// Route: /products/:id/variants/:variant_id/media
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 
@@ -10,10 +10,11 @@ import { EditVariantMediaForm } from "./edit-variant-media-form"
 
 export const Component = () => {
   const { t } = useTranslation()
-  const { product_id, variant_id } = useParams()
+  const { id, product_id, variant_id } = useParams()
+  const productId = id || product_id
 
   const { variant, isLoading, isError, error } = useProductVariant(
-    product_id!,
+    productId!,
     variant_id!,
     { fields: VARIANT_DETAIL_FIELDS }
   )

--- a/packages/vendor/src/pages/product-variants/product-variant-detail/product-variant-detail.tsx
+++ b/packages/vendor/src/pages/product-variants/product-variant-detail/product-variant-detail.tsx
@@ -14,9 +14,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
     ReturnType<typeof variantLoader>
   >
 
-  const { product_id, variant_id } = useParams()
+  const { id, product_id, variant_id } = useParams()
+  const productId = id || product_id
   const { variant, isLoading, isError, error } = useProductVariant(
-    product_id!,
+    productId!,
     variant_id!,
     { fields: VARIANT_DETAIL_FIELDS },
     {


### PR DESCRIPTION
## Summary
- The vendor variant details page was registered as a **standalone** top-level route (`/products/:product_id/variants/:variant_id`), so `useMatches()` returned only that one route and the breadcrumb rendered just the variant title (e.g. `M / Blue`) — "the current page" only.
- Nested the variant route under `/products/:id` (mirroring the admin panel), so the breadcrumb chain now accumulates **Products › Product Name › Variant**.
- Updated the detail page, breadcrumb, loader, and media route to read the product id from the `:id` param (with a `product_id` fallback for safety). The generated URLs are unchanged.

## Linear
[MER-137](https://linear.app/rigbyjs/issue/MER-137) — follow-up to merged PRs #969 and #1058. Addresses review feedback: "Not fixed. It shows only the current page."

## Test plan
- [ ] Open a product in the vendor panel → open a variant. Breadcrumb shows `Products › <Product> › <Variant>` and the first two segments are clickable.
- [ ] Variant `edit` drawer and `media` modal still open from the variant page.
- [x] `bun run build` (vendor + types) passes, incl. DTS typecheck
- [x] `oxlint` clean on changed files