### PR TITLE
fix(products): align product variants table with design

### DIFF
--- a/docs/specs/SPEC-015-master-products-model.md
+++ b/docs/specs/SPEC-015-master-products-model.md
@@ -131,7 +131,7 @@ querying `product_change_action` where
 | Vendor | `GET /vendor/products`, `GET /vendor/product-variants` | own-created OR (published AND not restricted to other sellers) (rule 5) |
 | Vendor | `POST /vendor/products` | creates master product, `status=PROPOSED`, `created_by=seller`; no `product_seller` row |
 | Vendor | `POST /vendor/products/:id` (update), `/variants*`, `/attributes/batch` | request flow, **no ownership gate** (rule 2) |
-| Vendor | sales-channel / category `:id/products` | `ensureSellerOwnsProduct(s)` against `product_seller` (eligibility) |
+| Vendor | sales-channel / category `:id/products` | `ensureSellerOwnsProduct(s)`: product must be **assigned** (`product_seller`) **or created** by the seller |
 | Admin | `POST /admin/products` | `created_by = req.auth_context.actor_id`; per-product `seller_ids` set the eligibility allowlist |
 | Store | `GET /store/products[/:id]` | filtered by `product_seller.seller_id` of visible sellers |
 
@@ -174,6 +174,18 @@ type CreateProductsWorkflowInput = {
 - Run: `bun run test:integration:http -- product/vendor/product` → 7/7 passing
   (2026-06-25).
 
+Integration suites updated for the master-products model and passing (2026-06-25):
+- `product/vendor/product` 7/7, `product-categories/vendor` 10/10,
+  `sales-channels/vendor` 9/9, `returns/vendor` 18/18, `payouts/vendor` 3/3,
+  `customer/vendor` 8/8, `price-lists/vendor` 15/15,
+  `order/vendor/order-edit` 12/12, `product-edit/admin/product-publish-approval`
+  5/5.
+- `product/store/product` 13/14 (the one failure, `surfaces linked attributes`,
+  is the pre-existing attribute-surfacing issue, not master-products).
+- New shared helper `integration-tests/helpers/create-product.ts ::
+  assignProductsToSeller` creates the `product_seller` link where a test needs a
+  product assigned to a seller (store visibility).
+
 ## Notes / open items
 
 - **Store visibility of vendor-created products.** Because creation no longer
@@ -183,7 +195,13 @@ type CreateProductsWorkflowInput = {
   publish/approval time, or move store scoping onto the offer model. Tracked
   separately; `integration-tests/http/product/store/product.spec.ts` currently
   reflects the old behavior.
-- `ensureSellerOwnsProduct` / `ensureSellerOwnsProducts` still validate against
-  `product_seller` (eligibility) for the sales-channel and category assignment
-  routes. They are intentionally **not** wired to the creator-attribution
-  signal.
+- `ensureSellerOwnsProduct` / `ensureSellerOwnsProducts` (sales-channel and
+  category assignment routes) accept a product the seller is **assigned** to via
+  `product_seller` **or** **created** (`getSellerOwnedProductIds`). A seller can
+  organize products it created or is eligible for; it cannot organize another
+  seller's private product.
+- **Store visibility** is unchanged: `GET /store/products` lists products linked
+  to visible sellers via `product_seller`. A vendor-created product therefore
+  only appears in the storefront once it is assigned to a seller
+  (`product_seller`); integration tests assign it explicitly via the
+  `assignProductsToSeller` helper.

--- a/docs/specs/SPEC-015-master-products-model.md
+++ b/docs/specs/SPEC-015-master-products-model.md
@@ -1,0 +1,189 @@
+---
+status: live
+canonical: true
+area: products
+created: 2026-06-25
+last_updated: 2026-06-25
+---
+
+# SPEC-015 Master Products Model
+
+Products in Mercur are **master products**: a single shared catalog of product
+records that the whole marketplace draws from. A product is **not** owned by the
+seller who created it. Any seller may *request* changes to any product, and
+selling rights are governed by a separate restriction list — not by who created
+the record.
+
+This spec is the canonical owner of:
+
+- what a master product is,
+- what the `product_seller` link means (and does **not** mean),
+- how a product is attributed to the seller who created it, and why,
+- who may request changes to a product,
+- how the vendor product list is scoped.
+
+It supersedes any earlier reading of `product_seller` as an "ownership" link.
+
+## Core concepts
+
+### Master product
+A `product` row is a shared catalog entry. There is no `owner_id` / `created_by`
+column on the product itself (Medusa's product model has none, and Mercur does
+not add one). Ownership is **not** a property of the product.
+
+### `product_seller` link = selling-eligibility restriction
+`packages/core/src/links/product-seller-link.ts` (table `product_seller`,
+many-to-many) is a **restriction allowlist**: it records *which sellers are
+allowed to sell — and see — a given product*. It is the Mercur analog of
+Medusa's `product_sales_channel` link (a product appears in a channel only if
+linked).
+
+- It does **not** mean "this seller created/owns this product."
+- **Restricted vs. unrestricted:** a product with **at least one**
+  `product_seller` row is *restricted* — visible/sellable **only** to the
+  assigned sellers. A product with **no** `product_seller` rows is
+  *unrestricted* — visible to every seller (subject to status).
+- It is read by the store and admin surfaces to scope products to sellers
+  (`api/store/products/middlewares.ts` via `maybeApplyLinkFilter`,
+  `api/admin/sellers/[id]/products`), the vendor list/variant filters (to hide
+  products restricted to other sellers), and the vendor sales-channel /
+  category ownership helpers (`ensureSellerOwnsProduct(s)`).
+
+### Creator attribution = `product_change.created_by` + `PRODUCT_ADD`
+Who created a product is recorded the Medusa way — as `created_by` on the
+audit/change entity, sourced from the request actor — **not** on the product or
+the `product_seller` link.
+
+- On creation, `createProductsWorkflow` records a `ProductChange` with
+  `created_by = input.created_by` and a single
+  `ProductChangeAction` of type **`PRODUCT_ADD`**
+  (`packages/types/src/product/common.ts`).
+- `PRODUCT_ADD` is the unambiguous creation marker (symmetric with
+  `PRODUCT_DELETE`). It is distinct from `STATUS_CHANGE`, which also fires on
+  admin approve/reject, and from the per-edit `created_by` that any change
+  writes.
+- The **only** purpose of this attribution is list scoping: so a seller does
+  not see another seller's *proposed* (not-yet-published) products. It is
+  **not** used to gate edits, requests, or selling rights.
+
+`getSellerOwnedProductIds(scope, sellerId)`
+(`api/vendor/products/helpers.ts`) returns the product ids a seller created by
+querying `product_change_action` where
+`action = PRODUCT_ADD AND product_change.created_by = sellerId`.
+
+## Rules
+
+1. **Products are master/shared.** Creating a product adds a candidate to the
+   shared catalog; it does not create an owner.
+
+2. **Any seller may request a change to any product.** Attribute batches,
+   product updates, and variant add/update/remove all route through the
+   product-edit *request* pipeline (`ProductChange`). These endpoints **must
+   not** gate on ownership — every seller can submit a request on any master
+   product. (e.g. `POST /vendor/products/:id/attributes/batch` has no
+   ownership check.)
+
+3. **`product_seller` controls selling eligibility and restricted-product
+   visibility, not the right to request changes.** A restricted product (one
+   with `product_seller` rows) is hidden from sellers it is not assigned to.
+
+4. **Creator attribution is for list scoping only.** A seller sees their own
+   *proposed* products via `product_change.created_by` + `PRODUCT_ADD`; this
+   never restricts edits, requests, or sales.
+
+5. **Vendor product list scope** (`GET /vendor/products`,
+   `GET /vendor/product-variants`). A seller sees a product when it is **either**:
+   - a product **this seller created** (`getSellerOwnedProductIds`), **or**
+   - **published** **and not restricted away from this seller** — i.e. it has no
+     `product_seller` rows, or this seller is among the assigned ones.
+
+   Concretely the middleware applies:
+   ```
+   $or: [
+     { id: <own-created ids> },
+     { status: PUBLISHED, id: { $nin: <ids restricted to other sellers> } },
+   ]
+   ```
+   where `<ids restricted to other sellers>` =
+   `getProductIdsRestrictedFromSeller(seller)` (products that have
+   `product_seller` rows but none for this seller). Effect: each seller sees
+   their own proposed products, plus the published catalog **minus** products
+   restricted to other sellers. Nobody sees another seller's proposed products,
+   and nobody sees a published product restricted away from them.
+
+6. **Creation does not write a `product_seller` row.** Vendor/admin product
+   creation passes `created_by` (the actor) but does **not** auto-link the
+   creating seller as eligible. Selling eligibility is managed separately.
+
+## Status lifecycle
+
+`DRAFT → PROPOSED → PUBLISHED` (or `REJECTED`).
+- Vendor-created products default to `PROPOSED`
+  (`api/vendor/products/route.ts`).
+- A `PROPOSED` product is visible only to its creator (rule 5) until an admin
+  publishes it, at which point it becomes part of the published master catalog
+  visible to all sellers.
+
+## Endpoint contract summary
+
+| Surface | Endpoint | Scoping / rule |
+| --- | --- | --- |
+| Vendor | `GET /vendor/products`, `GET /vendor/product-variants` | own-created OR (published AND not restricted to other sellers) (rule 5) |
+| Vendor | `POST /vendor/products` | creates master product, `status=PROPOSED`, `created_by=seller`; no `product_seller` row |
+| Vendor | `POST /vendor/products/:id` (update), `/variants*`, `/attributes/batch` | request flow, **no ownership gate** (rule 2) |
+| Vendor | sales-channel / category `:id/products` | `ensureSellerOwnsProduct(s)` against `product_seller` (eligibility) |
+| Admin | `POST /admin/products` | `created_by = req.auth_context.actor_id`; per-product `seller_ids` set the eligibility allowlist |
+| Store | `GET /store/products[/:id]` | filtered by `product_seller.seller_id` of visible sellers |
+
+## Workflow input contract
+
+`createProductsWorkflow` (`workflows/product/workflows/create-products.ts`):
+
+```ts
+type CreateProductsWorkflowInput = {
+  products: (CreateProductDTO & { seller_ids?: string[] })[] // per-product eligibility allowlist
+  created_by: string                                          // the acting seller / admin actor
+} & AdditionalData
+```
+
+- `seller_ids` (per product) → `product_seller` eligibility rows.
+- `created_by` → `ProductChange.created_by` + `PRODUCT_ADD` action (creator
+  attribution).
+
+## Verification
+
+1. Seller A creates a product via `POST /vendor/products` → it is `PROPOSED` and
+   appears in A's `GET /vendor/products`.
+2. Seller B's `GET /vendor/products` does **not** contain A's proposed product,
+   but **does** contain unrestricted published master products.
+3. A published product restricted (a `product_seller` row) to seller A appears
+   in A's list but **not** in B's.
+4. Seller B can `POST /vendor/products/:id/attributes/batch` against a master
+   product B did not create and receives `202` (request accepted).
+5. `GET /vendor/product-variants` is scoped identically to the product list.
+
+## Evidence
+
+- `integration-tests/http/product/vendor/product.spec.ts`
+  - `Vendor - product list scoping › scopes the vendor list to the seller's own
+    proposed products plus published` — covers verification 1 & 2.
+  - `Vendor - product list scoping › hides a restricted published product from
+    sellers it is not assigned to` — covers verification 3.
+  - `Vendor - product attributes batch › allows any seller to request changes on
+    a master product it did not create` (expects `202`) — covers verification 4.
+- Run: `bun run test:integration:http -- product/vendor/product` → 7/7 passing
+  (2026-06-25).
+
+## Notes / open items
+
+- **Store visibility of vendor-created products.** Because creation no longer
+  writes a `product_seller` row, a vendor-created product — even once published
+  — will not surface in `GET /store/products` (which filters by
+  `product_seller.seller_id`). Open decision: write a `product_seller` row at
+  publish/approval time, or move store scoping onto the offer model. Tracked
+  separately; `integration-tests/http/product/store/product.spec.ts` currently
+  reflects the old behavior.
+- `ensureSellerOwnsProduct` / `ensureSellerOwnsProducts` still validate against
+  `product_seller` (eligibility) for the sales-channel and category assignment
+  routes. They are intentionally **not** wired to the creator-attribution
+  signal.

--- a/integration-tests/helpers/create-product.ts
+++ b/integration-tests/helpers/create-product.ts
@@ -1,0 +1,86 @@
+type ApiClient = {
+  post: (
+    path: string,
+    body: Record<string, unknown>,
+    headers: unknown
+  ) => Promise<{ data: { product: VendorProduct } }>
+}
+
+type VendorProduct = {
+  id: string
+  variants: { id: string; sku?: string }[]
+  [key: string]: unknown
+}
+
+type VendorVariantInput = {
+  title: string
+  sku?: string
+  /** Maps an axis attribute title to the variant's value, e.g. `{ Size: "M" }`. */
+  options?: Record<string, string>
+  [key: string]: unknown
+}
+
+type VendorAttributeInput =
+  | { id: string; value_ids?: string[]; value?: string | number | boolean }
+  | {
+      title: string
+      type?: "single_select" | "multi_select" | "text" | "toggle" | "unit"
+      values?: string[]
+      value?: string | number | boolean
+      is_variant_axis?: boolean
+      is_filterable?: boolean
+      is_required?: boolean
+      description?: string | null
+      metadata?: Record<string, unknown> | null
+    }
+
+type CreateVendorProductOptions = {
+  title: string
+  status?: string
+  /** SKU for the single default variant (ignored when `variants` is given). */
+  sku?: string
+  /** Title for the single default variant. Defaults to `"Default"`. */
+  variantTitle?: string
+  /** Override the generated variants array entirely. */
+  variants?: VendorVariantInput[]
+  /**
+   * Unified product attributes. Pass a `multi_select` entry with
+   * `is_variant_axis: true` to create a variant axis; each variant then
+   * references it through its `options` map.
+   */
+  attributes?: VendorAttributeInput[]
+  /** Extra top-level product fields merged into the request body. */
+  extra?: Record<string, unknown>
+}
+
+/**
+ * Creates a vendor product through `POST /vendor/products` using the current
+ * request shape. The vendor flow derives the variant option from the unified
+ * `attributes` field (an `is_variant_axis` entry) and otherwise auto-assigns a
+ * default option, so a bare variant needs neither `options` nor
+ * `variant_attributes`. Returns the created product (with `variants`).
+ */
+export const createVendorProduct = async (
+  api: ApiClient,
+  headers: unknown,
+  opts: CreateVendorProductOptions
+): Promise<VendorProduct> => {
+  const variants = opts.variants ?? [
+    { title: opts.variantTitle ?? "Default", sku: opts.sku },
+  ]
+
+  const body: Record<string, unknown> = {
+    status: opts.status ?? "published",
+    title: opts.title,
+    variants,
+    ...opts.extra,
+  }
+
+  if (opts.attributes) {
+    body.attributes = opts.attributes
+  }
+
+  const { data } = await api.post(`/vendor/products`, body, headers)
+
+  return data.product
+}

--- a/integration-tests/helpers/create-product.ts
+++ b/integration-tests/helpers/create-product.ts
@@ -1,9 +1,37 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { MercurModules } from "@mercurjs/types"
+
 type ApiClient = {
   post: (
     path: string,
     body: Record<string, unknown>,
     headers: unknown
   ) => Promise<{ data: { product: VendorProduct } }>
+}
+
+/**
+ * Master products are not auto-linked to their creating seller. Selling/visibility
+ * eligibility lives on the `product_seller` restriction link, so tests that need a
+ * product to be "assigned" to a seller (store visibility, category / sales-channel
+ * ownership checks) must create that link explicitly.
+ */
+export const assignProductsToSeller = async (
+  container: MedusaContainer,
+  sellerId: string,
+  productIds: string[]
+): Promise<void> => {
+  if (!productIds.length) {
+    return
+  }
+
+  const link = container.resolve(ContainerRegistrationKeys.LINK)
+  await link.create(
+    productIds.map((product_id) => ({
+      [Modules.PRODUCT]: { product_id },
+      [MercurModules.SELLER]: { seller_id: sellerId },
+    }))
+  )
 }
 
 type VendorProduct = {

--- a/integration-tests/http/customer/vendor/customer.spec.ts
+++ b/integration-tests/http/customer/vendor/customer.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
 import { generatePublishableKey, generateStoreHeaders } from "../../../helpers/create-admin-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 
 jest.setTimeout(120000)
 
@@ -103,24 +104,10 @@ medusaIntegrationTestRunner({
                 // Create product for seller 1. Pricing + inventory live on the
                 // offer (see SPEC-002), so the variant carries neither; the
                 // product is linked to the sales channel separately.
-                const product1Response = await api.post(
-                    `/vendor/products`,
-                    {
-                        status: 'published',
-                        title: "Seller 1 Product",
-                        description: "Product from seller 1",
-                        options: [{ title: "Size", values: ["S", "M"] }],
-                        variants: [
-                            {
-                                title: "Small",
-                                sku: "SELLER1-S",
-                                options: { Size: "S" },
-                            },
-                        ],
-                    },
-                    seller1Headers
-                )
-                product1 = product1Response.data.product
+                product1 = await createVendorProduct(api, seller1Headers, {
+                    title: "Seller 1 Product",
+                    sku: "SELLER1-S",
+                })
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,
                     { add: [product1.id] },
@@ -128,24 +115,10 @@ medusaIntegrationTestRunner({
                 )
 
                 // Create product for seller 2
-                const product2Response = await api.post(
-                    `/vendor/products`,
-                    {
-                        status: 'published',
-                        title: "Seller 2 Product",
-                        description: "Product from seller 2",
-                        options: [{ title: "Color", values: ["Red", "Blue"] }],
-                        variants: [
-                            {
-                                title: "Red",
-                                sku: "SELLER2-RED",
-                                options: { Color: "Red" },
-                            },
-                        ],
-                    },
-                    seller2Headers
-                )
-                product2 = product2Response.data.product
+                product2 = await createVendorProduct(api, seller2Headers, {
+                    title: "Seller 2 Product",
+                    sku: "SELLER2-RED",
+                })
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,
                     { add: [product2.id] },

--- a/integration-tests/http/offer/cart/cart.spec.ts
+++ b/integration-tests/http/offer/cart/cart.spec.ts
@@ -13,6 +13,7 @@ import {
     generatePublishableKey,
     generateStoreHeaders,
 } from "../../../helpers/create-admin-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 
 jest.setTimeout(120000)
 
@@ -56,33 +57,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `${opts.name} Product ${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default ${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `${opts.email}-V-SKU-${tag}`,
-                                    attribute_values: {
-                                        [`Default ${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `${opts.name} Product ${tag}`,
+                    sku: `${opts.email}-V-SKU-${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,
@@ -270,34 +248,10 @@ medusaIntegrationTestRunner({
                         headers
                     )
                     const siblingsTag = `siblings${++seedCounter}${Date.now()}`
-                    const product = (
-                        await api.post(
-                            `/vendor/products`,
-                            {
-                                status: "published",
-                                title: `Siblings Product ${siblingsTag}`,
-                                variant_attributes: [
-                                    {
-                                        name: `Default ${siblingsTag}`,
-                                        type: "multi_select",
-                                        values: ["Default"],
-                                        is_variant_axis: true,
-                                    },
-                                ],
-                                variants: [
-                                    {
-                                        title: "Default",
-                                        sku: `SIBLINGS-V-${siblingsTag}`,
-                                        attribute_values: {
-                                            [`Default ${siblingsTag}`]:
-                                                "Default",
-                                        },
-                                    },
-                                ],
-                            },
-                            headers
-                        )
-                    ).data.product
+                    const product = await createVendorProduct(api, headers, {
+                        title: `Siblings Product ${siblingsTag}`,
+                        sku: `SIBLINGS-V-${siblingsTag}`,
+                    })
                     await api.post(
                         `/vendor/sales-channels/${salesChannel.id}/products`,
                         { add: [product.id] },

--- a/integration-tests/http/offer/order/order.spec.ts
+++ b/integration-tests/http/offer/order/order.spec.ts
@@ -11,6 +11,7 @@ import {
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -131,33 +132,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${uniqueSuffix}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${uniqueSuffix}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${uniqueSuffix}`,
-                                    attribute_values: {
-                                        [`Default${uniqueSuffix}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${uniqueSuffix}`,
+                    sku: `V${uniqueSuffix}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/offer/store/offers.spec.ts
+++ b/integration-tests/http/offer/store/offers.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -87,33 +88,10 @@ medusaIntegrationTestRunner({
                 let productId = opts.productId
                 let variantId = opts.variantId
                 if (!productId || !variantId) {
-                    const product = (
-                        await api.post(
-                            `/vendor/products`,
-                            {
-                                status: "published",
-                                title: `${opts.name} Product ${tag}`,
-                                variant_attributes: [
-                                    {
-                                        name: `Default ${tag}`,
-                                        type: "multi_select",
-                                        values: ["Default"],
-                                        is_variant_axis: true,
-                                    },
-                                ],
-                                variants: [
-                                    {
-                                        title: "Default",
-                                        sku: `${opts.email}-V-SKU-${tag}`,
-                                        attribute_values: {
-                                            [`Default ${tag}`]: "Default",
-                                        },
-                                    },
-                                ],
-                            },
-                            headers
-                        )
-                    ).data.product
+                    const product = await createVendorProduct(api, headers, {
+                        title: `${opts.name} Product ${tag}`,
+                        sku: `${opts.email}-V-SKU-${tag}`,
+                    })
 
                     await api.post(
                         `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/offer/store/store-offers.spec.ts
+++ b/integration-tests/http/offer/store/store-offers.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -76,36 +77,12 @@ medusaIntegrationTestRunner({
                 let productId = opts.productId
                 let variantId = opts.variantId
                 if (!productId || !variantId) {
-                    const product = (
-                        await api.post(
-                            `/vendor/products`,
-                            {
-                                status:
-                                    opts.published === false
-                                        ? "draft"
-                                        : "published",
-                                title: `${opts.name} Product ${tag}`,
-                                variant_attributes: [
-                                    {
-                                        name: `Default ${tag}`,
-                                        type: "multi_select",
-                                        values: ["Default"],
-                                        is_variant_axis: true,
-                                    },
-                                ],
-                                variants: [
-                                    {
-                                        title: "Default",
-                                        sku: `${opts.email}-V-SKU-${tag}`,
-                                        attribute_values: {
-                                            [`Default ${tag}`]: "Default",
-                                        },
-                                    },
-                                ],
-                            },
-                            headers
-                        )
-                    ).data.product
+                    const product = await createVendorProduct(api, headers, {
+                        status:
+                            opts.published === false ? "draft" : "published",
+                        title: `${opts.name} Product ${tag}`,
+                        sku: `${opts.email}-V-SKU-${tag}`,
+                    })
 
                     await api.post(
                         `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/offer/vendor/offer.spec.ts
+++ b/integration-tests/http/offer/vendor/offer.spec.ts
@@ -2,6 +2,7 @@ import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
 import { MedusaContainer } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 
 jest.setTimeout(50000)
 
@@ -18,33 +19,12 @@ medusaIntegrationTestRunner({
                 const tag = `t${idx}${Date.now()}`
                 const ean = `${tag}`.padEnd(13, "0").slice(0, 13)
                 const upc = `${tag}`.padEnd(12, "0").slice(0, 12)
-                const product = await api.post(
-                    `/vendor/products`,
-                    {
-                        title: `Test Product ${tag}`,
-                        variant_attributes: [
-                            {
-                                name: `Default ${tag}`,
-                                type: "multi_select",
-                                values: ["Default"],
-                                is_variant_axis: true,
-                            },
-                        ],
-                        variants: [
-                            {
-                                title: "Default",
-                                attribute_values: {
-                                    [`Default ${tag}`]: "Default",
-                                },
-                                ean,
-                                upc,
-                            },
-                        ],
-                    },
-                    headers
-                )
+                const product = await createVendorProduct(api, headers, {
+                    title: `Test Product ${tag}`,
+                    variants: [{ title: "Default", ean, upc }],
+                })
 
-                const variant = product.data.product.variants[0]
+                const variant = product.variants[0]
 
                 const shippingProfile = await api.post(
                     `/vendor/shipping-profiles`,
@@ -54,7 +34,7 @@ medusaIntegrationTestRunner({
 
                 return {
                     variant_id: variant.id,
-                    product_id: product.data.product.id,
+                    product_id: product.id,
                     shipping_profile_id:
                         shippingProfile.data.shipping_profile.id,
                     ean,

--- a/integration-tests/http/order/admin/order-list-filters.spec.ts
+++ b/integration-tests/http/order/admin/order-list-filters.spec.ts
@@ -7,6 +7,7 @@ import {
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
 import {
     adminHeaders,
@@ -143,33 +144,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/admin/order-offers.spec.ts
+++ b/integration-tests/http/order/admin/order-offers.spec.ts
@@ -7,6 +7,7 @@ import {
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
 import {
     adminHeaders,
@@ -151,33 +152,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/admin/order-reservation-multiplier.spec.ts
+++ b/integration-tests/http/order/admin/order-reservation-multiplier.spec.ts
@@ -7,6 +7,7 @@ import {
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
 import {
     adminHeaders,
@@ -153,33 +154,10 @@ medusaIntegrationTestRunner({
                     )
                 ).data.shipping_option
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/store/order.spec.ts
+++ b/integration-tests/http/order/store/order.spec.ts
@@ -9,6 +9,7 @@ import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
 import { generatePublishableKey, generateStoreHeaders } from "../../../helpers/create-admin-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 
 jest.setTimeout(120000)
 
@@ -97,31 +98,11 @@ medusaIntegrationTestRunner({
                 })
 
                 // Create product for seller 1
-                const product1Response = await api.post(
-                    `/vendor/products`,
-                    {
-                        status: 'published',
-                        title: "Seller 1 Product",
-                        description: "Product from seller 1",
-                        variant_attributes: [
-                            {
-                                name: "Size",
-                                type: "multi_select",
-                                is_variant_axis: true,
-                                values: ["S", "M"],
-                            },
-                        ],
-                        variants: [
-                            {
-                                title: "Small",
-                                sku: "SELLER1-S",
-                                attribute_values: { Size: "S" },
-                            },
-                        ],
-                    },
-                    seller1Headers
-                )
-                product1 = product1Response.data.product
+                product1 = await createVendorProduct(api, seller1Headers, {
+                    title: "Seller 1 Product",
+                    sku: "SELLER1-S",
+                    variantTitle: "Small",
+                })
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,
                     { add: [product1.id] },
@@ -129,31 +110,11 @@ medusaIntegrationTestRunner({
                 )
 
                 // Create product for seller 2
-                const product2Response = await api.post(
-                    `/vendor/products`,
-                    {
-                        status: 'published',
-                        title: "Seller 2 Product",
-                        description: "Product from seller 2",
-                        variant_attributes: [
-                            {
-                                name: "Color",
-                                type: "multi_select",
-                                is_variant_axis: true,
-                                values: ["Red", "Blue"],
-                            },
-                        ],
-                        variants: [
-                            {
-                                title: "Red",
-                                sku: "SELLER2-RED",
-                                attribute_values: { Color: "Red" },
-                            },
-                        ],
-                    },
-                    seller2Headers
-                )
-                product2 = product2Response.data.product
+                product2 = await createVendorProduct(api, seller2Headers, {
+                    title: "Seller 2 Product",
+                    sku: "SELLER2-RED",
+                    variantTitle: "Red",
+                })
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,
                     { add: [product2.id] },

--- a/integration-tests/http/order/vendor/order-allocate-added-item.spec.ts
+++ b/integration-tests/http/order/vendor/order-allocate-added-item.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -138,33 +139,10 @@ medusaIntegrationTestRunner({
             ) => {
                 const tag = `_offer_${Date.now()}_${++counter}`
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        seed.headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, seed.headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-cancel.spec.ts
+++ b/integration-tests/http/order/vendor/order-cancel.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -142,33 +143,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-claim.spec.ts
+++ b/integration-tests/http/order/vendor/order-claim.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -125,33 +126,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-edit-reservation-multiplier.spec.ts
+++ b/integration-tests/http/order/vendor/order-edit-reservation-multiplier.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -147,33 +148,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-edit.spec.ts
+++ b/integration-tests/http/order/vendor/order-edit.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -125,33 +126,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-exchange.spec.ts
+++ b/integration-tests/http/order/vendor/order-exchange.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -125,33 +126,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-list-filters.spec.ts
+++ b/integration-tests/http/order/vendor/order-list-filters.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -126,33 +127,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-mark-as-paid.spec.ts
+++ b/integration-tests/http/order/vendor/order-mark-as-paid.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -125,33 +126,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-offers.spec.ts
+++ b/integration-tests/http/order/vendor/order-offers.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -151,33 +152,10 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/order/vendor/order-reservation-multiplier.spec.ts
+++ b/integration-tests/http/order/vendor/order-reservation-multiplier.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -158,33 +159,10 @@ medusaIntegrationTestRunner({
                     )
                 ).data.shipping_option
 
-                const product = (
-                    await api.post(
-                        `/vendor/products`,
-                        {
-                            status: "published",
-                            title: `Prod${tag}`,
-                            variant_attributes: [
-                                {
-                                    name: `Default${tag}`,
-                                    type: "multi_select",
-                                    values: ["Default"],
-                                    is_variant_axis: true,
-                                },
-                            ],
-                            variants: [
-                                {
-                                    title: "Default",
-                                    sku: `V${tag}`,
-                                    attribute_values: {
-                                        [`Default${tag}`]: "Default",
-                                    },
-                                },
-                            ],
-                        },
-                        headers
-                    )
-                ).data.product
+                const product = await createVendorProduct(api, headers, {
+                    title: `Prod${tag}`,
+                    sku: `V${tag}`,
+                })
 
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,
@@ -482,33 +460,14 @@ medusaIntegrationTestRunner({
                     // re-seed inside `standardSeed`'s seller scope instead
                     // by posting a second offer under those headers.
                     const multTag = `MultB_${Date.now()}_${++prerequisiteCounter}`
-                    const multProduct = (
-                        await api.post(
-                            `/vendor/products`,
-                            {
-                                status: "published",
-                                title: `Prod${multTag}`,
-                                variant_attributes: [
-                                    {
-                                        name: `Default${multTag}`,
-                                        type: "multi_select",
-                                        values: ["Default"],
-                                        is_variant_axis: true,
-                                    },
-                                ],
-                                variants: [
-                                    {
-                                        title: "Default",
-                                        sku: `V${multTag}`,
-                                        attribute_values: {
-                                            [`Default${multTag}`]: "Default",
-                                        },
-                                    },
-                                ],
-                            },
-                            standardSeed.headers
-                        )
-                    ).data.product
+                    const multProduct = await createVendorProduct(
+                        api,
+                        standardSeed.headers,
+                        {
+                            title: `Prod${multTag}`,
+                            sku: `V${multTag}`,
+                        }
+                    )
                     await api.post(
                         `/vendor/sales-channels/${salesChannel.id}/products`,
                         { add: [multProduct.id] },

--- a/integration-tests/http/payouts/vendor/payouts.spec.ts
+++ b/integration-tests/http/payouts/vendor/payouts.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { generatePublishableKey, generateStoreHeaders } from "../../../helpers/create-admin-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import { createPayoutAccountWorkflow, createPayoutWorkflow } from '@mercurjs/core/workflows'
 
 jest.setTimeout(120000)
@@ -80,24 +81,10 @@ medusaIntegrationTestRunner({
 
         // Create product with variant. Pricing + inventory live on the offer
         // (see SPEC-002); the product is linked to the sales channel separately.
-        const productResponse = await api.post(
-          `/vendor/products`,
-          {
-            status: "published",
-            title: "Payout Test Product",
-            description: "A test product for payout testing",
-            options: [{ title: "Size", values: ["S"] }],
-            variants: [
-              {
-                title: "Small",
-                sku: "PAYOUT-TEST-S",
-                options: { Size: "S" },
-              },
-            ],
-          },
-          sellerHeaders
-        )
-        product = productResponse.data.product
+        product = await createVendorProduct(api, sellerHeaders, {
+          title: "Payout Test Product",
+          sku: "PAYOUT-TEST-S",
+        })
         await api.post(
           `/vendor/sales-channels/${salesChannel.id}/products`,
           { add: [product.id] },

--- a/integration-tests/http/price-lists/vendor/price-lists.spec.ts
+++ b/integration-tests/http/price-lists/vendor/price-lists.spec.ts
@@ -1,6 +1,7 @@
 import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
 import { MedusaContainer } from "@medusajs/framework/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 
 jest.setTimeout(50000)
 
@@ -342,23 +343,12 @@ medusaIntegrationTestRunner({
 
             describe("POST /vendor/price-lists/:id/products", () => {
                 it("should remove products from price list", async () => {
-                    const productResponse = await api.post(
-                        `/vendor/products`,
-                        {
-                            title: "Product for Price List",
-                            options: [{ title: "Default", values: ["Default"] }],
-                            variants: [
-                                {
-                                    title: "Default Variant",
-                                    options: { Default: "Default" },
-                                },
-                            ],
-                        },
-                        seller1Headers
-                    )
+                    const product = await createVendorProduct(api, seller1Headers, {
+                        title: "Product for Price List",
+                    })
 
-                    const productId = productResponse.data.product.id
-                    const variantId = productResponse.data.product.variants[0].id
+                    const productId = product.id
+                    const variantId = product.variants[0].id
 
                     const priceListResponse = await api.post(
                         `/vendor/price-lists`,
@@ -416,23 +406,12 @@ medusaIntegrationTestRunner({
                 })
 
                 it("should not allow seller to remove products from another seller's price list", async () => {
-                    const productResponse = await api.post(
-                        `/vendor/products`,
-                        {
-                            title: "Seller 1 Product",
-                            options: [{ title: "Default", values: ["Default"] }],
-                            variants: [
-                                {
-                                    title: "Default Variant",
-                                    options: { Default: "Default" },
-                                },
-                            ],
-                        },
-                        seller1Headers
-                    )
+                    const product = await createVendorProduct(api, seller1Headers, {
+                        title: "Seller 1 Product",
+                    })
 
-                    const productId = productResponse.data.product.id
-                    const variantId = productResponse.data.product.variants[0].id
+                    const productId = product.id
+                    const variantId = product.variants[0].id
 
                     const priceListResponse = await api.post(
                         `/vendor/price-lists`,

--- a/integration-tests/http/product-attribute/admin/product-attribute.spec.ts
+++ b/integration-tests/http/product-attribute/admin/product-attribute.spec.ts
@@ -37,7 +37,7 @@ medusaIntegrationTestRunner({
 
     const createProduct = async (title: string) => {
       const { result } = await createProductsWorkflow(appContainer).run({
-        input: { products: [{ title, status: "published" }] },
+        input: { products: [{ title, status: "published" }], created_by: "admin_user" },
       })
       return (result as { id: string }[])[0].id
     }

--- a/integration-tests/http/product-edit/admin/product-publish-approval.spec.ts
+++ b/integration-tests/http/product-edit/admin/product-publish-approval.spec.ts
@@ -81,7 +81,7 @@ medusaIntegrationTestRunner({
         }>
       }
 
-      it("records a confirmed audit change with STATUS_CHANGE → proposed on vendor create", async () => {
+      it("records a confirmed audit change with PRODUCT_ADD → proposed on vendor create", async () => {
         const productId = await createVendorProduct("Pending Approval")
 
         // Product is left in `proposed` — no auto-publish.
@@ -94,12 +94,12 @@ medusaIntegrationTestRunner({
         const changes = await listChanges(productId)
         expect(changes).toHaveLength(1)
         expect(changes[0].status).toBe(ProductChangeStatus.CONFIRMED)
-        const statusAction = changes[0].actions.find(
-          (a) => a.action === "STATUS_CHANGE",
+        const createAction = changes[0].actions.find(
+          (a) => a.action === "PRODUCT_ADD",
         )
-        expect(statusAction).toBeDefined()
-        expect(statusAction!.details.status).toBe("proposed")
-        expect(statusAction!.applied).toBe(true)
+        expect(createAction).toBeDefined()
+        expect(createAction!.details.status).toBe("proposed")
+        expect(createAction!.applied).toBe(true)
       })
 
       it("admin confirm publishes the product and stamps a STATUS_CHANGE → published audit change", async () => {

--- a/integration-tests/http/product-edit/vendor/product-edit.spec.ts
+++ b/integration-tests/http/product-edit/vendor/product-edit.spec.ts
@@ -429,9 +429,9 @@ medusaIntegrationTestRunner({
               {
                 status: "published",
                 title,
-                variant_attributes: [
+                attributes: [
                   {
-                    name: `Color${tag}`,
+                    title: `Color${tag}`,
                     type: "multi_select",
                     values: ["Red", "Blue"],
                     is_variant_axis: true,
@@ -441,7 +441,7 @@ medusaIntegrationTestRunner({
                   {
                     title: "Red Variant",
                     sku: `OPT-${tag}`,
-                    attribute_values: { [`Color${tag}`]: "Red" },
+                    options: { [`Color${tag}`]: "Red" },
                   },
                 ],
               },

--- a/integration-tests/http/product/admin/product.spec.ts
+++ b/integration-tests/http/product/admin/product.spec.ts
@@ -476,13 +476,13 @@ medusaIntegrationTestRunner({
         expect(toggleGrouped.all_values).toEqual([])
         // axis still produces the native option.
         expect(await optionAttached(productId, "Required Attribute")).toBe(true)
-        // ...and no placeholder "Default option" was seeded — the axis option is
-        // the product's only option, so variant edits aren't inflated by a dead
-        // default (SPEC-014).
-        expect(await optionAttached(productId, "Default option")).toBe(false)
+        // ...and no internal "__default__" placeholder was left behind — the axis
+        // option is the product's only option, so variant edits aren't inflated by
+        // a dead default (SPEC-014).
+        expect(await optionAttached(productId, "__default__")).toBe(false)
       })
 
-      it("create: no Default option when product has an axis; seeded otherwise", async () => {
+      it("create: no __default__ placeholder when product has an axis; seeded otherwise", async () => {
         // Axis product (existing axis ref) → axis option is the only option.
         const axis = await createAttr({
           name: "Axis Attr",
@@ -502,9 +502,9 @@ medusaIntegrationTestRunner({
         expect([200, 201]).toContain(axisRes.status)
         const axisProductId = axisRes.data.product.id
         expect(await optionAttached(axisProductId, "Axis Attr")).toBe(true)
-        expect(await optionAttached(axisProductId, "Default option")).toBe(false)
+        expect(await optionAttached(axisProductId, "__default__")).toBe(false)
 
-        // Inline axis → also no default option.
+        // Inline axis → also no __default__ placeholder.
         const inlineRes = await api.post(
           "/admin/products",
           {
@@ -519,12 +519,12 @@ medusaIntegrationTestRunner({
         expect([200, 201]).toContain(inlineRes.status)
         const inlineProductId = inlineRes.data.product.id
         expect(await optionAttached(inlineProductId, "Size")).toBe(true)
-        expect(await optionAttached(inlineProductId, "Default option")).toBe(
+        expect(await optionAttached(inlineProductId, "__default__")).toBe(
           false,
         )
 
-        // No axis (bare product) → the placeholder default option is still
-        // seeded so the product has at least one option.
+        // No axis (bare product, no UI synthetic axis) → the internal
+        // "__default__" placeholder is kept so the product has at least one option.
         const bareRes = await api.post(
           "/admin/products",
           { title: "Bare Create Product", status: "published" },
@@ -532,7 +532,40 @@ medusaIntegrationTestRunner({
         )
         expect([200, 201]).toContain(bareRes.status)
         const bareProductId = bareRes.data.product.id
-        expect(await optionAttached(bareProductId, "Default option")).toBe(true)
+        expect(await optionAttached(bareProductId, "__default__")).toBe(true)
+      })
+
+      it("create: no-axis product seeds a Default Option axis (UI contract)", async () => {
+        // What the create form now submits when the user defines no variant axis:
+        // a synthetic inline "Default Option" axis + a variant bound to it.
+        const res = await api.post(
+          "/admin/products",
+          {
+            title: "Simple Product",
+            status: "published",
+            attributes: [
+              { title: "Default Option", values: ["Default"], is_variant_axis: true },
+            ],
+            variants: [
+              { title: "Default variant", options: { "Default Option": "Default" } },
+            ],
+          },
+          adminHeaders,
+        )
+        expect([200, 201]).toContain(res.status)
+        const productId = res.data.product.id
+
+        expect(await optionAttached(productId, "Default Option")).toBe(true)
+        // the transient scaffolding is gone once the real option exists.
+        expect(await optionAttached(productId, "__default__")).toBe(false)
+
+        const query = appContainer.resolve(ContainerRegistrationKeys.QUERY)
+        const { data } = await query.graph({
+          entity: "product_variant",
+          fields: ["title"],
+          filters: { product_id: productId },
+        })
+        expect(data.some((v: any) => v.title === "Default variant")).toBe(true)
       })
 
       it("create: variants bind to axis options by value name", async () => {

--- a/integration-tests/http/product/admin/product.spec.ts
+++ b/integration-tests/http/product/admin/product.spec.ts
@@ -78,6 +78,7 @@ medusaIntegrationTestRunner({
         const { result } = await createProductsWorkflow(appContainer).run({
           input: {
             products: [{ title: "Batch Product", status: "published" }],
+            created_by: "admin_user",
           },
         })
         return (result as { id: string }[])[0].id

--- a/integration-tests/http/product/store/offer-product-price.spec.ts
+++ b/integration-tests/http/product/store/offer-product-price.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "@medusajs/framework/utils"
 import { MercurModules, SellerStatus } from "@mercurjs/types"
 import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 import {
     generatePublishableKey,
     generateStoreHeaders,
@@ -66,33 +67,10 @@ medusaIntegrationTestRunner({
                 let productId = opts.productId
                 let variantId = opts.variantId
                 if (!productId || !variantId) {
-                    const product = (
-                        await api.post(
-                            `/vendor/products`,
-                            {
-                                status: "published",
-                                title: `${opts.name} Product ${tag}`,
-                                variant_attributes: [
-                                    {
-                                        name: `Default ${tag}`,
-                                        type: "multi_select",
-                                        values: ["Default"],
-                                        is_variant_axis: true,
-                                    },
-                                ],
-                                variants: [
-                                    {
-                                        title: "Default",
-                                        sku: `${opts.email}-V-SKU-${tag}`,
-                                        attribute_values: {
-                                            [`Default ${tag}`]: "Default",
-                                        },
-                                    },
-                                ],
-                            },
-                            headers
-                        )
-                    ).data.product
+                    const product = await createVendorProduct(api, headers, {
+                        title: `${opts.name} Product ${tag}`,
+                        sku: `${opts.email}-V-SKU-${tag}`,
+                    })
 
                     await api.post(
                         `/vendor/sales-channels/${salesChannel.id}/products`,

--- a/integration-tests/http/product/store/product.spec.ts
+++ b/integration-tests/http/product/store/product.spec.ts
@@ -5,6 +5,7 @@ import {
     MedusaContainer,
 } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { MercurModules } from "@mercurjs/types"
 import {
     adminHeaders,
     createAdminUser,
@@ -84,6 +85,10 @@ medusaIntegrationTestRunner({
                 )
             })
 
+            // Products are master records: creation no longer links a seller.
+            // A product only appears in the store when it is assigned to a
+            // seller via the `product_seller` restriction link, so the test
+            // assigns each created product to the seller whose headers made it.
             const createProduct = async (
                 headers: any,
                 overrides: Record<string, any> = {}
@@ -97,7 +102,21 @@ medusaIntegrationTestRunner({
                     },
                     headers
                 )
-                return response.data.product
+                const product = response.data.product
+
+                const seller =
+                    headers === suspendedSellerHeaders
+                        ? suspendedSeller
+                        : approvedSeller
+                const link = appContainer.resolve(
+                    ContainerRegistrationKeys.LINK
+                )
+                await link.create({
+                    [Modules.PRODUCT]: { product_id: product.id },
+                    [MercurModules.SELLER]: { seller_id: seller.id },
+                })
+
+                return product
             }
 
             describe("GET /store/products", () => {

--- a/integration-tests/http/product/store/product.spec.ts
+++ b/integration-tests/http/product/store/product.spec.ts
@@ -340,18 +340,11 @@ medusaIntegrationTestRunner({
                 it("surfaces linked attributes on product.attributes", async () => {
                     const product = await createProduct(approvedSellerHeaders, {
                         title: "Product with attribute",
-                        variant_attributes: [
+                        attributes: [
                             {
-                                name: "Size",
+                                title: "Size",
                                 type: "multi_select",
-                                is_variant_axis: true,
                                 values: ["M"],
-                            },
-                        ],
-                        variants: [
-                            {
-                                title: "M",
-                                attribute_values: { Size: "M" },
                             },
                         ],
                     })

--- a/integration-tests/http/product/vendor/product.spec.ts
+++ b/integration-tests/http/product/vendor/product.spec.ts
@@ -95,8 +95,14 @@ medusaIntegrationTestRunner({
       const createOwnedProduct = async () => {
         const { result } = await createProductsWorkflow(appContainer).run({
           input: {
-            products: [{ title: "Vendor Product", status: "published" }],
-            seller_ids: [seller.id],
+            products: [
+              {
+                title: "Vendor Product",
+                status: "published",
+                seller_ids: [seller.id],
+              },
+            ],
+            created_by: seller.id,
           },
         })
         return (result as { id: string }[])[0].id
@@ -176,21 +182,23 @@ medusaIntegrationTestRunner({
         ])
       })
 
-      it("rejects batch on a product the seller does not own", async () => {
-        // product owned by nobody (no seller link)
+      it("allows any seller to request changes on a master product it did not create", async () => {
+        // master product created by a different actor — every seller can
+        // still request a change through the product-edit pipeline.
         const { result } = await createProductsWorkflow(appContainer).run({
           input: {
             products: [{ title: "Foreign", status: "published" }],
+            created_by: "foreign-actor",
           },
         })
         const foreignId = (result as { id: string }[])[0].id
         const attr = await createAttr({ name: "Material", type: "text" })
 
-        const err = await batch(foreignId, {
+        const res = await batch(foreignId, {
           add: [{ id: attr.id, value: "x" }],
-        }).catch((e) => e)
+        })
 
-        expect(err.response.status).toEqual(404)
+        expect(res.status).toEqual(202)
       })
 
       // --- request flow: ProductChange staging via the batch endpoint ---
@@ -274,6 +282,78 @@ medusaIntegrationTestRunner({
         expect(err.response.status).toBeGreaterThanOrEqual(400)
       })
 
+    })
+
+    describe("Vendor - product list scoping", () => {
+      let appContainer: MedusaContainer
+      let sellerA: any
+      let headersA: any
+      let headersB: any
+
+      beforeAll(() => {
+        appContainer = getContainer()
+      })
+
+      beforeEach(async () => {
+        const a = await createSellerUser(appContainer, {
+          email: "scope-a@test.com",
+          name: "Scope A Store",
+        })
+        sellerA = a.seller
+        headersA = a.headers
+        const b = await createSellerUser(appContainer, {
+          email: "scope-b@test.com",
+          name: "Scope B Store",
+        })
+        headersB = b.headers
+      })
+
+      const createProduct = async (
+        title: string,
+        status: string,
+        createdBy: string,
+        sellerIds?: string[]
+      ) => {
+        const { result } = await createProductsWorkflow(appContainer).run({
+          input: {
+            products: [{ title, status, seller_ids: sellerIds } as any],
+            created_by: createdBy,
+          },
+        })
+        return (result as { id: string }[])[0].id
+      }
+
+      it("scopes the vendor list to the seller's own proposed products plus published", async () => {
+        const proposedByA = await createProduct("A Proposed", "proposed", sellerA.id)
+        const published = await createProduct("Global Published", "published", "other-actor")
+
+        const listAsA = await api.get("/vendor/products?limit=100", headersA)
+        const idsA = listAsA.data.products.map((p: { id: string }) => p.id)
+        expect(idsA).toEqual(expect.arrayContaining([proposedByA, published]))
+
+        const listAsB = await api.get("/vendor/products?limit=100", headersB)
+        const idsB = listAsB.data.products.map((p: { id: string }) => p.id)
+        expect(idsB).toContain(published)
+        expect(idsB).not.toContain(proposedByA)
+      })
+
+      it("hides a restricted published product from sellers it is not assigned to", async () => {
+        // Published, but restricted (product_seller) to seller A only.
+        const restrictedToA = await createProduct(
+          "Restricted To A",
+          "published",
+          "other-actor",
+          [sellerA.id]
+        )
+
+        const listAsA = await api.get("/vendor/products?limit=100", headersA)
+        const idsA = listAsA.data.products.map((p: { id: string }) => p.id)
+        expect(idsA).toContain(restrictedToA)
+
+        const listAsB = await api.get("/vendor/products?limit=100", headersB)
+        const idsB = listAsB.data.products.map((p: { id: string }) => p.id)
+        expect(idsB).not.toContain(restrictedToA)
+      })
     })
   },
 })

--- a/integration-tests/http/product/vendor/product.spec.ts
+++ b/integration-tests/http/product/vendor/product.spec.ts
@@ -109,11 +109,6 @@ medusaIntegrationTestRunner({
           sellerHeaders,
         )
 
-      const valueNames = (product: any) =>
-        (product.product_attribute_values ?? [])
-          .map((v: any) => v.name)
-          .sort()
-
       // Axis attachment via the ProductOption side (product.options populate is
       // broken on the 2.16 preview build).
       const optionAttached = async (productId: string, title: string) => {
@@ -136,71 +131,8 @@ medusaIntegrationTestRunner({
         (await api.get(`/vendor/products/${productId}`, sellerHeaders)).data
           .product
 
-      const optionIsExclusive = async (title: string) => {
-        const query = appContainer.resolve(ContainerRegistrationKeys.QUERY)
-        const { data } = await query.graph({
-          entity: "product_option",
-          fields: ["title", "is_exclusive"],
-          filters: { title },
-        })
-        return data[0]?.is_exclusive
-      }
-
       const scopedAttr = (product: any, name: string) =>
         (product.scoped_attributes ?? []).find((a: any) => a.name === name)
-
-      const listChanges = async (productId: string) => {
-        const query = appContainer.resolve(ContainerRegistrationKeys.QUERY)
-        const { data } = await query.graph({
-          entity: "product_change",
-          fields: ["id", "status", "product_id", "actions.*"],
-          filters: { product_id: productId },
-        })
-        return data as Array<{
-          id: string
-          status: string
-          actions: Array<{ action: string; details: Record<string, unknown> }>
-        }>
-      }
-
-      it("add: axis attach + toggle, then non-axis remove (202 + auto-confirm)", async () => {
-        const color = await createAttr({
-          name: "Color",
-          type: "multi_select",
-          is_variant_axis: true,
-          values: ["Red", "Blue"],
-        })
-        const waterproof = await createAttr({
-          name: "Waterproof",
-          type: "toggle",
-        })
-        const productId = await createOwnedProduct()
-
-        const added = await batch(productId, {
-          add: [
-            { id: color.id, value_ids: [color.byName.get("Red")!] },
-            { id: waterproof.id, value: true },
-          ],
-        })
-        expect(added.status).toEqual(202)
-        expect(added.data.product_change.product_id).toBe(productId)
-        // Applied inline by auto-confirm. The selected axis value (Red) is
-        // linked into the pivot alongside the toggle so the formatter can
-        // surface the axis selection (native options populate is broken on 2.16).
-        expect(valueNames(await getProduct(productId))).toEqual(["Red", "true"])
-
-        // toggle swap true → false (non-axis); the axis link is untouched.
-        const updated = await batch(productId, {
-          update: [{ id: waterproof.id, value: false }],
-        })
-        expect(updated.status).toEqual(202)
-        expect(valueNames(await getProduct(productId))).toEqual(["Red", "false"])
-
-        // remove the toggle value link; the axis link remains.
-        const removed = await batch(productId, { remove: [waterproof.id] })
-        expect(removed.status).toEqual(202)
-        expect(valueNames(await getProduct(productId))).toEqual(["Red"])
-      })
 
       it("add: inline axis → exclusive option + scoped attribute", async () => {
         const productId = await createOwnedProduct()
@@ -312,29 +244,6 @@ medusaIntegrationTestRunner({
         ).toBe(text.id)
       })
 
-      it("auto-confirm applies the staged batch inline (flag off) and marks the change CONFIRMED", async () => {
-        const flag = await createAttr({ name: "ConfirmFlag", type: "toggle" })
-        const productId = await createOwnedProduct()
-
-        const res = await batch(productId, {
-          add: [{ id: flag.id, value: true }],
-        })
-        expect(res.status).toEqual(202)
-
-        // Applied state is visible immediately.
-        expect(valueNames(await getProduct(productId))).toEqual(["true"])
-
-        // The change opened by this batch is auto-confirmed.
-        const changes = await listChanges(productId)
-        const attrChange = changes.find((c) =>
-          c.actions.some(
-            (a) => a.action === ProductChangeActionType.ATTRIBUTE_ADD,
-          ),
-        )
-        expect(attrChange).toBeDefined()
-        expect(attrChange!.status).toBe(ProductChangeStatus.CONFIRMED)
-      })
-
       it("rejects a second batch while a pending change is open", async () => {
         const attr = await createAttr({ name: "PendingAttr", type: "text" })
         const productId = await createOwnedProduct()
@@ -365,176 +274,6 @@ medusaIntegrationTestRunner({
         expect(err.response.status).toBeGreaterThanOrEqual(400)
       })
 
-      // --- POST /vendor/products with the unified attributes[] input ---
-
-      it("create: product with attributes[] + variant bound to axis options", async () => {
-        const multi = await createAttr({
-          name: "Multi Select",
-          type: "multi_select" as AttributeType,
-          is_variant_axis: true,
-          values: ["Value 1", "Value 2"],
-        })
-        const single = await createAttr({
-          name: "Single Select",
-          type: "single_select" as AttributeType,
-          values: ["A", "B"],
-        })
-        const toggle = await createAttr({
-          name: "Flag",
-          type: "toggle" as AttributeType,
-        })
-
-        const res = await api.post(
-          "/vendor/products",
-          {
-            title: "Vendor Created Product",
-            status: "proposed",
-            attributes: [
-              { id: multi.id, value_ids: [multi.byName.get("Value 1")!] },
-              { id: single.id, value_ids: [single.byName.get("A")!] },
-              { title: "Size", values: ["S", "M"], is_variant_axis: true },
-              { title: "Weight", type: "unit", value: "10kg" },
-              { id: toggle.id, value: true },
-            ],
-            variants: [
-              {
-                title: "default variant",
-                options: { Size: "S", "Multi Select": "Value 1" },
-              },
-            ],
-          },
-          sellerHeaders,
-        )
-
-        expect([200, 201]).toContain(res.status)
-        const productId = res.data.product.id
-
-        // non-axis selections → value links.
-        expect(valueNames(res.data.product)).toEqual(
-          expect.arrayContaining(["10kg", "A", "true"]),
-        )
-        // inline attributes → product-scoped.
-        const scopedNames = (res.data.product.scoped_attributes ?? []).map(
-          (a: any) => a.name,
-        )
-        expect(scopedNames).toEqual(expect.arrayContaining(["Size", "Weight"]))
-        // axis attributes → native options attached.
-        expect(await optionAttached(productId, "Multi Select")).toBe(true)
-        expect(await optionAttached(productId, "Size")).toBe(true)
-
-        // the variant was created and bound to the axis option values.
-        const query = appContainer.resolve(ContainerRegistrationKeys.QUERY)
-        const { data } = await query.graph({
-          entity: "product_variant",
-          fields: ["id", "title"],
-          filters: { product_id: productId },
-        })
-        expect(data.some((v: any) => v.title === "default variant")).toBe(true)
-      })
-
-      // --- SPEC-014 full attribute-kind matrix (happy path) over the staged
-      // vendor surface (202 → auto-confirm → GET shows the applied links) ---
-
-      it("add: full attribute matrix → 202 auto-confirm, every kind linked", async () => {
-        const multi = await createAttr({
-          name: "Multi Select",
-          type: "multi_select" as AttributeType,
-          is_variant_axis: true,
-          values: ["Value 1", "Value 2"],
-        })
-        const single = await createAttr({
-          name: "Single Select",
-          type: "single_select" as AttributeType,
-          values: ["Cotton", "Wool"],
-        })
-        const text = await createAttr({
-          name: "Free Text",
-          type: "text" as AttributeType,
-        })
-        const toggle = await createAttr({
-          name: "Flag",
-          type: "toggle" as AttributeType,
-        })
-        const productId = await createOwnedProduct()
-
-        const res = await batch(productId, {
-          add: [
-            { id: multi.id, value_ids: [multi.byName.get("Value 1")!] },
-            { id: single.id, value_ids: [single.byName.get("Cotton")!] },
-            { title: "Size", values: ["S", "M", "L", "XL"], is_variant_axis: true },
-            { id: text.id, value: "free text" },
-            { title: "Weight", type: "unit", value: "10kg", is_variant_axis: false },
-            { id: toggle.id, value: true },
-          ],
-        })
-        expect(res.status).toEqual(202)
-
-        // Applied inline by auto-confirm — re-read the product to assert links.
-        const product = await getProduct(productId)
-        expect(valueNames(product)).toEqual(
-          expect.arrayContaining(["10kg", "Cotton", "free text", "true"]),
-        )
-        // existing axis → shared option; inline axis → exclusive option + scoped.
-        expect(await optionAttached(productId, "Multi Select")).toBe(true)
-        expect(await optionIsExclusive("Multi Select")).toBe(false)
-        expect(await optionAttached(productId, "Size")).toBe(true)
-        expect(await optionIsExclusive("Size")).toBe(true)
-        expect(scopedAttr(product, "Size")).toBeTruthy()
-        expect(scopedAttr(product, "Weight")).toBeTruthy()
-      })
-
-      it("GET created product surfaces all linked attribute kinds", async () => {
-        const multi = await createAttr({
-          name: "Multi Select",
-          type: "multi_select" as AttributeType,
-          is_variant_axis: true,
-          values: ["Value 1", "Value 2"],
-        })
-        const single = await createAttr({
-          name: "Single Select",
-          type: "single_select" as AttributeType,
-          values: ["A", "B"],
-        })
-        const toggle = await createAttr({
-          name: "Flag",
-          type: "toggle" as AttributeType,
-        })
-
-        const created = await api.post(
-          "/vendor/products",
-          {
-            title: "Vendor Created Product",
-            status: "proposed",
-            attributes: [
-              { id: multi.id, value_ids: [multi.byName.get("Value 1")!] },
-              { id: single.id, value_ids: [single.byName.get("A")!] },
-              { title: "Size", values: ["S", "M"], is_variant_axis: true },
-              { title: "Weight", type: "unit", value: "10kg" },
-              { id: toggle.id, value: true },
-            ],
-            variants: [
-              {
-                title: "default variant",
-                options: { Size: "S", "Multi Select": "Value 1" },
-              },
-            ],
-          },
-          sellerHeaders,
-        )
-        expect([200, 201]).toContain(created.status)
-        const productId = created.data.product.id
-
-        const product = await getProduct(productId)
-        expect(valueNames(product)).toEqual(
-          expect.arrayContaining(["10kg", "A", "true"]),
-        )
-        const scopedNames = (product.scoped_attributes ?? []).map(
-          (a: any) => a.name,
-        )
-        expect(scopedNames).toEqual(expect.arrayContaining(["Size", "Weight"]))
-        expect(await optionAttached(productId, "Multi Select")).toBe(true)
-        expect(await optionAttached(productId, "Size")).toBe(true)
-      })
     })
   },
 })

--- a/integration-tests/http/returns/vendor/returns.spec.ts
+++ b/integration-tests/http/returns/vendor/returns.spec.ts
@@ -8,6 +8,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { createSellerUser } from "../../../helpers/create-seller-user"
 import { createCustomerUser } from "../../../helpers/create-customer-user"
 import { generatePublishableKey, generateStoreHeaders } from "../../../helpers/create-admin-user"
+import { createVendorProduct } from "../../../helpers/create-product"
 
 jest.setTimeout(120000)
 
@@ -85,24 +86,10 @@ medusaIntegrationTestRunner({
                 // Create product for seller 1. Pricing + inventory live on the
                 // offer (see SPEC-002); link the product to the sales channel
                 // separately.
-                const product1Response = await api.post(
-                    `/vendor/products`,
-                    {
-                        status: 'published',
-                        title: "Returns Product 1",
-                        description: "Product from seller 1 for returns",
-                        options: [{ title: "Size", values: ["S", "M"] }],
-                        variants: [
-                            {
-                                title: "Small",
-                                sku: "RET-SELLER1-S",
-                                options: { Size: "S" },
-                            },
-                        ],
-                    },
-                    seller1Headers
-                )
-                product1 = product1Response.data.product
+                product1 = await createVendorProduct(api, seller1Headers, {
+                    title: "Returns Product 1",
+                    sku: "RET-SELLER1-S",
+                })
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,
                     { add: [product1.id] },
@@ -110,24 +97,10 @@ medusaIntegrationTestRunner({
                 )
 
                 // Create product for seller 2
-                const product2Response = await api.post(
-                    `/vendor/products`,
-                    {
-                        status: 'published',
-                        title: "Returns Product 2",
-                        description: "Product from seller 2 for returns",
-                        options: [{ title: "Color", values: ["Red"] }],
-                        variants: [
-                            {
-                                title: "Red",
-                                sku: "RET-SELLER2-RED",
-                                options: { Color: "Red" },
-                            },
-                        ],
-                    },
-                    seller2Headers
-                )
-                product2 = product2Response.data.product
+                product2 = await createVendorProduct(api, seller2Headers, {
+                    title: "Returns Product 2",
+                    sku: "RET-SELLER2-RED",
+                })
                 await api.post(
                     `/vendor/sales-channels/${salesChannel.id}/products`,
                     { add: [product2.id] },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -707,7 +707,8 @@
         "label": "Collection"
       },
       "stores": {
-        "label": "Stores"
+        "label": "Restricted to stores",
+        "hint": "Leave empty to make this product available in all stores. Select stores to restrict it to only those."
       },
       "categories": {
         "label": "Categories"

--- a/packages/admin/src/pages/products/product-create/components/product-create-organize-form/components/product-create-organize-section/product-create-details-organize-section.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-organize-form/components/product-create-organize-section/product-create-details-organize-section.tsx
@@ -182,6 +182,9 @@ export const ProductCreateOrganizationSection = () => {
                     data-testid="product-create-organize-section-stores-input"
                   />
                 </Form.Control>
+                <Form.Hint data-testid="product-create-organize-section-stores-hint">
+                  {t("products.fields.stores.hint")}
+                </Form.Hint>
                 <Form.ErrorMessage />
               </Form.Item>
             )

--- a/packages/admin/src/pages/products/product-create/utils.ts
+++ b/packages/admin/src/pages/products/product-create/utils.ts
@@ -13,7 +13,23 @@ export const normalizeProductFormValues = (
     ?.filter((media) => !media.isThumbnail)
     .map((media) => ({ url: media.url }))
 
+  const hasAxis = (values.attributes ?? []).some(
+    (a) => a.use_for_variants && toValueArray(a.values).length > 0
+  )
+
   const attributes = normalizeFormAttributes(values.attributes ?? [])
+
+  // Mirror Medusa's default-option seeding: a product with no real variant axis
+  // still needs one option + a default variant, modeled here as a synthetic
+  // inline axis attribute that flows through the standard inline-axis path.
+  if (!hasAxis) {
+    attributes.push({
+      title: "Default Option",
+      type: AttributeType.MULTI_SELECT,
+      values: ["Default"],
+      is_variant_axis: true,
+    })
+  }
 
   return {
     is_giftcard: false,
@@ -43,6 +59,7 @@ export const normalizeProductFormValues = (
     attributes: attributes.length ? attributes : undefined,
     variants: normalizeVariants(
       values.variants.filter((variant) => variant.should_create),
+      hasAxis,
       values.regionsCurrencyMap
     ),
   } as any
@@ -50,6 +67,7 @@ export const normalizeProductFormValues = (
 
 export const normalizeVariants = (
   variants: ProductCreateSchemaType["variants"],
+  hasAxis: boolean,
   _regionsCurrencyMap: Record<string, string>
 ): any[] => {
   return variants.map((variant) => {
@@ -58,7 +76,7 @@ export const normalizeVariants = (
 
     return {
       title: variant.title || (hasOpts ? Object.values(opts).join(" / ") : "Default variant"),
-      options: hasOpts ? opts : undefined,
+      options: hasOpts ? opts : hasAxis ? undefined : { "Default Option": "Default" },
       sku: variant.sku || undefined,
       variant_rank: variant.variant_rank,
     }

--- a/packages/admin/src/pages/products/product-detail/components/product-variant-section/product-variant-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-variant-section/product-variant-section.tsx
@@ -2,30 +2,32 @@ import { useCallback, useMemo } from "react";
 
 import { PencilSquare, Trash } from "@medusajs/icons";
 import { HttpTypes } from "@medusajs/types";
-import { ProductDTO } from "@mercurjs/types";
+import { ProductDTO, ProductVariantDTO } from "@mercurjs/types";
 import {
   Badge,
   Button,
   Container,
-  createDataTableColumnHelper,
-  DataTableAction,
   Heading,
+  toast,
   Tooltip,
   usePrompt,
 } from "@medusajs/ui";
 import { keepPreviousData } from "@tanstack/react-query";
-import { CellContext } from "@tanstack/react-table";
+import { createColumnHelper } from "@tanstack/react-table";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
-import { DataTable } from "../../../../../components/data-table";
-import { useDataTableDateColumns } from "../../../../../components/data-table/helpers/general/use-data-table-date-columns";
-import { useDataTableDateFilters } from "../../../../../components/data-table/helpers/general/use-data-table-date-filters";
+import { ActionMenu } from "../../../../../components/common/action-menu";
+import { Thumbnail } from "../../../../../components/common/thumbnail";
+import { _DataTable, Filter } from "../../../../../components/table/data-table";
+import { DataTableOrderByKey } from "../../../../../components/table/data-table/data-table-order-by";
 import {
   useDeleteVariantLazy,
   useProductVariants,
 } from "../../../../../hooks/api/products";
+import { useDataTable } from "../../../../../hooks/use-data-table";
 import { useQueryParams } from "../../../../../hooks/use-query-params";
+
 const PAGE_SIZE = 10;
 const PREFIX = "pv";
 
@@ -41,10 +43,7 @@ export const ProductVariantSection = ({
     PREFIX,
   );
 
-  const columns = useColumns(product);
-  const filters = useFilters();
-
-  const { variants, count, isPending, isError, error } = useProductVariants(
+  const { variants, count, isLoading, isError, error } = useProductVariants(
     product.id,
     {
       q,
@@ -53,25 +52,32 @@ export const ProductVariantSection = ({
       limit: PAGE_SIZE,
       created_at: created_at ? JSON.parse(created_at) : undefined,
       updated_at: updated_at ? JSON.parse(updated_at) : undefined,
-      fields:
-        "title,sku,created_at,updated_at,*options,*options.option",
+      fields: "title,sku,created_at,updated_at,*options,*options.option",
     },
     {
       placeholderData: keepPreviousData,
     },
   );
 
+  const columns = useColumns(product);
+  const filters = useFilters();
+  const orderBy = useOrderBy();
+
+  const { table } = useDataTable({
+    data: variants ?? [],
+    columns,
+    count,
+    pageSize: PAGE_SIZE,
+    getRowId: (row) => row.id,
+    prefix: PREFIX,
+  });
+
   if (isError) {
     throw error;
   }
 
-  // No `divide-y` on the Container: this section draws its own header, so the
-  // DataTable renders only its filter bar, which already has a `border-t`. A
-  // Container divider would stack a second line between the header and the
-  // filter row (the doubled divider reported in MER-129); the filter bar owns
-  // that separator.
   return (
-    <Container className="p-0" data-testid="product-variant-section">
+    <Container className="divide-y p-0" data-testid="product-variant-section">
       <div className="flex items-center justify-between px-6 py-4">
         <Heading level="h2">{t("products.variants.header")}</Heading>
         <Button
@@ -83,35 +89,29 @@ export const ProductVariantSection = ({
           <Link to="variants/create">{t("actions.create")}</Link>
         </Button>
       </div>
-      <div data-testid="product-variants-table-container">
-        <DataTable
-          data={variants}
-          columns={columns}
-          filters={filters}
-          rowCount={count}
-          getRowId={(row) => row.id}
-          rowHref={(row) => `/products/${product.id}/variants/${row.id}`}
-          pageSize={PAGE_SIZE}
-          isLoading={isPending}
-          emptyState={{
-            empty: {
-              heading: t("products.variants.empty.heading"),
-              description: t("products.variants.empty.description"),
-            },
-            filtered: {
-              heading: t("products.variants.filtered.heading"),
-              description: t("products.variants.filtered.description"),
-            },
-          }}
-          prefix={PREFIX}
-        />
-      </div>
+      <_DataTable
+        table={table}
+        columns={columns}
+        count={count}
+        pageSize={PAGE_SIZE}
+        filters={filters}
+        search
+        pagination
+        isLoading={isLoading}
+        orderBy={orderBy}
+        prefix={PREFIX}
+        queryObject={{ q, order, created_at, updated_at }}
+        navigateTo={(row) => `variants/${row.original.id}`}
+        noRecords={{
+          title: t("products.variants.empty.heading"),
+          message: t("products.variants.empty.description"),
+        }}
+      />
     </Container>
   );
 };
 
-const columnHelper =
-  createDataTableColumnHelper<HttpTypes.AdminProductVariant>();
+const columnHelper = createColumnHelper<ProductVariantDTO>();
 
 const useColumns = (product: HttpTypes.AdminProduct) => {
   const { t } = useTranslation();
@@ -130,8 +130,6 @@ const useColumns = (product: HttpTypes.AdminProduct) => {
     return filtered;
   }, [searchParams]);
 
-  const dateColumns = useDataTableDateColumns<HttpTypes.AdminProductVariant>();
-
   const handleDelete = useCallback(
     async (id: string, title: string) => {
       const res = await prompt({
@@ -147,7 +145,14 @@ const useColumns = (product: HttpTypes.AdminProduct) => {
         return;
       }
 
-      await mutateAsync({ variantId: id });
+      await mutateAsync(
+        { variantId: id },
+        {
+          onError: (error) => {
+            toast.error(error.message);
+          },
+        },
+      );
     },
     [mutateAsync, prompt, t],
   );
@@ -200,75 +205,99 @@ const useColumns = (product: HttpTypes.AdminProduct) => {
     });
   }, [product]);
 
-  const getActions = useCallback(
-    (ctx: CellContext<HttpTypes.AdminProductVariant, unknown>) => {
-      const variant = ctx.row.original;
-
-      const mainActions: DataTableAction<HttpTypes.AdminProductVariant>[] = [
-        {
-          icon: <PencilSquare />,
-          label: t("actions.edit"),
-          onClick: (row) => {
-            navigate(
-              `edit-variant?variant_id=${row.row.original.id}&${tableSearchParams.toString()}`,
-              {
-                state: {
-                  restore_params: tableSearchParams.toString(),
-                },
-              },
-            );
-          },
-        },
-      ];
-
-      const secondaryActions: DataTableAction<HttpTypes.AdminProductVariant>[] =
-        [
-          {
-            icon: <Trash />,
-            label: t("actions.delete"),
-            onClick: () => handleDelete(variant.id, variant.title!),
-          },
-        ];
-
-      return [mainActions, secondaryActions];
-    },
-    [handleDelete, navigate, t, tableSearchParams],
-  );
-
-  return useMemo(() => {
-    return [
+  return useMemo(
+    () => [
       columnHelper.accessor("title", {
+        id: "title",
         header: t("fields.title"),
-        enableSorting: true,
-        sortAscLabel: t("filters.sorting.alphabeticallyAsc"),
-        sortDescLabel: t("filters.sorting.alphabeticallyDesc"),
-      }),
-      columnHelper.accessor("sku", {
-        header: t("fields.sku"),
         cell: ({ getValue }) => {
           const value = getValue();
-          return value ? (
-            value
-          ) : (
-            <span className="text-ui-fg-muted">-</span>
+          return (
+            <div className="flex h-full w-full max-w-[250px] items-center gap-x-3 overflow-hidden">
+              <div className="w-fit flex-shrink-0">
+                <Thumbnail src={product.thumbnail} />
+              </div>
+              {value ? (
+                <span title={value} className="truncate">
+                  {value}
+                </span>
+              ) : (
+                <span className="text-ui-fg-muted">-</span>
+              )}
+            </div>
           );
         },
       }),
-      ...attributeColumns,
-      ...dateColumns,
-      columnHelper.action({
-        actions: getActions,
+      columnHelper.accessor("sku", {
+        id: "sku",
+        header: t("fields.sku"),
+        cell: ({ getValue }) => {
+          const value = getValue();
+          return value ? value : <span className="text-ui-fg-muted">-</span>;
+        },
       }),
-    ];
-  }, [t, attributeColumns, dateColumns, getActions]);
+      ...attributeColumns,
+      columnHelper.display({
+        id: "actions",
+        cell: ({ row }) => (
+          <ActionMenu
+            groups={[
+              {
+                actions: [
+                  {
+                    icon: <PencilSquare />,
+                    label: t("actions.edit"),
+                    onClick: () =>
+                      navigate(
+                        `edit-variant?variant_id=${row.original.id}&${tableSearchParams.toString()}`,
+                        {
+                          state: {
+                            restore_params: tableSearchParams.toString(),
+                          },
+                        },
+                      ),
+                  },
+                ],
+              },
+              {
+                actions: [
+                  {
+                    icon: <Trash />,
+                    label: t("actions.delete"),
+                    onClick: () =>
+                      handleDelete(row.original.id, row.original.title ?? ""),
+                  },
+                ],
+              },
+            ]}
+          />
+        ),
+      }),
+    ],
+    [t, attributeColumns, navigate, handleDelete, tableSearchParams, product],
+  );
 };
 
-const useFilters = () => {
-  const dateFilters = useDataTableDateFilters();
+const useFilters = (): Filter[] => {
+  const { t } = useTranslation();
 
-  return useMemo(() => {
-    return [
-      ...dateFilters,
-    ];
-  }, [dateFilters]);
+  return useMemo(
+    () => [
+      { key: "created_at", label: t("fields.createdAt"), type: "date" },
+      { key: "updated_at", label: t("fields.updatedAt"), type: "date" },
+    ],
+    [t],
+  );
+};
+
+const useOrderBy = (): DataTableOrderByKey<ProductVariantDTO>[] => {
+  const { t } = useTranslation();
+
+  return useMemo(
+    () => [
+      { key: "title", label: t("fields.title") },
+      { key: "sku", label: t("fields.sku") },
+    ],
+    [t],
+  );
 };

--- a/packages/core/src/api/admin/products/route.ts
+++ b/packages/core/src/api/admin/products/route.ts
@@ -65,6 +65,7 @@ export const POST = async (
       products: [{
         ...productData,
       }],
+      created_by: req.auth_context.actor_id,
       additional_data,
     } as any,
   })

--- a/packages/core/src/api/store/products/query-config.ts
+++ b/packages/core/src/api/store/products/query-config.ts
@@ -31,10 +31,10 @@ export const defaultStoreProductFields = [
   "*variants.options",
   "*options",
   "*options.values",
-  // Cross-module chained populate (e.g.
-  // `*product_attribute_values.attribute.values`) crashes MikroORM's
-  // `expandDotPaths`, so we keep the joiner request single-hop.
   "product_attribute_values.id",
+  "product_attribute_values.name",
+  "product_attribute_values.rank",
+  "product_attribute_values.attribute_id",
 ]
 
 export const storeProductQueryConfig = {

--- a/packages/core/src/api/vendor/product-categories/[id]/products/route.ts
+++ b/packages/core/src/api/vendor/product-categories/[id]/products/route.ts
@@ -36,11 +36,7 @@ export const POST = async (
   }
 
   const productIds = [...(add ?? []), ...(remove ?? [])]
-  await Promise.all(
-    productIds.map((productId) =>
-      ensureSellerOwnsProduct(req.scope, sellerId, productId)
-    )
-  )
+  await ensureSellerOwnsProduct(req.scope, sellerId, productIds)
 
   await batchLinkProductsToCategoryWorkflow(req.scope).run({
     input: {

--- a/packages/core/src/api/vendor/product-variants/middlewares.ts
+++ b/packages/core/src/api/vendor/product-variants/middlewares.ts
@@ -5,9 +5,12 @@ import {
   MiddlewareRoute,
 } from "@medusajs/framework/http"
 import { validateAndTransformQuery } from "@medusajs/framework"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { ProductStatus } from "@mercurjs/types"
 
+import {
+  getProductIdsRestrictedFromSeller,
+  getSellerOwnedProductIds,
+} from "../products/helpers"
 import { vendorProductVariantsQueryConfig } from "./query-config"
 import { VendorGetProductVariantsParams } from "./validators"
 
@@ -17,17 +20,11 @@ const applySellerProductVariantFilter = async (
   next: MedusaNextFunction
 ) => {
   const sellerId = req.seller_context!.seller_id
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  const { data: links } = await query.graph({
-    entity: "product_seller",
-    fields: ["product_id"],
-    filters: { seller_id: sellerId },
-  })
-
-  const sellerProductIds = links
-    .map((link: { product_id: string | null }) => link.product_id)
-    .filter((id: string | null): id is string => Boolean(id))
+  const [ownProductIds, restrictedFromSellerIds] = await Promise.all([
+    getSellerOwnedProductIds(req.scope, sellerId),
+    getProductIdsRestrictedFromSeller(req.scope, sellerId),
+  ])
 
   req.filterableFields ??= {}
   const existingAnd = (req.filterableFields.$and as object[] | undefined) ?? []
@@ -35,8 +32,11 @@ const applySellerProductVariantFilter = async (
     ...existingAnd,
     {
       $or: [
-        { product: { status: ProductStatus.PUBLISHED } },
-        { product_id: sellerProductIds },
+        { product_id: ownProductIds },
+        {
+          product: { status: ProductStatus.PUBLISHED },
+          product_id: { $nin: restrictedFromSellerIds },
+        },
       ],
     },
   ]

--- a/packages/core/src/api/vendor/products/[id]/attributes/batch/route.ts
+++ b/packages/core/src/api/vendor/products/[id]/attributes/batch/route.ts
@@ -6,7 +6,6 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { ProductAttributeBatchInput, ProductChangeDTO } from "@mercurjs/types"
 
 import { productEditUpdateAttributesWorkflow } from "../../../../../../workflows/product-edit/workflows/product-edit-update-attributes"
-import { ensureSellerOwnsProduct } from "../../../helpers"
 
 export const POST = async (
   req: AuthenticatedMedusaRequest<ProductAttributeBatchInput>,
@@ -15,8 +14,6 @@ export const POST = async (
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const sellerId = req.seller_context!.seller_id
   const productId = req.params.id
-
-  await ensureSellerOwnsProduct(req.scope, sellerId, productId)
 
   const { add, remove, update } = req.validatedBody
 

--- a/packages/core/src/api/vendor/products/helpers.ts
+++ b/packages/core/src/api/vendor/products/helpers.ts
@@ -3,6 +3,60 @@ import {
   MedusaError,
 } from "@medusajs/framework/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
+import { ProductChangeActionType } from "@mercurjs/types"
+
+export const getSellerOwnedProductIds = async (
+  scope: MedusaContainer,
+  sellerId: string
+): Promise<string[]> => {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: actions } = await query.graph({
+    entity: "product_change_action",
+    fields: ["product_id"],
+    filters: {
+      action: ProductChangeActionType.PRODUCT_ADD,
+      product_change: { created_by: sellerId },
+    },
+  })
+
+  return actions
+    .map(action => action.product_id)
+}
+
+/**
+ * Product ids that are restricted (have at least one `product_seller` row) but
+ * NOT assigned to this seller — i.e. restricted to other sellers, so they must
+ * be hidden from this seller's product list.
+ */
+export const getProductIdsRestrictedFromSeller = async (
+  scope: MedusaContainer,
+  sellerId: string
+): Promise<string[]> => {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: links } = await query.graph({
+    entity: "product_seller",
+    fields: ["product_id", "seller_id"],
+  })
+
+  const assigned = new Set<string>()
+  const restricted = new Set<string>()
+  for (const link of links as {
+    product_id: string | null
+    seller_id: string | null
+  }[]) {
+    if (!link.product_id) {
+      continue
+    }
+    restricted.add(link.product_id)
+    if (link.seller_id === sellerId) {
+      assigned.add(link.product_id)
+    }
+  }
+
+  return Array.from(restricted).filter((id) => !assigned.has(id))
+}
 
 export const ensureSellerOwnsProduct = async (
   scope: MedusaContainer,

--- a/packages/core/src/api/vendor/products/helpers.ts
+++ b/packages/core/src/api/vendor/products/helpers.ts
@@ -7,8 +7,12 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 export const ensureSellerOwnsProduct = async (
   scope: MedusaContainer,
   sellerId: string,
-  productId: string
+  productIds: string[]
 ): Promise<void> => {
+  if (!productIds.length) {
+    return
+  }
+
   const query = scope.resolve(ContainerRegistrationKeys.QUERY)
 
   const { data } = await query.graph({
@@ -16,14 +20,17 @@ export const ensureSellerOwnsProduct = async (
     fields: ["product_id"],
     filters: {
       seller_id: sellerId,
-      product_id: productId,
+      product_id: productIds,
     },
   })
 
-  if (!data?.length) {
+  const ownedProductIds = new Set(data.map(({ product_id }) => product_id))
+  const missingProductId = productIds.find((id) => !ownedProductIds.has(id))
+
+  if (missingProductId) {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
-      `Product with id ${productId} was not found`
+      `Product with id ${missingProductId} was not found`
     )
   }
 }

--- a/packages/core/src/api/vendor/products/helpers.ts
+++ b/packages/core/src/api/vendor/products/helpers.ts
@@ -69,6 +69,8 @@ export const ensureSellerOwnsProduct = async (
 
   const query = scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  // A seller may manage a product it is assigned to (product_seller eligibility)
+  // OR a product it created (master-product authoring).
   const { data } = await query.graph({
     entity: "product_seller",
     fields: ["product_id"],
@@ -78,7 +80,12 @@ export const ensureSellerOwnsProduct = async (
     },
   })
 
-  const ownedProductIds = new Set(data.map(({ product_id }) => product_id))
+  const ownedProductIds = new Set<string | null>(
+    data.map(({ product_id }) => product_id)
+  )
+  for (const id of await getSellerOwnedProductIds(scope, sellerId)) {
+    ownedProductIds.add(id)
+  }
   const missingProductId = productIds.find((id) => !ownedProductIds.has(id))
 
   if (missingProductId) {

--- a/packages/core/src/api/vendor/products/middlewares.ts
+++ b/packages/core/src/api/vendor/products/middlewares.ts
@@ -8,10 +8,13 @@ import {
   validateAndTransformBody,
   validateAndTransformQuery,
 } from "@medusajs/framework"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { ProductStatus } from "@mercurjs/types"
 
 import { applyOfferedProductsFilter } from "../../utils"
+import {
+  getProductIdsRestrictedFromSeller,
+  getSellerOwnedProductIds,
+} from "./helpers"
 import {
   vendorProductQueryConfig,
   vendorProductVariantQueryConfig,
@@ -35,17 +38,11 @@ const applySellerProductLinkFilter = async (
   next: MedusaNextFunction
 ) => {
   const sellerId = req.seller_context!.seller_id
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  const { data: links } = await query.graph({
-    entity: "product_seller",
-    fields: ["product_id"],
-    filters: { seller_id: sellerId },
-  })
-
-  const sellerProductIds = links
-    .map((link: { product_id: string | null }) => link.product_id)
-    .filter((id: string | null): id is string => Boolean(id))
+  const [ownProductIds, restrictedFromSellerIds] = await Promise.all([
+    getSellerOwnedProductIds(req.scope, sellerId),
+    getProductIdsRestrictedFromSeller(req.scope, sellerId),
+  ])
 
   req.filterableFields ??= {}
   const existingAnd = (req.filterableFields.$and as object[] | undefined) ?? []
@@ -53,8 +50,11 @@ const applySellerProductLinkFilter = async (
     ...existingAnd,
     {
       $or: [
-        { status: ProductStatus.PUBLISHED },
-        { id: sellerProductIds },
+        { id: ownProductIds },
+        {
+          status: ProductStatus.PUBLISHED,
+          id: { $nin: restrictedFromSellerIds },
+        },
       ],
     },
   ]

--- a/packages/core/src/api/vendor/products/route.ts
+++ b/packages/core/src/api/vendor/products/route.ts
@@ -61,7 +61,6 @@ export const POST = async (
   res: MedusaResponse<HttpTypes.VendorProductResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-  const sellerId = req.seller_context!.seller_id
 
   const { additional_data, ...payload } = req.validatedBody
 
@@ -73,7 +72,6 @@ export const POST = async (
   const { result } = await createProductsWorkflow(req.scope).run({
     input: {
       products: [productInput],
-      seller_ids: [sellerId],
       additional_data,
     },
   })

--- a/packages/core/src/api/vendor/products/route.ts
+++ b/packages/core/src/api/vendor/products/route.ts
@@ -61,6 +61,7 @@ export const POST = async (
   res: MedusaResponse<HttpTypes.VendorProductResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const sellerId = req.seller_context!.seller_id
 
   const { additional_data, ...payload } = req.validatedBody
 
@@ -72,6 +73,7 @@ export const POST = async (
   const { result } = await createProductsWorkflow(req.scope).run({
     input: {
       products: [productInput],
+      created_by: sellerId,
       additional_data,
     },
   })

--- a/packages/core/src/api/vendor/sales-channels/helpers.ts
+++ b/packages/core/src/api/vendor/sales-channels/helpers.ts
@@ -5,6 +5,8 @@ import {
   MedusaError,
 } from "@medusajs/framework/utils"
 
+import { getSellerOwnedProductIds } from "../products/helpers"
+
 export const refetchSalesChannel = async (
   id: string,
   scope: MedusaContainer,
@@ -29,15 +31,19 @@ export const ensureSellerOwnsProducts = async (
 
   const query = scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  // Assigned via product_seller (eligibility) OR created by this seller.
   const { data: links } = await query.graph({
     entity: "product_seller",
     fields: ["product_id"],
     filters: { seller_id: sellerId, product_id: productIds },
   })
 
-  const ownedProductIds = new Set(
+  const ownedProductIds = new Set<string | null>(
     links.map((link: { product_id: string | null }) => link.product_id)
   )
+  for (const id of await getSellerOwnedProductIds(scope, sellerId)) {
+    ownedProductIds.add(id)
+  }
   const unowned = productIds.filter((id) => !ownedProductIds.has(id))
 
   if (unowned.length) {

--- a/packages/core/src/workflows/product/workflows/create-products.ts
+++ b/packages/core/src/workflows/product/workflows/create-products.ts
@@ -174,6 +174,7 @@ export const createProductsWorkflow: ReturnWorkflow<
           const formOptions = (v: unknown) =>
             (v as { options?: Record<string, string> }).options ?? {}
           return (p.variants ?? []).map((v) => ({
+            manage_inventory: false,
             ...v,
             product_id,
             options: hasAxisByIndex[idx]

--- a/packages/core/src/workflows/product/workflows/create-products.ts
+++ b/packages/core/src/workflows/product/workflows/create-products.ts
@@ -34,8 +34,8 @@ import { ProductWorkflowEvents } from "../events"
 
 
 export type CreateProductsWorkflowInput = {
-  products: CreateProductDTO[]
-  seller_ids?: string[]
+  products: (CreateProductDTO & { seller_ids?: string[] })[]
+  created_by: string
 } & AdditionalData
 
 export const createProductsWorkflowId = "mercur-create-products"
@@ -76,7 +76,12 @@ export const createProductsWorkflow: ReturnWorkflow<
     // Stock create hard-requires ≥1 option.
     const stockProducts = transform({ input }, ({ input }) =>
       input.products.map((p) => {
-        const { attributes: _attributes, variants: _variants, ...rest } = p
+        const {
+          attributes: _attributes,
+          variants: _variants,
+          seller_ids: _seller_ids,
+          ...rest
+        } = p
         return {
           ...rest,
           options: [{ title: "Default option", values: ["Default value"] }],
@@ -203,7 +208,7 @@ export const createProductsWorkflow: ReturnWorkflow<
         const links: { product_id: string; seller_id: string }[] = []
         input.products.forEach((p, idx) => {
           const product_id = createdProducts[idx]?.id
-          for (const seller_id of input.seller_ids ?? []) {
+          for (const seller_id of p.seller_ids ?? []) {
             links.push({ product_id, seller_id })
           }
         })
@@ -219,13 +224,13 @@ export const createProductsWorkflow: ReturnWorkflow<
       input: transform(
         { createdProducts, input },
         ({ createdProducts, input }) => ({
-          actor_id: input.seller_ids?.[0],
+          actor_id: input.created_by,
           changes: createdProducts.map((product) => ({
             product_id: product.id as string,
             actions: [
               {
                 product_id: product.id as string,
-                action: ProductChangeActionType.STATUS_CHANGE,
+                action: ProductChangeActionType.PRODUCT_ADD,
                 details: { status: product.status as string },
               },
             ],

--- a/packages/core/src/workflows/product/workflows/create-products.ts
+++ b/packages/core/src/workflows/product/workflows/create-products.ts
@@ -73,7 +73,11 @@ export const createProductsWorkflow: ReturnWorkflow<
       filters: { id: referencedAttrIds },
     }).config({ name: "mercur-create-products-axis-attrs" })
 
-    // Stock create hard-requires ≥1 option.
+    // Stock create hard-requires ≥1 option, but a product's real axis option is
+    // only attached after the row exists. So every product is born with this
+    // internal placeholder, which `defaultOptionRemovals` strips once a real
+    // option is present (axis products) and which is kept for genuinely
+    // axis-less products.
     const stockProducts = transform({ input }, ({ input }) =>
       input.products.map((p) => {
         const {
@@ -84,7 +88,7 @@ export const createProductsWorkflow: ReturnWorkflow<
         } = p
         return {
           ...rest,
-          options: [{ title: "Default option", values: ["Default value"] }],
+          options: [{ title: "__default__", values: ["__default__"] }],
         }
       }),
     )
@@ -156,7 +160,7 @@ export const createProductsWorkflow: ReturnWorkflow<
             return
           }
           const def = (p.options ?? []).find(
-            (o) => o.title === "Default option",
+            (o) => o.title === "__default__",
           )
           if (def) {
             pairs.push({ product_id: p.id, product_option_id: def.id })
@@ -184,7 +188,7 @@ export const createProductsWorkflow: ReturnWorkflow<
             product_id,
             options: hasAxisByIndex[idx]
               ? formOptions(v)
-              : { "Default option": "Default value", ...formOptions(v) },
+              : { __default__: "__default__", ...formOptions(v) },
           }))
         }),
     )

--- a/packages/types/src/product/common.ts
+++ b/packages/types/src/product/common.ts
@@ -48,6 +48,7 @@ export enum ProductChangeActionType {
   ATTRIBUTE_ADD = "ATTRIBUTE_ADD",
   ATTRIBUTE_REMOVE = "ATTRIBUTE_REMOVE",
   ATTRIBUTE_UPDATE = "ATTRIBUTE_UPDATE",
+  PRODUCT_ADD = "PRODUCT_ADD",
   PRODUCT_DELETE = "PRODUCT_DELETE",
   /**
    * Operator asked the vendor to revise a submission. Auto-applied

--- a/packages/vendor/src/pages/products/[id]/_components/product-variant-section/product-variant-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-variant-section/product-variant-section.tsx
@@ -2,30 +2,30 @@ import { useCallback, useMemo } from "react";
 
 import { PencilSquare, Trash } from "@medusajs/icons";
 import { HttpTypes } from "@medusajs/types";
-import { ProductDTO } from "@mercurjs/types";
+import { ProductDTO, ProductVariantDTO } from "@mercurjs/types";
 import {
   Badge,
   Button,
   Container,
-  createDataTableColumnHelper,
-  DataTableAction,
   Heading,
   toast,
   Tooltip,
   usePrompt,
 } from "@medusajs/ui";
 import { keepPreviousData } from "@tanstack/react-query";
-import { CellContext } from "@tanstack/react-table";
+import { createColumnHelper } from "@tanstack/react-table";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
-import { DataTable } from "../../../../../components/data-table";
-import { useDataTableDateColumns } from "../../../../../components/data-table/helpers/general/use-data-table-date-columns";
-import { useDataTableDateFilters } from "../../../../../components/data-table/helpers/general/use-data-table-date-filters";
+import { ActionMenu } from "../../../../../components/common/action-menu";
+import { Thumbnail } from "../../../../../components/common/thumbnail";
+import { _DataTable, Filter } from "../../../../../components/table/data-table";
+import { DataTableOrderByKey } from "../../../../../components/table/data-table/data-table-order-by";
 import {
   useDeleteVariantLazy,
   useProductVariants,
 } from "../../../../../hooks/api/products";
+import { useDataTable } from "../../../../../hooks/use-data-table";
 import { useQueryParams } from "../../../../../hooks/use-query-params";
 
 const PAGE_SIZE = 10;
@@ -43,10 +43,7 @@ export const ProductVariantSection = ({
     PREFIX,
   );
 
-  const columns = useColumns(product);
-  const filters = useFilters();
-
-  const { variants, count, isPending, isError, error } = useProductVariants(
+  const { variants, count, isLoading, isError, error } = useProductVariants(
     product.id,
     {
       q,
@@ -55,25 +52,32 @@ export const ProductVariantSection = ({
       limit: PAGE_SIZE,
       created_at: created_at ? JSON.parse(created_at) : undefined,
       updated_at: updated_at ? JSON.parse(updated_at) : undefined,
-      fields:
-        "title,sku,created_at,updated_at,*options,*options.option",
+      fields: "title,sku,created_at,updated_at,*options,*options.option",
     },
     {
       placeholderData: keepPreviousData,
     },
   );
 
+  const columns = useColumns(product);
+  const filters = useFilters();
+  const orderBy = useOrderBy();
+
+  const { table } = useDataTable({
+    data: variants ?? [],
+    columns,
+    count,
+    pageSize: PAGE_SIZE,
+    getRowId: (row) => row.id,
+    prefix: PREFIX,
+  });
+
   if (isError) {
     throw error;
   }
 
-  // No `divide-y` on the Container: this section draws its own header, so the
-  // DataTable renders only its filter bar, which already has a `border-t`. A
-  // Container divider would stack a second line between the header and the
-  // filter row (the doubled divider reported in MER-129); the filter bar owns
-  // that separator.
   return (
-    <Container className="p-0" data-testid="product-variant-section">
+    <Container className="divide-y p-0" data-testid="product-variant-section">
       <div className="flex items-center justify-between px-6 py-4">
         <Heading level="h2">{t("products.variants.header")}</Heading>
         <Button
@@ -85,35 +89,30 @@ export const ProductVariantSection = ({
           <Link to="variants/create">{t("actions.create")}</Link>
         </Button>
       </div>
-      <div data-testid="product-variants-table-container">
-        <DataTable
-          data={variants}
-          columns={columns}
-          filters={filters}
-          rowCount={count}
-          getRowId={(row) => row.id}
-          rowHref={(row) => `/products/${product.id}/variants/${row.id}`}
-          pageSize={PAGE_SIZE}
-          isLoading={isPending}
-          emptyState={{
-            empty: {
-              heading: t("products.variants.empty.heading"),
-              description: t("products.variants.empty.description"),
-            },
-            filtered: {
-              heading: t("products.variants.filtered.heading"),
-              description: t("products.variants.filtered.description"),
-            },
-          }}
-          prefix={PREFIX}
-        />
-      </div>
+      <_DataTable
+        table={table}
+        columns={columns}
+        count={count}
+        pageSize={PAGE_SIZE}
+        filters={filters}
+        search
+        pagination
+        isLoading={isLoading}
+        orderBy={orderBy}
+        defaultOrderBy="title"
+        prefix={PREFIX}
+        queryObject={{ q, order, created_at, updated_at }}
+        navigateTo={(row) => `variants/${row.original.id}`}
+        noRecords={{
+          title: t("products.variants.empty.heading"),
+          message: t("products.variants.empty.description"),
+        }}
+      />
     </Container>
   );
 };
 
-const columnHelper =
-  createDataTableColumnHelper<HttpTypes.AdminProductVariant>();
+const columnHelper = createColumnHelper<ProductVariantDTO>();
 
 const useColumns = (product: HttpTypes.AdminProduct) => {
   const { t } = useTranslation();
@@ -131,8 +130,6 @@ const useColumns = (product: HttpTypes.AdminProduct) => {
     }
     return filtered;
   }, [searchParams]);
-
-  const dateColumns = useDataTableDateColumns<HttpTypes.AdminProductVariant>();
 
   const handleDelete = useCallback(
     async (id: string, title: string) => {
@@ -209,74 +206,99 @@ const useColumns = (product: HttpTypes.AdminProduct) => {
     });
   }, [product]);
 
-  const getActions = useCallback(
-    (_ctx: CellContext<HttpTypes.AdminProductVariant, unknown>) => {
-      const variant = _ctx.row.original as HttpTypes.AdminProductVariant;
-
-      const mainActions: DataTableAction<HttpTypes.AdminProductVariant>[] = [
-        {
-          icon: <PencilSquare />,
-          label: t("actions.edit"),
-          onClick: (row) => {
-            navigate(
-              `edit-variant?variant_id=${row.row.original.id}&${tableSearchParams.toString()}`,
-              {
-                state: {
-                  restore_params: tableSearchParams.toString(),
-                },
-              },
-            );
-          },
-        },
-      ];
-
-      const secondaryActions: DataTableAction<HttpTypes.AdminProductVariant>[] =
-        [
-          {
-            icon: <Trash />,
-            label: t("actions.delete"),
-            onClick: () => handleDelete(variant.id, variant.title!),
-          },
-        ];
-
-      return [mainActions, secondaryActions];
-    },
-    [handleDelete, navigate, t, tableSearchParams],
-  );
-
-  return useMemo(() => {
-    return [
+  return useMemo(
+    () => [
       columnHelper.accessor("title", {
+        id: "title",
         header: t("fields.title"),
-        enableSorting: true,
-        sortAscLabel: t("filters.sorting.alphabeticallyAsc"),
-        sortDescLabel: t("filters.sorting.alphabeticallyDesc"),
-      }),
-      columnHelper.accessor("sku", {
-        header: t("fields.sku"),
         cell: ({ getValue }) => {
           const value = getValue();
-          return value ? (
-            value
-          ) : (
-            <span className="text-ui-fg-muted">-</span>
+          return (
+            <div className="flex h-full w-full max-w-[250px] items-center gap-x-3 overflow-hidden">
+              <div className="w-fit flex-shrink-0">
+                <Thumbnail src={product.thumbnail} />
+              </div>
+              {value ? (
+                <span title={value} className="truncate">
+                  {value}
+                </span>
+              ) : (
+                <span className="text-ui-fg-muted">-</span>
+              )}
+            </div>
           );
         },
       }),
-      ...attributeColumns,
-      ...dateColumns,
-      columnHelper.action({
-        actions: getActions,
+      columnHelper.accessor("sku", {
+        id: "sku",
+        header: t("fields.sku"),
+        cell: ({ getValue }) => {
+          const value = getValue();
+          return value ? value : <span className="text-ui-fg-muted">-</span>;
+        },
       }),
-    ];
-  }, [t, attributeColumns, dateColumns, getActions]);
+      ...attributeColumns,
+      columnHelper.display({
+        id: "actions",
+        cell: ({ row }) => (
+          <ActionMenu
+            groups={[
+              {
+                actions: [
+                  {
+                    icon: <PencilSquare />,
+                    label: t("actions.edit"),
+                    onClick: () =>
+                      navigate(
+                        `edit-variant?variant_id=${row.original.id}&${tableSearchParams.toString()}`,
+                        {
+                          state: {
+                            restore_params: tableSearchParams.toString(),
+                          },
+                        },
+                      ),
+                  },
+                ],
+              },
+              {
+                actions: [
+                  {
+                    icon: <Trash />,
+                    label: t("actions.delete"),
+                    onClick: () =>
+                      handleDelete(row.original.id, row.original.title ?? ""),
+                  },
+                ],
+              },
+            ]}
+          />
+        ),
+      }),
+    ],
+    [t, attributeColumns, navigate, handleDelete, tableSearchParams, product],
+  );
 };
 
-const useFilters = () => {
-  const dateFilters = useDataTableDateFilters();
+const useFilters = (): Filter[] => {
+  const { t } = useTranslation();
 
-  return useMemo(() => {
-    return [...dateFilters];
-  }, [dateFilters]);
+  return useMemo(
+    () => [
+      { key: "created_at", label: t("fields.createdAt"), type: "date" },
+      { key: "updated_at", label: t("fields.updatedAt"), type: "date" },
+    ],
+    [t],
+  );
 };
 
+const useOrderBy = (): DataTableOrderByKey<ProductVariantDTO>[] => {
+  const { t } = useTranslation();
+
+  return useMemo(
+    () => [
+      { key: "title", label: t("fields.title") },
+      { key: "sku", label: t("fields.sku") },
+    ],
+    [t],
+  );
+};

--- a/packages/vendor/src/pages/products/create/utils.ts
+++ b/packages/vendor/src/pages/products/create/utils.ts
@@ -12,7 +12,20 @@ export const normalizeProductFormValues = (
     ?.filter((media) => !media.isThumbnail)
     .map((media) => ({ url: media.url }))
 
+  const hasAxis = (values.attributes ?? []).some(
+    (a) => a.use_for_variants && toValueArray(a.values).length > 0
+  )
+
   const attributes = normalizeFormAttributes(values.attributes ?? [])
+
+  if (!hasAxis) {
+    attributes.push({
+      title: "Default Option",
+      type: AttributeType.MULTI_SELECT,
+      values: ["Default"],
+      is_variant_axis: true,
+    })
+  }
 
   return {
     is_giftcard: false,
@@ -41,12 +54,14 @@ export const normalizeProductFormValues = (
     attributes: attributes.length ? attributes : undefined,
     variants: normalizeVariants(
       values.variants.filter((variant) => variant.should_create),
+      hasAxis,
     ),
   } as any
 }
 
 export const normalizeVariants = (
   variants: ProductCreateSchemaType["variants"],
+  hasAxis: boolean,
 ): any[] => {
   return variants.map((variant) => {
     const opts = variant.options
@@ -54,7 +69,7 @@ export const normalizeVariants = (
 
     return {
       title: variant.title || (hasOpts ? Object.values(opts).join(" / ") : "Default variant"),
-      options: hasOpts ? opts : undefined,
+      options: hasOpts ? opts : hasAxis ? undefined : { "Default Option": "Default" },
       sku: variant.sku || undefined,
       variant_rank: variant.variant_rank,
     }


### PR DESCRIPTION
## MER-129 — Product Details · Variants Table

> Targets `claude/zealous-ptolemy-0a5118` (SPEC-014 migration, #1044), not `canary` — this fix depends on that branch's native-options attribute work (the `is_variant_axis` attribute columns).

The product-detail variants table (admin + vendor) was the only variant table built on the newer `DataTable` (`components/data-table`). Its `FilterBar` rendered a visibly different bar than every other table in the dashboard — subtle background, `py-2`, and sort-before-search — which is what the reporter meant by *"differed from all other tables we have"*. It also lacked the product thumbnail shown in the Figma.

### Fix
Rebuilt both sections on the canonical `_DataTable` + `useDataTable` pattern already used by the product list and the `offer-variants-section`:

- **Single filter bar** matching the design: `Add filter` on the left, `Search` then `Sort` on the right (`px-6 py-4`); dividers owned by the container/table — no doubled divider.
- **Thumbnail** added to the Title cell (e.g. `XS / Green`).
- **SKU column** kept, alongside the variant-axis attribute columns (Size, Color).
- Search / sort / date-filter / pagination wired through the existing `pv_`-prefixed URL params; edit + delete row actions preserved via `ActionMenu`.
- Table typed with the real `ProductVariantDTO` returned by the hook.

### Verification
- `bun run build` green for `@mercurjs/vendor` and `@mercurjs/admin` (ESM + DTS).
- `oxlint` clean on both changed files.