### PR TITLE
fix(client): send multipart when a mutate payload contains files

### DIFF
--- a/packages/admin/src/lib/client/client.ts
+++ b/packages/admin/src/lib/client/client.ts
@@ -77,15 +77,3 @@ export const fetchQuery = async (
 
   return response.json()
 }
-
-export const uploadFilesQuery = async (files: any[]) => {
-  const formData = new FormData()
-
-  for (const { file } of files) {
-    formData.append("files", file)
-  }
-
-  return sdk.admin.uploads.mutate({
-    fetchOptions: { body: formData },
-  })
-}

--- a/packages/admin/src/pages/categories/common/components/category-image-fields/upload-category-images.ts
+++ b/packages/admin/src/pages/categories/common/components/category-image-fields/upload-category-images.ts
@@ -1,4 +1,4 @@
-import { uploadFilesQuery } from "@lib/client"
+import { sdk } from "@lib/client"
 import { CategoryIconItem, CategoryMediaItem } from "./types"
 
 export type CategoryImagesPayload = {
@@ -32,7 +32,9 @@ export const uploadCategoryImages = async ({
       media.map(async (item, index) => {
         let url = item.url
         if (item.file) {
-          const uploaded = await uploadFilesQuery([{ file: item.file }])
+          const uploaded = await sdk.admin.uploads.mutate({
+            files: [item.file],
+          })
           url = uploaded.files?.[0]?.url ?? url
         }
         return {
@@ -49,7 +51,7 @@ export const uploadCategoryImages = async ({
     if (!icon) {
       payload.icon = null
     } else if (icon.file) {
-      const uploaded = await uploadFilesQuery([{ file: icon.file }])
+      const uploaded = await sdk.admin.uploads.mutate({ files: [icon.file] })
       payload.icon = uploaded.files?.[0]?.url ?? icon.url
     } else {
       payload.icon = icon.url

--- a/packages/admin/src/pages/collections/common/components/collection-image-fields/upload-collection-images.ts
+++ b/packages/admin/src/pages/collections/common/components/collection-image-fields/upload-collection-images.ts
@@ -1,4 +1,4 @@
-import { uploadFilesQuery } from "@lib/client"
+import { sdk } from "@lib/client"
 import { CollectionIconItem, CollectionMediaItem } from "./types"
 
 export type CollectionImagesPayload = {
@@ -32,7 +32,9 @@ export const uploadCollectionImages = async ({
       media.map(async (item, index) => {
         let url = item.url
         if (item.file) {
-          const uploaded = await uploadFilesQuery([{ file: item.file }])
+          const uploaded = await sdk.admin.uploads.mutate({
+            files: [item.file],
+          })
           url = uploaded.files?.[0]?.url ?? url
         }
         return {
@@ -49,7 +51,7 @@ export const uploadCollectionImages = async ({
     if (!icon) {
       payload.icon = null
     } else if (icon.file) {
-      const uploaded = await uploadFilesQuery([{ file: icon.file }])
+      const uploaded = await sdk.admin.uploads.mutate({ files: [icon.file] })
       payload.icon = uploaded.files?.[0]?.url ?? icon.url
     } else {
       payload.icon = icon.url

--- a/packages/admin/src/pages/products/constants.ts
+++ b/packages/admin/src/pages/products/constants.ts
@@ -17,6 +17,6 @@
  * options + `is_exclusive` must be read from the `product_option` side.
  */
 export const PRODUCT_DETAIL_FIELDS =
-  "*categories,*sellers,-variants,*scoped_attributes,*scoped_attributes.values,*product_attribute_values,*product_attribute_values.attribute,*product_attribute_values.attribute.values"
+  "*images,*categories,*sellers,-variants,*scoped_attributes,*scoped_attributes.values,*product_attribute_values,*product_attribute_values.attribute,*product_attribute_values.attribute.values"
 
 export const PRODUCT_DETAIL_QUERY = { fields: PRODUCT_DETAIL_FIELDS } as const

--- a/packages/admin/src/pages/products/product-media/components/edit-product-media-form/edit-product-media-form.tsx
+++ b/packages/admin/src/pages/products/product-media/components/edit-product-media-form/edit-product-media-form.tsx
@@ -44,7 +44,7 @@ import {
 } from "../../../../../components/modals";
 import { KeyboundForm } from "../../../../../components/utilities/keybound-form";
 import { useUpdateProduct } from "../../../../../hooks/api/products";
-import { uploadFilesQuery } from "../../../../../lib/client";
+import { sdk } from "../../../../../lib/client";
 import { UploadMediaFormItem } from "../../../common/components/upload-media-form-item";
 import {
   EditProductMediaSchema,
@@ -118,15 +118,15 @@ export const EditProductMediaForm = ({ product }: ProductMediaViewProps) => {
     let uploaded: HttpTypes.AdminFile[] = [];
 
     if (filesToUpload.length) {
-      const { files: uploads } = await uploadFilesQuery(filesToUpload).catch(
-        () => {
+      const { files: uploads } = await sdk.admin.uploads
+        .mutate({ files: filesToUpload.map((m) => m.file) })
+        .catch(() => {
           form.setError("media", {
             type: "invalid_file",
             message: t("products.media.failedToUpload"),
           });
           return { files: [] };
-        },
-      );
+        });
       uploaded = uploads;
     }
 

--- a/packages/admin/src/pages/products/product-media/components/edit-product-media-form/edit-product-media-form.tsx
+++ b/packages/admin/src/pages/products/product-media/components/edit-product-media-form/edit-product-media-form.tsx
@@ -44,7 +44,7 @@ import {
 } from "../../../../../components/modals";
 import { KeyboundForm } from "../../../../../components/utilities/keybound-form";
 import { useUpdateProduct } from "../../../../../hooks/api/products";
-import { sdk } from "../../../../../lib/client";
+import { uploadFilesQuery } from "../../../../../lib/client";
 import { UploadMediaFormItem } from "../../../common/components/upload-media-form-item";
 import {
   EditProductMediaSchema,
@@ -118,23 +118,15 @@ export const EditProductMediaForm = ({ product }: ProductMediaViewProps) => {
     let uploaded: HttpTypes.AdminFile[] = [];
 
     if (filesToUpload.length) {
-      const formData = new FormData();
-      for (const { file } of filesToUpload) {
-        formData.append("files", file);
-      }
-
-      const { files: uploads } = await sdk.admin.uploads
-        .mutate({
-          files: filesToUpload.map((m) => m.file),
-          fetchOptions: { body: formData },
-        })
-        .catch(() => {
+      const { files: uploads } = await uploadFilesQuery(filesToUpload).catch(
+        () => {
           form.setError("media", {
             type: "invalid_file",
             message: t("products.media.failedToUpload"),
           });
           return { files: [] };
-        });
+        },
+      );
       uploaded = uploads;
     }
 

--- a/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
+++ b/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
@@ -21,7 +21,6 @@ import { SwitchBox } from "@components/common/switch-box";
 import { HandleInput } from "@components/inputs/handle-input";
 import { RouteDrawer, useRouteModal } from "@components/modals";
 import { KeyboundForm } from "@components/utilities/keybound-form";
-import { uploadFilesQuery } from "@lib/client";
 import { MediaSchema } from "@pages/products/product-create/constants";
 import { InferClientOutput } from "@mercurjs/client";
 import { sdk } from "@lib/client";
@@ -140,14 +139,18 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
 
     try {
       if (newLogoFile) {
-        const uploaded = await uploadFilesQuery([newLogoFile]);
+        const uploaded = await sdk.admin.uploads.mutate({
+          files: [newLogoFile.file],
+        });
         logoUrl = uploaded.files?.[0]?.url || null;
       } else if (values.media?.length) {
         logoUrl = values.media[0].url;
       }
 
       if (newBannerFile) {
-        const uploaded = await uploadFilesQuery([newBannerFile]);
+        const uploaded = await sdk.admin.uploads.mutate({
+          files: [newBannerFile.file],
+        });
         bannerUrl = uploaded.files?.[0]?.url || null;
       } else if (values.bannerMedia?.length) {
         bannerUrl = values.bannerMedia[0].url;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -27,6 +27,43 @@ export class ClientError extends Error {
     }
 }
 
+const isFileLike = (value: unknown): value is Blob =>
+    typeof Blob !== "undefined" && value instanceof Blob;
+
+const payloadHasFiles = (payload: Record<string, any>): boolean =>
+    Object.values(payload).some(
+        (value) =>
+            isFileLike(value) || (Array.isArray(value) && value.some(isFileLike))
+    );
+
+const toFormData = (payload: Record<string, any>): FormData => {
+    const formData = new FormData();
+
+    for (const [key, value] of Object.entries(payload)) {
+        if (value === undefined || value === null) {
+            continue;
+        }
+
+        const append = (item: unknown) => {
+            if (isFileLike(item)) {
+                formData.append(key, item);
+            } else if (typeof item === "object") {
+                formData.append(key, JSON.stringify(item));
+            } else {
+                formData.append(key, String(item));
+            }
+        };
+
+        if (Array.isArray(value)) {
+            value.forEach(append);
+        } else {
+            append(value);
+        }
+    }
+
+    return formData;
+};
+
 export function createClient(options: ClientOptions) {
     const { baseUrl, fetchOptions: defaultFetchOptions } = options;
 
@@ -58,12 +95,16 @@ export function createClient(options: ClientOptions) {
         const fullPath = `${base.pathname.replace(/\/$/, "")}/${urlPath.replace(/^\//, "")}`;
         const url = new URL(fullPath, base.origin);
 
-        const isFormData = inputFetchOptions?.body instanceof FormData;
+        const hasExplicitFormData = inputFetchOptions?.body instanceof FormData;
+        const hasFilePayload = method !== "GET" && payloadHasFiles(rest);
+        const isMultipart = hasExplicitFormData || hasFilePayload;
 
         let body: string | FormData | undefined;
 
-        if (isFormData) {
+        if (hasExplicitFormData) {
             body = inputFetchOptions!.body as FormData;
+        } else if (hasFilePayload) {
+            body = toFormData(rest);
         } else if (method === "GET" && Object.keys(rest).length > 0) {
             url.search = qs.stringify(rest, { skipNulls: true });
         } else if (method !== "GET" && Object.keys(rest).length > 0) {
@@ -74,7 +115,7 @@ export function createClient(options: ClientOptions) {
             Accept: "application/json",
         };
 
-        if (!isFormData) {
+        if (!isMultipart) {
             defaultHeaders["Content-Type"] = "application/json";
         }
 

--- a/packages/vendor/src/lib/client/client.ts
+++ b/packages/vendor/src/lib/client/client.ts
@@ -77,23 +77,3 @@ export const fetchQuery = async (
 
   return response.json()
 }
-
-export const uploadFilesQuery = async (files: any[]) => {
-  const formData = new FormData()
-
-  for (const { file } of files) {
-    formData.append('files', file)
-  }
-
-  const response = await fetch(`${backendUrl}/vendor/uploads`, {
-    method: 'POST',
-    credentials: 'include',
-    body: formData,
-  })
-
-  if (!response.ok) {
-    return null
-  }
-
-  return response.json()
-}

--- a/packages/vendor/src/pages/products/[id]/media/edit-product-media-form/edit-product-media-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/media/edit-product-media-form/edit-product-media-form.tsx
@@ -38,7 +38,7 @@ import {
 import { KeyboundForm } from "@components/utilities/keybound-form"
 import { useFeatureFlags } from "@hooks/api"
 import { useUpdateProduct } from "@hooks/api/products"
-import { uploadFilesQuery } from "@lib/client"
+import { sdk } from "@lib/client"
 import { UploadMediaFormItem } from "../../../common/components/upload-media-form-item"
 import {
   EditProductMediaSchema,
@@ -116,8 +116,8 @@ export const EditProductMediaForm = ({ product }: ProductMediaViewProps) => {
     let uploaded: HttpTypes.AdminFile[] = []
 
     if (filesToUpload.length) {
-      const { files } = await uploadFilesQuery(filesToUpload)
-        // .then((res) => res.json())
+      const { files } = await sdk.vendor.uploads
+        .mutate({ files: filesToUpload.map((m) => m.file) })
         .catch(() => {
           form.setError("media", {
             type: "invalid_file",

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -23,6 +23,7 @@ export const PRODUCT_VARIANT_IDS_KEY = "product_variant_ids"
  */
 export const PRODUCT_DETAIL_FIELDS = [
   "-variants",
+  "*images",
   "*categories",
   "+additional_data",
   "*scoped_attributes",

--- a/packages/vendor/src/pages/products/create/components/product-create-form/product-create-form.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-form/product-create-form.tsx
@@ -9,7 +9,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { RouteFocusModal, useRouteModal } from "@components/modals"
 import { TabbedForm } from "@components/tabbed-form/tabbed-form"
 import { useCreateProduct, useFeatureFlags } from "@hooks/api"
-import { uploadFilesQuery } from "@lib/client"
+import { sdk } from "@lib/client"
 
 import { PRODUCT_CREATE_FORM_DEFAULTS, ProductCreateSchema } from "../../constants"
 import { ProductCreateSchemaType } from "../../types"
@@ -86,9 +86,9 @@ export const ProductCreateForm = ({
         .filter((m) => !!m.file)
 
       if (filesToUpload.length) {
-        const result = await uploadFilesQuery(
-          filesToUpload.map(({ file }) => ({ file }))
-        )
+        const result = await sdk.vendor.uploads.mutate({
+          files: filesToUpload.map(({ file }) => file),
+        })
         const uploadedFiles: UploadedFile[] = result?.files ?? []
         uploadedMedia = uploadedFiles.map((file, i) => ({
           ...file,

--- a/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
+++ b/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
@@ -20,7 +20,7 @@ import { Form } from "@components/common/form";
 import { HandleInput } from "@components/inputs/handle-input";
 import { RouteDrawer, useRouteModal } from "@components/modals";
 import { KeyboundForm } from "@components/utilities/keybound-form";
-import { uploadFilesQuery } from "@lib/client";
+import { sdk } from "@lib/client";
 import { currencies } from "@lib/data/currencies";
 import { MediaSchema } from "@pages/products/create/constants";
 import { HttpTypes } from "@mercurjs/types";
@@ -131,14 +131,18 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
 
     try {
       if (newLogoFile) {
-        const uploaded = await uploadFilesQuery([newLogoFile]);
+        const uploaded = await sdk.vendor.uploads.mutate({
+          files: [newLogoFile.file],
+        });
         logoUrl = uploaded.files?.[0]?.url || null;
       } else if (values.media?.length) {
         logoUrl = values.media[0].url;
       }
 
       if (newBannerFile) {
-        const uploaded = await uploadFilesQuery([newBannerFile]);
+        const uploaded = await sdk.vendor.uploads.mutate({
+          files: [newBannerFile.file],
+        });
         bannerUrl = uploaded.files?.[0]?.url || null;
       } else if (values.bannerMedia?.length) {
         bannerUrl = values.bannerMedia[0].url;


### PR DESCRIPTION
## Summary
Fixes the root cause behind #1073 in `@mercurjs/client`, removes the now-redundant `uploadFilesQuery` workaround across both dashboards, and makes the product detail page actually display its media.

### 1. Client sends multipart automatically (the real fix)
`@mercurjs/client` only sent a `multipart/form-data` body when `fetchOptions.body` was already a `FormData`. Any other payload was `JSON.stringify`-ed with `Content-Type: application/json`, so `File` objects serialised to `{}` and `POST /admin/uploads` returned `400 invalid_data` ("No files were uploaded"). Image uploads silently failed.

Now, when a non-GET `mutate`/`delete` payload contains `File`/`Blob` values (directly or inside arrays), the client builds a `FormData` automatically and sends multipart, leaving the boundary `Content-Type` to the runtime. Explicit `fetchOptions.body` FormData and plain JSON payloads behave exactly as before.

### 2. Use the SDK directly everywhere; remove `uploadFilesQuery`
With the client handling files, the `uploadFilesQuery` wrapper is dead weight. Every call site in **admin** and **vendor** now calls `sdk.<surface>.uploads.mutate({ files })` directly, and the helper is deleted from both `lib/client` modules:

- Admin: product media edit, store logo/banner, category images, collection images.
- Vendor: product media edit, product create, store logo/banner.

The vendor helper previously bypassed the SDK with a raw `fetch('/vendor/uploads')` (returning a silent `null` on failure); routing it through `sdk.vendor.uploads` keeps auth, base URL, and error handling consistent and surfaces failures as `ClientError`.

### 3. Product detail page now requests images
`PRODUCT_DETAIL_FIELDS` (admin + vendor) never asked for the `images` relation, so the detail media section always got an empty `images` array and showed nothing — even right after a successful upload. Added `*images` to both field sets (the offer detail query already did this).

### Related issue
Addresses #1073. The client fix lives at the SDK layer, so every `sdk.*.uploads.mutate({ files })` call benefits.

## Test plan
- [ ] Admin → product → Media → upload image(s) → Save → images upload (multipart `POST /admin/uploads`, 200) **and render on the detail page**.
- [ ] Admin → store / category / collection image upload → persists.
- [ ] Vendor → product media / product create / store logo+banner upload → persists and renders.
- [x] `bun run build`