### PR TITLE
chore(scripts): clarify deploy file-url proxying and force worktree build

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -286,8 +286,11 @@ cp "$DEPLOY_DIR/packages/api/.env" "$PROD_DIR/.env"
 # Point the local file provider at the public origin. Without this it
 # defaults to http://localhost:9000/static and every uploaded image
 # (category thumbnails, product media) renders broken in the dashboards
-# served from $MERCUR_BACKEND_URL. nginx serves the static upload dir
-# under /dist, so files resolve at $MERCUR_BACKEND_URL/dist/<key>.
+# served from $MERCUR_BACKEND_URL. Medusa serves the upload dir natively
+# at /static; Caddy (the reverse proxy on the host) maps /dist/* onto that
+# /static/* route, so files resolve at $MERCUR_BACKEND_URL/dist/<key>.
+# That Caddy `handle_path /dist/*` rewrite is required for these URLs to
+# resolve — it is maintained in /etc/caddy/Caddyfile on the host, not here.
 FILE_BACKEND_URL="${MERCUR_BACKEND_URL%/}/dist"
 if grep -q '^FILE_BACKEND_URL=' "$PROD_DIR/.env"; then
   sed -i "s#^FILE_BACKEND_URL=.*#FILE_BACKEND_URL=${FILE_BACKEND_URL}#" "$PROD_DIR/.env"

--- a/scripts/dev-worktree.sh
+++ b/scripts/dev-worktree.sh
@@ -69,7 +69,7 @@ if [ ! -d node_modules ]; then
 fi
 
 echo "→ Building packages"
-bun run build
+bun run build --force
 
 echo "→ Running medusa db:migrate"
 (cd apps/api && bunx medusa db:migrate)


### PR DESCRIPTION
## Summary

Two small scripting tweaks:

- **`scripts/deploy.sh`** — corrects the comment around `FILE_BACKEND_URL`. Medusa serves the upload dir natively at `/static`; Caddy (the host reverse proxy) maps `/dist/*` onto that route, so files resolve at `$MERCUR_BACKEND_URL/dist/<key>`. Notes that the `handle_path /dist/*` rewrite lives in `/etc/caddy/Caddyfile` on the host, not in this repo. Comment-only change; behavior unchanged.
- **`scripts/dev-worktree.sh`** — uses `bun run build --force` so a worktree spin-up doesn't reuse stale Turborepo cache.