### PR TITLE
fix(vendor): send SKU on variant create and singularize select placeholder

### DIFF
--- a/packages/vendor/src/components/inputs/attribute-value-input/attribute-value-input.tsx
+++ b/packages/vendor/src/components/inputs/attribute-value-input/attribute-value-input.tsx
@@ -44,7 +44,7 @@ export const AttributeValueInput = ({
         >
           <Select.Trigger>
             <Select.Value
-              placeholder={t("products.create.attributes.selectValues")}
+              placeholder={t("products.create.attributes.selectValuePlaceholder")}
             />
           </Select.Trigger>
           <Select.Content>
@@ -65,7 +65,7 @@ export const AttributeValueInput = ({
         >
           <Select.Trigger>
             <Select.Value
-              placeholder={t("products.create.attributes.selectValues")}
+              placeholder={t("products.create.attributes.selectValuePlaceholder")}
             />
           </Select.Trigger>
           <Select.Content>

--- a/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/create-product-variant-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/variants/create/create-product-variant-form/create-product-variant-form.tsx
@@ -60,7 +60,7 @@ export const CreateProductVariantForm = ({
   const { mutateAsync, isPending } = useCreateProductVariant(product.id)
 
   const handleSubmit = form.handleSubmit(async (data) => {
-    const { title, options } = data
+    const { title, sku, options } = data
 
     // Form keys variant fields by `handle ?? id`; backend keys options
     // by option title (= attribute name). Remap before submitting.
@@ -77,6 +77,7 @@ export const CreateProductVariantForm = ({
     await mutateAsync(
       {
         title,
+        sku: sku || undefined,
         options: Object.keys(cleanedOptions).length
           ? cleanedOptions
           : undefined,


### PR DESCRIPTION
## Summary
- Variant create form now forwards the SKU field to the mutation — previously it was collected in the form but dropped, so a SKU set by the vendor never persisted.
- Single-select and toggle attribute inputs now use the singular "Select value" placeholder (was "Select values").

## Linear
[MER-136](https://linear.app/rigbyjs/issue/MER-136)

## Test plan
- [ ] In the vendor panel, open a product and create a variant with a SKU set — confirm the SKU is persisted and visible afterwards.
- [ ] Single-select / toggle attribute fields show "Select value" placeholder; multi-select still shows "Select values".
- [ ] `bun run build`