### PR TITLE
fix(admin): show stores combobox when product is not globally available

### DIFF
--- a/packages/admin/src/pages/products/product-create/components/product-create-organize-form/components/product-create-organize-section/product-create-details-organize-section.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-organize-form/components/product-create-organize-section/product-create-details-organize-section.tsx
@@ -1,4 +1,5 @@
 import { Heading } from "@medusajs/ui"
+import { useWatch } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 
 import { Form } from "../../../../../../../components/common/form"
@@ -54,7 +55,10 @@ export const ProductCreateOrganizationSection = () => {
       })),
   })
 
-  const isGloballyAvailable = form.watch("globally_available")
+  const isGloballyAvailable = useWatch({
+    control: form.control,
+    name: "globally_available",
+  })
 
   return (
     <div id="organize" className="flex flex-col gap-y-8" data-testid="product-create-organize-section">


### PR DESCRIPTION
## Problem

In the product create flow (Organize tab), unchecking the **Globally available** switch did not reveal the **Stores** combobox. There was no way to assign a product to specific sellers from the admin create form.

## Root cause

`ProductCreateOrganizationSection` read the flag with the `form.watch("globally_available")` *method*. In react-hook-form, the `watch()` method only triggers a re-render of the component that called `useForm()` — here that's the create-form host, not this section. The section consumes the form via context (`useTabbedForm`) and is rendered as a stable, memoized element inside `ProgressTabs.Content`, so toggling the switch updated the form value but never re-rendered the section. The `!isGloballyAvailable` condition was evaluated once at mount (`globally_available` defaults to `true`) and never re-evaluated.

## Fix

Replaced the `form.watch` method call with the `useWatch` hook, which establishes its own subscription and re-renders this component when the value changes:

```tsx
const isGloballyAvailable = useWatch({
  control: form.control,
  name: "globally_available",
})
```

Unchecking **Globally available** now immediately reveals the Stores combobox.