### PR TITLE
fix(vendor): redesign edit required attribute drawer to match design

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -469,6 +469,7 @@
         "useForVariantsDescription": "If checked, you will be able to create variants using this attribute. If not, the attribute will be used for informational purposes only.",
         "tip": "Tip",
         "variantAxisTip": "This attribute will create variants. You can define them in the next step.",
+        "editVariantAxisTip": "You will be able to create variants using this attribute.",
         "warning": "Warning",
         "editWarning": "Changes to this attribute may affect existing product variants or details. Review your variants and product details after saving.",
         "errors": {

--- a/packages/admin/src/pages/products/product-edit-attribute/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/admin/src/pages/products/product-edit-attribute/components/edit-attribute-form/edit-attribute-form.tsx
@@ -46,10 +46,6 @@ export const EditAttributeForm = ({
   productId,
   attribute,
 }: EditAttributeFormProps) => {
-  // A product-scoped (inline) attribute is owned by this product, so it gets
-  // the same authoring affordances as the create form: editable title and
-  // free-form values (chips for variant axes, a textarea for text). Shared
-  // catalog attributes keep the value-selection form (pick from the catalog).
   if (attribute.is_scoped) {
     return <EditScopedAttributeForm productId={productId} attribute={attribute} />;
   }
@@ -127,8 +123,6 @@ const EditScopedAttributeForm = ({
     let payload: Parameters<typeof mutateAsync>[0];
 
     if (isAxis) {
-      // Diff the chip names against the existing value rows: new names become
-      // `add: [{ value }]`, dropped value rows become `remove: [value_id]`.
       const newNames = (Array.isArray(data.values) ? data.values : [])
         .map((v) => v.trim())
         .filter(Boolean);
@@ -143,7 +137,6 @@ const EditScopedAttributeForm = ({
         update: [{ id: attribute.id, title, add, remove }],
       };
     } else {
-      // Free-form text/unit: a single scalar swap (plus optional rename).
       const value = Array.isArray(data.values)
         ? data.values[0] ?? ""
         : data.values;
@@ -243,9 +236,6 @@ const EditScopedAttributeForm = ({
                   )}
                 />
                 <div />
-                {/* Use-for-variants reflects the attribute's axis nature; it is
-                    read-only here because flipping it would create/drop the
-                    backing variant option and re-key existing variants. */}
                 <div className="flex items-start gap-x-3 py-1.5">
                   <Switch
                     className="shrink-0 rtl:rotate-180"
@@ -306,9 +296,6 @@ const EditCatalogAttributeForm = ({
     attribute.type === AttributeType.SINGLE_SELECT ||
     attribute.type === AttributeType.MULTI_SELECT;
 
-  // The info icon next to the attribute name carries the same context shown in
-  // the product attributes list: the attribute's own description, falling back
-  // to the marketplace-required note for required attributes.
   const labelTooltip =
     attribute.description ||
     (attribute.is_required
@@ -347,26 +334,22 @@ const EditCatalogAttributeForm = ({
     let payload: Parameters<typeof mutateAsync>[0];
 
     if (hasPresetValues) {
-      // Map the chosen value names to ids over the attribute's full value set.
       const selectedIds = (attribute.all_values ?? [])
         .filter((v) => vals.includes(v.name))
         .map((v) => v.id);
 
       if (attribute.is_variant_axis) {
-        // Shared axis: adjust the per-product value subset (add/remove diff).
         const currentIds = (attribute.values ?? []).map((v) => v.id);
         const add = selectedIds.filter((id) => !currentIds.includes(id));
         const remove = currentIds.filter((id) => !selectedIds.includes(id));
         payload = { update: [{ id: attribute.id, add, remove }] };
       } else {
-        // Non-axis select: replace the value links (remove → add in one call).
         payload = {
           remove: [attribute.id],
           add: [{ id: attribute.id, value_ids: selectedIds }],
         };
       }
     } else {
-      // Text / unit / toggle: a single free-form scalar.
       payload = {
         update: [
           {

--- a/packages/admin/src/pages/products/product-edit-attribute/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/admin/src/pages/products/product-edit-attribute/components/edit-attribute-form/edit-attribute-form.tsx
@@ -395,7 +395,7 @@ const EditCatalogAttributeForm = ({
               control={form.control}
               name="values"
               render={({ field: { onChange, value } }) => (
-                <Form.Item className="flex flex-col gap-y-2">
+                <Form.Item>
                   <Form.Label tooltip={labelTooltip}>
                     {attribute.name}
                   </Form.Label>

--- a/packages/admin/src/pages/products/product-edit-attribute/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/admin/src/pages/products/product-edit-attribute/components/edit-attribute-form/edit-attribute-form.tsx
@@ -1,5 +1,13 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Hint, Input, Label, Switch, Text, Textarea, toast } from "@medusajs/ui";
+import {
+  Button,
+  Hint,
+  InlineTip,
+  Input,
+  Label,
+  Switch,
+  toast,
+} from "@medusajs/ui";
 import { AttributeType } from "@mercurjs/types";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -18,6 +26,8 @@ type EditAttributeAttribute = {
   id: string;
   name: string;
   type: AttributeType | string;
+  description?: string;
+  is_required?: boolean;
   is_variant_axis?: boolean;
   is_scoped?: boolean;
   values?: AttributeValue[];
@@ -28,6 +38,9 @@ type EditAttributeFormProps = {
   productId: string;
   attribute: EditAttributeAttribute;
 };
+
+const isVariantAxis = (attribute: EditAttributeAttribute) =>
+  attribute.type === AttributeType.MULTI_SELECT || !!attribute.is_variant_axis;
 
 export const EditAttributeForm = ({
   productId,
@@ -44,6 +57,29 @@ export const EditAttributeForm = ({
   return <EditCatalogAttributeForm productId={productId} attribute={attribute} />;
 };
 
+const AttributeWarning = () => {
+  const { t } = useTranslation();
+
+  return (
+    <InlineTip
+      variant="warning"
+      label={t("products.create.attributes.warning")}
+    >
+      {t("products.create.attributes.editWarning")}
+    </InlineTip>
+  );
+};
+
+const VariantAxisTip = () => {
+  const { t } = useTranslation();
+
+  return (
+    <InlineTip label={t("products.create.attributes.tip")}>
+      {t("products.create.attributes.editVariantAxisTip")}
+    </InlineTip>
+  );
+};
+
 type ScopedFormValues = {
   title: string;
   values: string | string[];
@@ -56,7 +92,7 @@ const EditScopedAttributeForm = ({
   const { t } = useTranslation();
   const { handleSuccess } = useRouteModal();
 
-  const isAxis = attribute.type === AttributeType.MULTI_SELECT;
+  const isAxis = isVariantAxis(attribute);
   const currentValues = attribute.values ?? attribute.all_values ?? [];
 
   const schema = zod.object({
@@ -192,23 +228,13 @@ const EditScopedAttributeForm = ({
                             )}
                           />
                         ) : (
-                          <Textarea
-                            aria-invalid={
-                              fieldState.invalid ? "true" : undefined
-                            }
-                            className={
-                              fieldState.invalid
-                                ? "bg-ui-bg-field-component shadow-borders-error focus:shadow-borders-error"
-                                : "bg-ui-bg-field-component hover:bg-ui-bg-field-component-hover"
-                            }
-                            value={
-                              Array.isArray(value) ? value.join(", ") : value ?? ""
-                            }
-                            onChange={(e) => onChange(e.target.value)}
+                          <AttributeValueInput
+                            type={attribute.type}
+                            value={value}
+                            onChange={onChange}
                             placeholder={t(
                               "products.create.attributes.valuePlaceholder",
                             )}
-                            data-testid="edit-attribute-values-input"
                           />
                         )}
                       </Form.Control>
@@ -237,15 +263,8 @@ const EditScopedAttributeForm = ({
                 </div>
               </div>
             </div>
-            <div className="bg-ui-bg-component shadow-elevation-card-rest flex items-center gap-x-3 rounded-lg px-3 py-2.5">
-              <div className="bg-ui-tag-orange-icon h-full min-h-[24px] w-1 shrink-0 rounded-full" />
-              <Text size="small" className="text-ui-fg-subtle">
-                <span className="text-ui-fg-base txt-compact-small-plus">
-                  {t("products.create.attributes.warning")}:{" "}
-                </span>
-                {t("products.create.attributes.editWarning")}
-              </Text>
-            </div>
+            {isAxis && <VariantAxisTip />}
+            <AttributeWarning />
           </div>
         </RouteDrawer.Body>
         <RouteDrawer.Footer>
@@ -281,9 +300,20 @@ const EditCatalogAttributeForm = ({
   const { t } = useTranslation();
   const { handleSuccess } = useRouteModal();
 
+  const isAxis = isVariantAxis(attribute);
+
   const hasPresetValues =
     attribute.type === AttributeType.SINGLE_SELECT ||
     attribute.type === AttributeType.MULTI_SELECT;
+
+  // The info icon next to the attribute name carries the same context shown in
+  // the product attributes list: the attribute's own description, falling back
+  // to the marketplace-required note for required attributes.
+  const labelTooltip =
+    attribute.description ||
+    (attribute.is_required
+      ? t("products.attributeRequiredByMarketplace")
+      : undefined);
 
   const initialValues = (() => {
     const selected = attribute.values ?? [];
@@ -361,51 +391,28 @@ const EditCatalogAttributeForm = ({
       <KeyboundForm onSubmit={handleSubmit} className="flex h-full flex-col">
         <RouteDrawer.Body>
           <div className="flex flex-col gap-y-4">
-            <div className="bg-ui-bg-component shadow-elevation-card-rest rounded-xl p-1.5">
-              <div className="grid grid-cols-[min-content,1fr] items-center gap-1.5">
-                <div className="flex items-center px-2 py-1.5">
-                  <Label
-                    size="xsmall"
-                    weight="plus"
-                    className="text-ui-fg-subtle"
-                  >
-                    {t("fields.title")}
-                  </Label>
-                </div>
-                <Input
-                  className="bg-ui-bg-field-component"
-                  value={attribute.name}
-                  disabled
-                  data-testid="edit-attribute-title-input"
-                />
-                <div className="flex items-center px-2 py-1.5">
-                  <Label
-                    size="xsmall"
-                    weight="plus"
-                    className="text-ui-fg-subtle"
-                  >
-                    {t("fields.values")}
-                  </Label>
-                </div>
-                <Form.Field
-                  control={form.control}
-                  name="values"
-                  render={({ field: { onChange, value } }) => (
-                    <Form.Item>
-                      <Form.Control>
-                        <AttributeValueInput
-                          type={attribute.type}
-                          value={value}
-                          onChange={onChange}
-                          availableValues={attribute.all_values ?? []}
-                        />
-                      </Form.Control>
-                      <Form.ErrorMessage />
-                    </Form.Item>
-                  )}
-                />
-              </div>
-            </div>
+            <Form.Field
+              control={form.control}
+              name="values"
+              render={({ field: { onChange, value } }) => (
+                <Form.Item className="flex flex-col gap-y-2">
+                  <Form.Label tooltip={labelTooltip}>
+                    {attribute.name}
+                  </Form.Label>
+                  <Form.Control>
+                    <AttributeValueInput
+                      type={attribute.type}
+                      value={value}
+                      onChange={onChange}
+                      availableValues={attribute.all_values ?? []}
+                    />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                  {isAxis && <VariantAxisTip />}
+                </Form.Item>
+              )}
+            />
+            <AttributeWarning />
           </div>
         </RouteDrawer.Body>
         <RouteDrawer.Footer>

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -2259,6 +2259,15 @@
                 "variantAxisTip": {
                   "type": "string"
                 },
+                "editVariantAxisTip": {
+                  "type": "string"
+                },
+                "warning": {
+                  "type": "string"
+                },
+                "editWarning": {
+                  "type": "string"
+                },
                 "titlePlaceholder": {
                   "type": "string"
                 },
@@ -2298,6 +2307,9 @@
                 "useForVariants",
                 "useForVariantsDescription",
                 "variantAxisTip",
+                "editVariantAxisTip",
+                "warning",
+                "editWarning",
                 "titlePlaceholder",
                 "valuePlaceholder",
                 "enterValuePlaceholder",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -559,6 +559,7 @@
         "useForVariants": "Use for variants",
         "useForVariantsDescription": "If checked, we will create variants with this attribute. You can define them in the next step. If not, the attribute will be used for informational purposes only.",
         "variantAxisTip": "This attribute will create variants. You can define them in the next step.",
+        "editVariantAxisTip": "You will be able to create variants using this attribute.",
         "warning": "Warning",
         "editWarning": "Changes to this attribute may affect existing product variants or details. Review your variants and product details after saving.",
         "titlePlaceholder": "e.g. Color",

--- a/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
@@ -2,11 +2,10 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   Button,
   Hint,
+  InlineTip,
   Input,
   Label,
   Switch,
-  Text,
-  Textarea,
   toast,
 } from "@medusajs/ui"
 import { AttributeType, MercurFeatureFlags } from "@mercurjs/types"
@@ -28,6 +27,8 @@ type EditAttributeAttribute = {
   id: string
   name: string
   type: AttributeType | string
+  description?: string
+  is_required?: boolean
   is_variant_axis?: boolean
   is_scoped?: boolean
   values?: AttributeValue[]
@@ -38,6 +39,9 @@ type EditAttributeFormProps = {
   productId: string
   attribute: EditAttributeAttribute
 }
+
+const isVariantAxis = (attribute: EditAttributeAttribute) =>
+  attribute.type === AttributeType.MULTI_SELECT || !!attribute.is_variant_axis
 
 export const EditAttributeForm = ({
   productId,
@@ -54,6 +58,29 @@ export const EditAttributeForm = ({
   return <EditCatalogAttributeForm productId={productId} attribute={attribute} />
 }
 
+const AttributeWarning = () => {
+  const { t } = useTranslation()
+
+  return (
+    <InlineTip
+      variant="warning"
+      label={t("products.create.attributes.warning")}
+    >
+      {t("products.create.attributes.editWarning")}
+    </InlineTip>
+  )
+}
+
+const VariantAxisTip = () => {
+  const { t } = useTranslation()
+
+  return (
+    <InlineTip label={t("products.create.attributes.tip")}>
+      {t("products.create.attributes.editVariantAxisTip")}
+    </InlineTip>
+  )
+}
+
 type ScopedFormValues = {
   title: string
   values: string | string[]
@@ -66,7 +93,7 @@ const EditScopedAttributeForm = ({
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
 
-  const isAxis = attribute.type === AttributeType.MULTI_SELECT
+  const isAxis = isVariantAxis(attribute)
   const currentValues = attribute.values ?? attribute.all_values ?? []
 
   const schema = zod.object({
@@ -202,23 +229,13 @@ const EditScopedAttributeForm = ({
                             )}
                           />
                         ) : (
-                          <Textarea
-                            aria-invalid={
-                              fieldState.invalid ? "true" : undefined
-                            }
-                            className={
-                              fieldState.invalid
-                                ? "bg-ui-bg-field-component shadow-borders-error focus:shadow-borders-error"
-                                : "bg-ui-bg-field-component hover:bg-ui-bg-field-component-hover"
-                            }
-                            value={
-                              Array.isArray(value) ? value.join(", ") : value ?? ""
-                            }
-                            onChange={(e) => onChange(e.target.value)}
+                          <AttributeValueInput
+                            type={attribute.type}
+                            value={value}
+                            onChange={onChange}
                             placeholder={t(
                               "products.create.attributes.valuePlaceholder",
                             )}
-                            data-testid="edit-attribute-values-input"
                           />
                         )}
                       </Form.Control>
@@ -247,15 +264,8 @@ const EditScopedAttributeForm = ({
                 </div>
               </div>
             </div>
-            <div className="bg-ui-bg-component shadow-elevation-card-rest flex items-center gap-x-3 rounded-lg px-3 py-2.5">
-              <div className="bg-ui-tag-orange-icon h-full min-h-[24px] w-1 shrink-0 rounded-full" />
-              <Text size="small" className="text-ui-fg-subtle">
-                <span className="text-ui-fg-base txt-compact-small-plus">
-                  {t("products.create.attributes.warning")}:{" "}
-                </span>
-                {t("products.create.attributes.editWarning")}
-              </Text>
-            </div>
+            {isAxis && <VariantAxisTip />}
+            <AttributeWarning />
           </div>
         </RouteDrawer.Body>
         <RouteDrawer.Footer>
@@ -295,9 +305,20 @@ const EditCatalogAttributeForm = ({
   const isProductRequestEnabled =
     !!feature_flags?.[MercurFeatureFlags.PRODUCT_REQUEST]
 
+  const isAxis = isVariantAxis(attribute)
+
   const hasPresetValues =
     attribute.type === AttributeType.SINGLE_SELECT ||
     attribute.type === AttributeType.MULTI_SELECT
+
+  // The info icon next to the attribute name carries the same context shown in
+  // the product attributes list: the attribute's own description, falling back
+  // to the marketplace-required note for required attributes.
+  const labelTooltip =
+    attribute.description ||
+    (attribute.is_required
+      ? t("products.create.attributes.requiredTooltip")
+      : undefined)
 
   const initialValues = (() => {
     const selected = attribute.values ?? []
@@ -382,51 +403,28 @@ const EditCatalogAttributeForm = ({
       <KeyboundForm onSubmit={handleSubmit} className="flex h-full flex-col">
         <RouteDrawer.Body>
           <div className="flex flex-col gap-y-4">
-            <div className="bg-ui-bg-component shadow-elevation-card-rest rounded-xl p-1.5">
-              <div className="grid grid-cols-[min-content,1fr] items-center gap-1.5">
-                <div className="flex items-center px-2 py-1.5">
-                  <Label
-                    size="xsmall"
-                    weight="plus"
-                    className="text-ui-fg-subtle"
-                  >
-                    {t("fields.title")}
-                  </Label>
-                </div>
-                <Input
-                  className="bg-ui-bg-field-component"
-                  value={attribute.name}
-                  disabled
-                  data-testid="edit-attribute-title-input"
-                />
-                <div className="flex items-center px-2 py-1.5">
-                  <Label
-                    size="xsmall"
-                    weight="plus"
-                    className="text-ui-fg-subtle"
-                  >
-                    {t("fields.values")}
-                  </Label>
-                </div>
-                <Form.Field
-                  control={form.control}
-                  name="values"
-                  render={({ field: { onChange, value } }) => (
-                    <Form.Item>
-                      <Form.Control>
-                        <AttributeValueInput
-                          type={attribute.type}
-                          value={value}
-                          onChange={onChange}
-                          availableValues={attribute.all_values ?? []}
-                        />
-                      </Form.Control>
-                      <Form.ErrorMessage />
-                    </Form.Item>
-                  )}
-                />
-              </div>
-            </div>
+            <Form.Field
+              control={form.control}
+              name="values"
+              render={({ field: { onChange, value } }) => (
+                <Form.Item className="flex flex-col gap-y-2">
+                  <Form.Label tooltip={labelTooltip}>
+                    {attribute.name}
+                  </Form.Label>
+                  <Form.Control>
+                    <AttributeValueInput
+                      type={attribute.type}
+                      value={value}
+                      onChange={onChange}
+                      availableValues={attribute.all_values ?? []}
+                    />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                  {isAxis && <VariantAxisTip />}
+                </Form.Item>
+              )}
+            />
+            <AttributeWarning />
           </div>
         </RouteDrawer.Body>
         <RouteDrawer.Footer>

--- a/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
@@ -47,10 +47,6 @@ export const EditAttributeForm = ({
   productId,
   attribute,
 }: EditAttributeFormProps) => {
-  // A product-scoped (inline) attribute is owned by this product, so it gets
-  // the same authoring affordances as the create form: editable title and
-  // free-form values (chips for variant axes, a textarea for text). Shared
-  // catalog attributes keep the value-selection form (pick from the catalog).
   if (attribute.is_scoped) {
     return <EditScopedAttributeForm productId={productId} attribute={attribute} />
   }
@@ -128,8 +124,6 @@ const EditScopedAttributeForm = ({
     let payload: Parameters<typeof mutateAsync>[0]
 
     if (isAxis) {
-      // Diff the chip names against the existing value rows: new names become
-      // `add: [{ value }]`, dropped value rows become `remove: [value_id]`.
       const newNames = (Array.isArray(data.values) ? data.values : [])
         .map((v) => v.trim())
         .filter(Boolean)
@@ -144,7 +138,6 @@ const EditScopedAttributeForm = ({
         update: [{ id: attribute.id, title, add, remove }],
       }
     } else {
-      // Free-form text/unit: a single scalar swap (plus optional rename).
       const value = Array.isArray(data.values)
         ? data.values[0] ?? ""
         : data.values
@@ -244,9 +237,6 @@ const EditScopedAttributeForm = ({
                   )}
                 />
                 <div />
-                {/* Use-for-variants reflects the attribute's axis nature; it is
-                    read-only here because flipping it would create/drop the
-                    backing variant option and re-key existing variants. */}
                 <div className="flex items-start gap-x-3 py-1.5">
                   <Switch
                     className="shrink-0 rtl:rotate-180"
@@ -311,9 +301,6 @@ const EditCatalogAttributeForm = ({
     attribute.type === AttributeType.SINGLE_SELECT ||
     attribute.type === AttributeType.MULTI_SELECT
 
-  // The info icon next to the attribute name carries the same context shown in
-  // the product attributes list: the attribute's own description, falling back
-  // to the marketplace-required note for required attributes.
   const labelTooltip =
     attribute.description ||
     (attribute.is_required
@@ -352,26 +339,22 @@ const EditCatalogAttributeForm = ({
     let payload: Parameters<typeof mutateAsync>[0]
 
     if (hasPresetValues) {
-      // Map the chosen value names to ids over the attribute's full value set.
       const selectedIds = (attribute.all_values ?? [])
         .filter((v) => vals.includes(v.name))
         .map((v) => v.id)
 
       if (attribute.is_variant_axis) {
-        // Shared axis: adjust the per-product value subset (add/remove diff).
         const currentIds = (attribute.values ?? []).map((v) => v.id)
         const add = selectedIds.filter((id) => !currentIds.includes(id))
         const remove = currentIds.filter((id) => !selectedIds.includes(id))
         payload = { update: [{ id: attribute.id, add, remove }] }
       } else {
-        // Non-axis select: replace the value links (remove → add in one call).
         payload = {
           remove: [attribute.id],
           add: [{ id: attribute.id, value_ids: selectedIds }],
         }
       }
     } else {
-      // Text / unit / toggle: a single free-form scalar.
       payload = {
         update: [
           {

--- a/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
@@ -407,7 +407,7 @@ const EditCatalogAttributeForm = ({
               control={form.control}
               name="values"
               render={({ field: { onChange, value } }) => (
-                <Form.Item className="flex flex-col gap-y-2">
+                <Form.Item>
                   <Form.Label tooltip={labelTooltip}>
                     {attribute.name}
                   </Form.Label>


### PR DESCRIPTION
## Summary
- Rework the vendor **Edit Attribute** drawer to match the Figma design: the attribute name becomes the field label (with an info-icon tooltip carrying the attribute description, falling back to the required note), the value selector sits directly beneath it, a neutral **Tip** explains variant creation for axis attributes, and a **Warning** callout reuses the shared `InlineTip`. Removes the bespoke Title/Values card and hand-rolled orange warning bar.
- Sync the vendor i18n schema with `en.json` for the attribute `warning` / `editWarning` keys and add `editVariantAxisTip`, so the translation validation no longer flags these keys.

## Linear
[MER-195](https://linear.app/rigbyjs/issue/MER-195)

## Design
[Figma — Edit Attribute](https://www.figma.com/design/sYJoh84Owr5tomRjpxG0no/-Mercur-2.0----Vendor-Panel?node-id=40016102-270346)

## Notes
- The translation validation spec has separate **pre-existing** failures on `canary` (e.g. `store.validation.nameTooLong` missing, plus many `orders.claims` / `orders.exchanges` extras) that are unrelated to this change; this PR only resolves the attribute tip/warning key mismatch.

## Test plan
- [x] `bun run build` (all 9 packages, including vendor DTS type-check)
- [x] `oxlint` on changed file
- [ ] Manually verify the Edit Attribute drawer on a product (required multi-select attribute) renders label + values + tip + warning per design