### PR TITLE
fix(admin,vendor): edit-attribute drawer cleanup (hide variant switch, drop hint)

### DIFF
--- a/packages/admin/src/pages/products/product-edit-attribute/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/admin/src/pages/products/product-edit-attribute/components/edit-attribute-form/edit-attribute-form.tsx
@@ -1,13 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Button,
-  Hint,
-  InlineTip,
-  Input,
-  Label,
-  Switch,
-  toast,
-} from "@medusajs/ui";
+import { Button, InlineTip, Input, Label, toast } from "@medusajs/ui";
 import { AttributeType } from "@mercurjs/types";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -235,22 +227,6 @@ const EditScopedAttributeForm = ({
                     </Form.Item>
                   )}
                 />
-                <div />
-                <div className="flex items-start gap-x-3 py-1.5">
-                  <Switch
-                    className="shrink-0 rtl:rotate-180"
-                    checked={isAxis}
-                    disabled
-                  />
-                  <div className="flex flex-col">
-                    <Label size="xsmall" weight="plus">
-                      {t("products.create.attributes.useForVariants")}
-                    </Label>
-                    <Hint className="!txt-small">
-                      {t("products.create.attributes.useForVariantsDescription")}
-                    </Hint>
-                  </div>
-                </div>
               </div>
             </div>
             {isAxis && <VariantAxisTip />}

--- a/packages/admin/src/pages/products/product-edit-attribute/product-edit-attribute.tsx
+++ b/packages/admin/src/pages/products/product-edit-attribute/product-edit-attribute.tsx
@@ -1,4 +1,4 @@
-import { Heading, Text } from "@medusajs/ui";
+import { Heading } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
@@ -32,10 +32,8 @@ export const ProductEditAttribute = () => {
         <RouteDrawer.Title asChild>
           <Heading>{t("products.editAttribute")}</Heading>
         </RouteDrawer.Title>
-        <RouteDrawer.Description asChild>
-          <Text size="small" className="text-ui-fg-subtle">
-            {t("products.editAttributeHint")}
-          </Text>
+        <RouteDrawer.Description className="sr-only">
+          {t("products.editAttributeHint")}
         </RouteDrawer.Description>
       </RouteDrawer.Header>
       {ready && (

--- a/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/components/edit-attribute-form/edit-attribute-form.tsx
@@ -1,13 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import {
-  Button,
-  Hint,
-  InlineTip,
-  Input,
-  Label,
-  Switch,
-  toast,
-} from "@medusajs/ui"
+import { Button, InlineTip, Input, Label, toast } from "@medusajs/ui"
 import { AttributeType, MercurFeatureFlags } from "@mercurjs/types"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -236,22 +228,6 @@ const EditScopedAttributeForm = ({
                     </Form.Item>
                   )}
                 />
-                <div />
-                <div className="flex items-start gap-x-3 py-1.5">
-                  <Switch
-                    className="shrink-0 rtl:rotate-180"
-                    checked={isAxis}
-                    disabled
-                  />
-                  <div className="flex flex-col">
-                    <Label size="xsmall" weight="plus">
-                      {t("products.create.attributes.useForVariants")}
-                    </Label>
-                    <Hint className="!txt-small">
-                      {t("products.create.attributes.useForVariantsDescription")}
-                    </Hint>
-                  </div>
-                </div>
               </div>
             </div>
             {isAxis && <VariantAxisTip />}

--- a/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/[attribute_id]/edit/index.tsx
@@ -1,5 +1,5 @@
 // Route: /products/:id/attributes/:attribute_id/edit
-import { Heading, Text } from "@medusajs/ui";
+import { Heading } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
@@ -33,10 +33,8 @@ export const Component = () => {
         <RouteDrawer.Title asChild>
           <Heading>{t("products.editAttribute")}</Heading>
         </RouteDrawer.Title>
-        <RouteDrawer.Description asChild>
-          <Text size="small" className="text-ui-fg-subtle">
-            {t("products.editAttributeHint")}
-          </Text>
+        <RouteDrawer.Description className="sr-only">
+          {t("products.editAttributeHint")}
         </RouteDrawer.Description>
       </RouteDrawer.Header>
       {ready && (


### PR DESCRIPTION
## Summary
- Hide the permanently-disabled "Use for variants" switch in the edit-attribute drawer (the variant axis can't be toggled after creation) — applied to both the vendor and admin panels.
- Remove the visible "Update the values selected for this attribute on the product." supporting text from both edit-attribute drawers. Kept as an `sr-only` dialog description for accessibility.

## Linear
- [MER-196](https://linear.app/rigbyjs/issue/MER-196) — hide variant switch
- [MER-195](https://linear.app/rigbyjs/issue/MER-195) — remove supporting text (required attribute)
- [MER-194](https://linear.app/rigbyjs/issue/MER-194) — remove supporting text + hide switch (custom attribute)

## Test plan
- [ ] Vendor & admin: edit a product attribute (custom, required, axis, non-axis) — the "Use for variants" switch no longer appears.
- [ ] Vendor & admin: the edit-attribute drawer no longer shows the "Update the values…" supporting line under the title.
- [ ] `bun run build`