### PR TITLE
fix(admin): use checkmark for multi-select category indicator and rename label

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -3164,7 +3164,7 @@
       "required": "Required",
       "global": "Global",
       "category": "Category",
-      "categories": "Product Categories",
+      "categories": "Categories",
       "productAttribute": "Product Attribute",
       "values": "Values",
       "possibleValues": "Possible values",

--- a/packages/admin/src/pages/products/common/components/category-combobox/category-combobox.tsx
+++ b/packages/admin/src/pages/products/common/components/category-combobox/category-combobox.tsx
@@ -1,6 +1,6 @@
 import {
   ArrowUturnLeft,
-  EllipseMiniSolid,
+  CheckMini,
   TriangleRightMini,
   TrianglesMini,
   XMarkMini,
@@ -399,7 +399,7 @@ export const CategoryCombobox = forwardRef<
                   tabIndex={-1}
                 >
                   <div className="flex size-5 items-center justify-center">
-                    {isSelected(value, option.value) && <EllipseMiniSolid />}
+                    {isSelected(value, option.value) && <CheckMini />}
                   </div>
                   <Text
                     as="span"


### PR DESCRIPTION
## Summary
- Multi-select `CategoryCombobox` now uses a checkmark (`CheckMini`) for the selected indicator instead of a dot (`EllipseMiniSolid`). This matches the established codebase convention — multi-select uses a checkmark, single-select uses a dot (see `select-filter.tsx` and `combobox.tsx`). The single-select `single-category-combobox` is intentionally left on the dot.
- Renamed the attribute categories field label from "Product Categories" to "Categories".

## Linear
[MER-113](https://linear.app/rigbyjs/issue/MER-113)

## Test plan
- [ ] Open admin → attribute create (step 1) → category selector shows checkmarks on selected categories
- [ ] Field label reads "Categories"
- [ ] Product organization category picker (same multi-select combobox) also shows checkmarks