### PR TITLE
fix(vendor): show update-requested toast for product attribute and variant changes

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -1842,6 +1842,18 @@
             "attributes": {
               "type": "object",
               "properties": {
+                "createSuccessToast": {
+                  "type": "string"
+                },
+                "addSuccessToast": {
+                  "type": "string"
+                },
+                "updateSuccessToast": {
+                  "type": "string"
+                },
+                "deleteSuccessToast": {
+                  "type": "string"
+                },
                 "addAttribute": {
                   "type": "string"
                 },
@@ -1874,6 +1886,10 @@
                 }
               },
               "required": [
+                "createSuccessToast",
+                "addSuccessToast",
+                "updateSuccessToast",
+                "deleteSuccessToast",
                 "addAttribute",
                 "editHeader",
                 "required",
@@ -3392,10 +3408,14 @@
               "properties": {
                 "header": {
                   "type": "string"
+                },
+                "successToast": {
+                  "type": "string"
                 }
               },
               "required": [
-                "header"
+                "header",
+                "successToast"
               ],
               "additionalProperties": false
             },

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -832,7 +832,7 @@
       },
       "edit": {
         "header": "Edit Variant",
-        "success": "Product variant edited successfully",
+        "success": "Product update was successfully requested. Once confirmed by the Admin, changes will appear on the storefront.",
         "attributesTooltip": "These are default values used to describe the item. They are not defined by Marketplace."
       },
       "create": {

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -453,6 +453,10 @@
       "requestSuccessToast": "Product update was successfully requested. Once confirmed by the Admin, changes will appear on the storefront.",
       "duplicateRequestErrorToast": "You already have an active request. You can only have one at a time.",
       "attributes": {
+        "createSuccessToast": "Attribute was successfully created.",
+        "addSuccessToast": "Attributes were successfully added.",
+        "updateSuccessToast": "Attribute was successfully updated.",
+        "deleteSuccessToast": "Attribute was successfully deleted.",
         "addAttribute": "Add Attribute",
         "editHeader": "Edit Attribute",
         "required": "Required attribute",
@@ -832,11 +836,12 @@
       },
       "edit": {
         "header": "Edit Variant",
-        "success": "Product update was successfully requested. Once confirmed by the Admin, changes will appear on the storefront.",
+        "success": "Variant was successfully updated.",
         "attributesTooltip": "These are default values used to describe the item. They are not defined by Marketplace."
       },
       "create": {
-        "header": "Variant details"
+        "header": "Variant details",
+        "successToast": "Variant was successfully created."
       },
       "deleteWarning": "Are you sure you want to delete this variant?",
       "tableItemAvailable": "{{availableCount}} available",

--- a/packages/vendor/src/pages/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
+++ b/packages/vendor/src/pages/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
@@ -7,13 +7,14 @@ import { useTranslation } from "react-i18next"
 import { z } from "zod"
 
 import { HttpTypes } from "@medusajs/types"
-import { ProductDTO, AttributeType } from "@mercurjs/types"
+import { ProductDTO, AttributeType, MercurFeatureFlags } from "@mercurjs/types"
 
 import { Form } from "@components/common/form"
 import { AttributeValueInput } from "@components/inputs/attribute-value-input"
 import { CountrySelect } from "@components/inputs/country-select"
 import { RouteDrawer, useRouteModal } from "@components/modals"
 import { KeyboundForm } from "@components/utilities/keybound-form"
+import { useFeatureFlags } from "@hooks/api"
 import { useUpdateProductVariant } from "@hooks/api/products"
 import {
   transformNullableFormData,
@@ -50,6 +51,10 @@ export const ProductEditVariantForm = ({
 }: ProductEditVariantFormProps) => {
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
+
+  const { feature_flags } = useFeatureFlags()
+  const isProductRequestEnabled =
+    !!feature_flags?.[MercurFeatureFlags.PRODUCT_REQUEST]
 
   const variantAttributes =
     (product as HttpTypes.AdminProduct & Pick<ProductDTO, "attributes">)
@@ -136,7 +141,11 @@ export const ProductEditVariantForm = ({
       {
         onSuccess: () => {
           handleSuccess("../")
-          toast.success(t("products.variant.edit.success"))
+          toast.success(
+            isProductRequestEnabled
+              ? t("products.edit.requestSuccessToast")
+              : t("products.variant.edit.success"),
+          )
         },
         onError: (error) => {
           toast.error(error.message)

--- a/packages/vendor/src/pages/products/[id]/_components/product-attribute-section/product-attribute-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-attribute-section/product-attribute-section.tsx
@@ -19,7 +19,12 @@ import {
 import { useTranslation } from "react-i18next";
 
 import { ActionMenu } from "@components/common/action-menu";
-import { ProductAttributeDTO, ProductDTO } from "@mercurjs/types";
+import {
+  MercurFeatureFlags,
+  ProductAttributeDTO,
+  ProductDTO,
+} from "@mercurjs/types";
+import { useFeatureFlags } from "@hooks/api";
 import { useRemoveProductAttribute } from "@hooks/api/products";
 
 type ProductWithAttributes = Pick<ProductDTO, "id" | "attributes">;
@@ -33,6 +38,9 @@ const AttributeActions = ({
 }) => {
   const { t } = useTranslation();
   const prompt = usePrompt();
+  const { feature_flags } = useFeatureFlags();
+  const isProductRequestEnabled =
+    !!feature_flags?.[MercurFeatureFlags.PRODUCT_REQUEST];
   const { mutateAsync } = useRemoveProductAttribute(productId, attribute.id);
 
   const handleDelete = async () => {
@@ -51,7 +59,11 @@ const AttributeActions = ({
 
     await mutateAsync(undefined, {
       onSuccess: () => {
-        toast.success(t("products.edit.requestSuccessToast"));
+        toast.success(
+          isProductRequestEnabled
+            ? t("products.edit.requestSuccessToast")
+            : t("products.edit.attributes.deleteSuccessToast"),
+        );
       },
       onError: (error) => {
         toast.error(error.message);

--- a/packages/vendor/src/pages/products/[id]/_components/product-attribute-section/product-attribute-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-attribute-section/product-attribute-section.tsx
@@ -50,6 +50,9 @@ const AttributeActions = ({
     }
 
     await mutateAsync(undefined, {
+      onSuccess: () => {
+        toast.success(t("products.edit.requestSuccessToast"));
+      },
       onError: (error) => {
         toast.error(error.message);
       },

--- a/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
@@ -80,7 +80,10 @@ export const EditAttributeForm = ({
       : { values: vals }
 
     await mutateAsync(payload, {
-      onSuccess: () => handleSuccess(),
+      onSuccess: () => {
+        handleSuccess()
+        toast.success(t("products.edit.requestSuccessToast"))
+      },
       onError: (error) => toast.error(error.message),
     })
   })

--- a/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Button, Input, Label, toast } from "@medusajs/ui"
-import { AttributeType } from "@mercurjs/types"
+import { AttributeType, MercurFeatureFlags } from "@mercurjs/types"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
@@ -9,6 +9,7 @@ import { AttributeValueInput } from "@components/inputs/attribute-value-input"
 import { Form } from "@components/common/form"
 import { RouteDrawer, useRouteModal } from "@components/modals"
 import { KeyboundForm } from "@components/utilities/keybound-form"
+import { useFeatureFlags } from "@hooks/api"
 import { useUpdateProductAttribute } from "@hooks/api/products"
 
 type AttributeValue = { id: string; name: string }
@@ -34,6 +35,10 @@ export const EditAttributeForm = ({
 }: EditAttributeFormProps) => {
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
+
+  const { feature_flags } = useFeatureFlags()
+  const isProductRequestEnabled =
+    !!feature_flags?.[MercurFeatureFlags.PRODUCT_REQUEST]
 
   const hasPresetValues =
     attribute.type === AttributeType.SINGLE_SELECT ||
@@ -82,7 +87,11 @@ export const EditAttributeForm = ({
     await mutateAsync(payload, {
       onSuccess: () => {
         handleSuccess()
-        toast.success(t("products.edit.requestSuccessToast"))
+        toast.success(
+          isProductRequestEnabled
+            ? t("products.edit.requestSuccessToast")
+            : t("products.edit.attributes.updateSuccessToast"),
+        )
       },
       onError: (error) => toast.error(error.message),
     })

--- a/packages/vendor/src/pages/products/[id]/attributes/add/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/add/index.tsx
@@ -13,7 +13,11 @@ import {
   Text,
   toast,
 } from "@medusajs/ui"
-import { ProductAttributeDTO, AttributeType } from "@mercurjs/types"
+import {
+  ProductAttributeDTO,
+  AttributeType,
+  MercurFeatureFlags,
+} from "@mercurjs/types"
 import { useEffect, useMemo, useState } from "react"
 import { useFieldArray, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -28,6 +32,7 @@ import { Form } from "@components/common/form"
 import { RouteFocusModal, useRouteModal } from "@components/modals"
 import { KeyboundForm } from "@components/utilities/keybound-form"
 import { useProductAttributes } from "@hooks/api/product-attributes"
+import { useFeatureFlags } from "@hooks/api"
 import { useBatchProductAttributes, useProduct } from "@hooks/api/products"
 import { useAttributeTableQuery } from "@hooks/table/query/use-attribute-table-query"
 import { useAttributeTableFilters } from "@hooks/table/filters/use-attribute-table-filters"
@@ -84,6 +89,10 @@ export const Component = () => {
 const Content = ({ productId }: { productId: string }) => {
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
+
+  const { feature_flags } = useFeatureFlags()
+  const isProductRequestEnabled =
+    !!feature_flags?.[MercurFeatureFlags.PRODUCT_REQUEST]
 
   const [step, setStep] = useState<"select" | "values">("select")
   const [rowSelection, setRowSelection] =
@@ -237,7 +246,11 @@ const Content = ({ productId }: { productId: string }) => {
       {
         onSuccess: () => {
           handleSuccess()
-          toast.success(t("products.edit.requestSuccessToast"))
+          toast.success(
+            isProductRequestEnabled
+              ? t("products.edit.requestSuccessToast")
+              : t("products.edit.attributes.addSuccessToast")
+          )
         },
         onError: (err) => {
           toast.error(err.message)

--- a/packages/vendor/src/pages/products/[id]/attributes/add/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/add/index.tsx
@@ -237,6 +237,7 @@ const Content = ({ productId }: { productId: string }) => {
       {
         onSuccess: () => {
           handleSuccess()
+          toast.success(t("products.edit.requestSuccessToast"))
         },
         onError: (err) => {
           toast.error(err.message)

--- a/packages/vendor/src/pages/products/[id]/attributes/create/components/create-attribute-form/create-attribute-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/create/components/create-attribute-form/create-attribute-form.tsx
@@ -90,6 +90,7 @@ export const CreateAttributeForm = ({
       {
         onSuccess: () => {
           handleSuccess()
+          toast.success(t("products.edit.requestSuccessToast"))
         },
         onError: (error) => {
           toast.error(error.message)

--- a/packages/vendor/src/pages/products/[id]/attributes/create/components/create-attribute-form/create-attribute-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/create/components/create-attribute-form/create-attribute-form.tsx
@@ -13,10 +13,13 @@ import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
 
+import { MercurFeatureFlags } from "@mercurjs/types"
+
 import { ChipInput } from "@components/inputs/chip-input"
 import { Form } from "@components/common/form"
 import { RouteDrawer, useRouteModal } from "@components/modals"
 import { KeyboundForm } from "@components/utilities/keybound-form"
+import { useFeatureFlags } from "@hooks/api"
 import { useAddProductAttribute } from "@hooks/api/products"
 
 const normalizeValues = (raw: string | string[]): string[] =>
@@ -54,6 +57,10 @@ export const CreateAttributeForm = ({
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
 
+  const { feature_flags } = useFeatureFlags()
+  const isProductRequestEnabled =
+    !!feature_flags?.[MercurFeatureFlags.PRODUCT_REQUEST]
+
   const schema = useMemo(
     () =>
       buildSchema({
@@ -90,7 +97,11 @@ export const CreateAttributeForm = ({
       {
         onSuccess: () => {
           handleSuccess()
-          toast.success(t("products.edit.requestSuccessToast"))
+          toast.success(
+            isProductRequestEnabled
+              ? t("products.edit.requestSuccessToast")
+              : t("products.edit.attributes.createSuccessToast")
+          )
         },
         onError: (error) => {
           toast.error(error.message)

--- a/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/create-product-variant-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/create-product-variant-form.tsx
@@ -79,6 +79,7 @@ export const CreateProductVariantForm = ({
       {
         onSuccess: () => {
           handleSuccess()
+          toast.success(t("products.edit.requestSuccessToast"))
         },
         onError: (error) => {
           toast.error(error.message)

--- a/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/create-product-variant-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/create-product-variant-form.tsx
@@ -5,12 +5,13 @@ import { useTranslation } from "react-i18next"
 import { z } from "zod"
 
 import { HttpTypes } from "@medusajs/types"
-import { AttributeType, ProductDTO } from "@mercurjs/types"
+import { AttributeType, MercurFeatureFlags, ProductDTO } from "@mercurjs/types"
 
 import { Form } from "@components/common/form"
 import { AttributeValueInput } from "@components/inputs/attribute-value-input"
 import { RouteFocusModal, useRouteModal } from "@components/modals"
 import { KeyboundForm } from "@components/utilities/keybound-form"
+import { useFeatureFlags } from "@hooks/api"
 import { useCreateProductVariant } from "@hooks/api/products"
 import { CreateProductVariantSchema } from "./constants"
 
@@ -27,6 +28,10 @@ export const CreateProductVariantForm = ({
 }: CreateProductVariantFormProps) => {
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
+
+  const { feature_flags } = useFeatureFlags()
+  const isProductRequestEnabled =
+    !!feature_flags?.[MercurFeatureFlags.PRODUCT_REQUEST]
 
   const variantAttributes =
     (
@@ -79,7 +84,11 @@ export const CreateProductVariantForm = ({
       {
         onSuccess: () => {
           handleSuccess()
-          toast.success(t("products.edit.requestSuccessToast"))
+          toast.success(
+            isProductRequestEnabled
+              ? t("products.edit.requestSuccessToast")
+              : t("products.variant.create.successToast")
+          )
         },
         onError: (error) => {
           toast.error(error.message)


### PR DESCRIPTION
## Summary
Follow-up to the MER-169 review comments. The vendor product panel was missing success toasts for several actions, and the variant edit toast used inconsistent copy.

- Add the standard toast — *"Product update was successfully requested. Once confirmed by the Admin, changes will appear on the storefront."* — to attribute **add** (create new + add existing), **edit**, and **delete** flows.
- Add the same toast to variant **create** (previously silent).
- Change the variant **edit** toast from "Product variant edited successfully" to the standard copy.

All sites reuse the existing `products.edit.requestSuccessToast` translation key (variant edit reuses `products.variant.edit.success`, whose value was updated) to avoid string duplication and i18n schema churn.

## Linear
[MER-169](https://linear.app/rigbyjs/issue/MER-169/products-vendor-panel-toast-updates)

## Test plan
- [ ] In the vendor panel, add / edit / delete a product attribute → standard "update requested" toast appears
- [ ] Add a product variant → toast appears
- [ ] Edit a product variant → toast shows the standard copy
- [x] Vendor package builds (`turbo run build --filter=@mercurjs/vendor`) — ESM + DTS pass
- [x] `oxlint` clean on changed files