### PR TITLE
fix(admin): correct category handle tooltip and title validation message

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -3636,6 +3636,21 @@
         "subtitle": {
           "type": "string"
         },
+        "handleTooltip": {
+          "type": "string"
+        },
+        "validation": {
+          "type": "object",
+          "properties": {
+            "titleRequired": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "titleRequired"
+          ],
+          "additionalProperties": false
+        },
         "create": {
           "type": "object",
           "properties": {
@@ -4102,6 +4117,8 @@
       "required": [
         "domain",
         "subtitle",
+        "handleTooltip",
+        "validation",
         "create",
         "edit",
         "delete",

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -942,6 +942,10 @@
   "categories": {
     "domain": "Categories",
     "subtitle": "Organize products into categories, and manage those categories' ranking and hierarchy.",
+    "handleTooltip": "The handle is used to reference the category on the storefront. If not specified, the handle will be generated from the category title.",
+    "validation": {
+      "titleRequired": "Please enter a title"
+    },
     "create": {
       "header": "Create Category",
       "hint": "Create a new category to organize your products.",

--- a/packages/admin/src/pages/categories/category-edit/components/edit-category-form/edit-category-form.tsx
+++ b/packages/admin/src/pages/categories/category-edit/components/edit-category-form/edit-category-form.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Button, Input, Select, Textarea, toast } from "@medusajs/ui"
+import i18n from "i18next"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { z } from "zod"
@@ -13,7 +14,7 @@ import { useUpdateProductCategory } from "../../../../../hooks/api/categories"
 import { useDocumentDirection } from "../../../../../hooks/use-document-direction"
 
 const EditCategorySchema = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1, { message: i18n.t("categories.validation.titleRequired") }),
   handle: z.string().min(1),
   description: z.string().optional(),
   status: z.enum(["active", "inactive"]),
@@ -89,7 +90,7 @@ export const EditCategoryForm = ({ category }: EditCategoryFormProps) => {
                   <Form.Item>
                     <Form.Label
                       optional
-                      tooltip={t("collections.handleTooltip")}
+                      tooltip={t("categories.handleTooltip")}
                     >
                       {t("fields.handle")}
                     </Form.Label>


### PR DESCRIPTION
## Summary
- Edit Category drawer now uses a category-specific handle tooltip: "The handle is used to reference the category on the storefront. If not specified, the handle will be generated from the category title." (previously reused the collection copy).
- The title field now shows "Please enter a title" when left empty, instead of the generic Zod default.

## Linear
[MER-237](https://linear.app/rigbyjs/issue/MER-237)

## Test plan
- [ ] Open a category → Edit, hover the Handle tooltip → shows the new category copy
- [ ] Clear the title → Save → shows "Please enter a title"
- [x] `bun run build` (9/9 packages)
- [x] i18n schema parity for new `categories.handleTooltip` / `categories.validation.titleRequired` keys