### PR TITLE
fix(admin): align customers pages sorting, filtering, empty states and copy with vendor

### DIFF
--- a/packages/admin/src/hooks/table/query/use-customer-table-query.tsx
+++ b/packages/admin/src/hooks/table/query/use-customer-table-query.tsx
@@ -31,7 +31,7 @@ export const useCustomerTableQuery = ({
     offset: offset ? Number(offset) : 0,
     groups: groups?.split(","),
     has_account: has_account ? has_account === "true" : undefined,
-    order,
+    order: order ? order : "-created_at",
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,
     q,

--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -4529,6 +4529,9 @@
             "label": {
               "type": "string"
             },
+            "removeTitle": {
+              "type": "string"
+            },
             "remove": {
               "type": "string"
             },
@@ -4541,11 +4544,15 @@
             "list": {
               "type": "object",
               "properties": {
+                "emptyTitle": {
+                  "type": "string"
+                },
                 "noRecordsMessage": {
                   "type": "string"
                 }
               },
               "required": [
+                "emptyTitle",
                 "noRecordsMessage"
               ],
               "additionalProperties": false
@@ -4553,7 +4560,10 @@
             "add": {
               "type": "object",
               "properties": {
-                "success": {
+                "successOne": {
+                  "type": "string"
+                },
+                "successMany": {
                   "type": "string"
                 },
                 "list": {
@@ -4570,7 +4580,8 @@
                 }
               },
               "required": [
-                "success",
+                "successOne",
+                "successMany",
                 "list"
               ],
               "additionalProperties": false
@@ -4578,7 +4589,10 @@
             "removed": {
               "type": "object",
               "properties": {
-                "success": {
+                "successOne": {
+                  "type": "string"
+                },
+                "successMany": {
                   "type": "string"
                 },
                 "list": {
@@ -4595,7 +4609,8 @@
                 }
               },
               "required": [
-                "success",
+                "successOne",
+                "successMany",
                 "list"
               ],
               "additionalProperties": false
@@ -4603,6 +4618,7 @@
           },
           "required": [
             "label",
+            "removeTitle",
             "remove",
             "removeMany",
             "alreadyAddedTooltip",
@@ -4685,6 +4701,12 @@
           "type": "object",
           "properties": {
             "title": {
+              "type": "string"
+            },
+            "emptyTitle": {
+              "type": "string"
+            },
+            "emptyMessage": {
               "type": "string"
             },
             "fields": {
@@ -4782,6 +4804,8 @@
           },
           "required": [
             "title",
+            "emptyTitle",
+            "emptyMessage",
             "fields",
             "create",
             "edit"

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -1157,20 +1157,24 @@
     },
     "groups": {
       "label": "Customer groups",
-      "remove": "Are you sure you want to remove the customer from \"{{name}}\" customer group?",
-      "removeMany": "Are you sure you want to remove customer from following customer groups: {{groups}}?",
+      "removeTitle": "Remove customer",
+      "remove": "You are about to remove customer from {{name}} group. This action cannot be undone.",
+      "removeMany": "You are about to remove customer from {{groups}} groups. This action cannot be undone.",
       "alreadyAddedTooltip": "The customer is already in this customer group.",
       "list": {
+        "emptyTitle": "No customer groups yet",
         "noRecordsMessage": "This customer doesn't belong to any group."
       },
       "add": {
-        "success": "Customer added to: {{groups}}.",
+        "successOne": "Customer was successfully added to {{groups}} group.",
+        "successMany": "Customer was successfully added to {{groups}} groups.",
         "list": {
           "noRecordsMessage": "Please create a customer group first."
         }
       },
       "removed": {
-        "success": "Customer removed from: {{groups}}.",
+        "successOne": "Customer was successfully removed from {{groups}} group.",
+        "successMany": "Customer was successfully removed from {{groups}} groups.",
         "list": {
           "noRecordsMessage": "Please create a customer group first."
         }
@@ -1196,6 +1200,8 @@
     "hasAccount": "Has account",
     "addresses": {
       "title": "Addresses",
+      "emptyTitle": "No addresses yet",
+      "emptyMessage": "This customer doesn't have any addresses",
       "fields": {
         "addressName": "Address name",
         "address1": "Address 1",

--- a/packages/admin/src/pages/customers/customer-detail/components/customer-address-section/customer-address-section.tsx
+++ b/packages/admin/src/pages/customers/customer-detail/components/customer-address-section/customer-address-section.tsx
@@ -70,8 +70,8 @@ export const CustomerAddressSection = ({
               "flex h-full flex-col overflow-hidden border-t p-6": true,
             })}
             icon={null}
-            title={t("general.noRecordsTitle")}
-            message={t("general.noRecordsMessage")}
+            title={t("customers.addresses.emptyTitle")}
+            message={t("customers.addresses.emptyMessage")}
           />
         </div>
       )}

--- a/packages/admin/src/pages/customers/customer-detail/components/customer-group-section/customer-group-section.tsx
+++ b/packages/admin/src/pages/customers/customer-detail/components/customer-group-section/customer-group-section.tsx
@@ -30,6 +30,7 @@ import { useDataTable } from "../../../../../hooks/use-data-table"
 
 const PAGE_SIZE = 10
 const PREFIX = "cusgr"
+const DEFAULT_ORDER = "-created_at"
 
 export const CustomerGroupSection = ({
   customer,
@@ -48,6 +49,7 @@ export const CustomerGroupSection = ({
     useCustomerGroups(
       {
         ...searchParams,
+        order: searchParams.order || DEFAULT_ORDER,
         fields: "+customers.id,+seller.id,+seller.name",
         customers: { id: customer.id },
       },
@@ -79,15 +81,16 @@ export const CustomerGroupSection = ({
 
   const handleRemove = async () => {
     const customerGroupIds = Object.keys(rowSelection)
+    const selectedGroups =
+      customer_groups?.filter((g) => customerGroupIds.includes(g.id)) ?? []
+    const names = selectedGroups.map((g) => g.name)
+    const isSingle = selectedGroups.length === 1
 
     const res = await prompt({
-      title: t("general.areYouSure"),
-      description: t("customers.groups.removeMany", {
-        groups: customer_groups
-          ?.filter((g) => customerGroupIds.includes(g.id))
-          .map((g) => g.name)
-          .join(","),
-      }),
+      title: t("customers.groups.removeTitle"),
+      description: isSingle
+        ? t("customers.groups.remove", { name: names[0] })
+        : t("customers.groups.removeMany", { groups: names.join(", ") }),
       confirmText: t("actions.remove"),
       cancelText: t("actions.cancel"),
     })
@@ -101,11 +104,11 @@ export const CustomerGroupSection = ({
       {
         onSuccess: () => {
           toast.success(
-            t("customers.groups.removed.success", {
-              groups: customer_groups!
-                .filter((cg) => customerGroupIds.includes(cg.id))
-                .map((cg) => cg?.name),
-            })
+            isSingle
+              ? t("customers.groups.removed.successOne", { groups: names[0] })
+              : t("customers.groups.removed.successMany", {
+                  groups: names.join(", "),
+                })
           )
         },
         onError: (error) => {
@@ -145,6 +148,7 @@ export const CustomerGroupSection = ({
           { key: "created_at", label: t("fields.createdAt") },
           { key: "updated_at", label: t("fields.updatedAt") },
         ]}
+        defaultOrder={DEFAULT_ORDER}
         commands={[
           {
             action: handleRemove,
@@ -154,7 +158,9 @@ export const CustomerGroupSection = ({
         ]}
         queryObject={raw}
         noRecords={{
+          title: t("customers.groups.list.emptyTitle"),
           message: t("customers.groups.list.noRecordsMessage"),
+          icon: null,
         }}
       />
     </Container>
@@ -175,7 +181,7 @@ const CustomerGroupRowActions = ({
 
   const onRemove = async () => {
     const res = await prompt({
-      title: t("general.areYouSure"),
+      title: t("customers.groups.removeTitle"),
       description: t("customers.groups.remove", {
         name: group.name,
       }),
@@ -188,6 +194,11 @@ const CustomerGroupRowActions = ({
     }
 
     await mutateAsync([customerId], {
+      onSuccess: () => {
+        toast.success(
+          t("customers.groups.removed.successOne", { groups: group.name })
+        )
+      },
       onError: (error) => {
         toast.error(error.message)
       },

--- a/packages/admin/src/pages/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
+++ b/packages/admin/src/pages/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
@@ -28,6 +28,7 @@ import {
 import { useOrderGroups } from "../../../../../hooks/api/order-groups"
 import { useOrderTableQuery } from "../../../../../hooks/table/query/use-order-table-query"
 import { useDataTable } from "../../../../../hooks/use-data-table"
+import { useOrderGroupTableFilters } from "../../../../orders/order-list/components/order-list-table/use-order-table-filters"
 import { getStylizedAmount } from "../../../../../lib/money-amount-helpers"
 
 const PREFIX = "cusord"
@@ -141,6 +142,10 @@ export const CustomerOrderSection = ({
     [order_groups, t]
   )
 
+  // Orders are already scoped to this customer, so the customer filter is dropped.
+  const filters = useOrderGroupTableFilters().filter(
+    (f) => f.key !== "customer_id"
+  )
   const columns = useColumns()
 
   const { table } = useDataTable({
@@ -174,11 +179,13 @@ export const CustomerOrderSection = ({
         count={count}
         isLoading={isLoading}
         pageSize={PAGE_SIZE}
+        filters={filters}
         orderBy={[
           { key: "display_id", label: t("orders.fields.displayId") },
           { key: "created_at", label: t("fields.createdAt") },
           { key: "updated_at", label: t("fields.updatedAt") },
         ]}
+        defaultOrder="-display_id"
         search={true}
         queryObject={raw}
         prefix={PREFIX}

--- a/packages/admin/src/pages/customers/customer-list/components/customer-list-table/customer-list-table.tsx
+++ b/packages/admin/src/pages/customers/customer-list/components/customer-list-table/customer-list-table.tsx
@@ -110,6 +110,7 @@ export const CustomerListDataTable = () => {
         { key: "created_at", label: t("fields.createdAt") },
         { key: "updated_at", label: t("fields.updatedAt") },
       ]}
+      defaultOrder="-created_at"
       isLoading={isLoading}
       navigateTo={(row) => row.original.id}
       search

--- a/packages/admin/src/pages/customers/customers-add-customer-group/components/add-customers-form/add-customer-groups-form.tsx
+++ b/packages/admin/src/pages/customers/customers-add-customer-group/components/add-customers-form/add-customer-groups-form.tsx
@@ -119,13 +119,16 @@ export const AddCustomerGroupsForm = ({
     try {
       await batchCustomerCustomerGroups({ add: data.customer_group_ids });
 
+      const names = data.customer_group_ids
+        .map((id) => customer_groups?.find((g) => g.id === id)?.name)
+        .filter(Boolean);
+
       toast.success(
-        t("customers.groups.add.success", {
-          groups: data.customer_group_ids
-            .map((id) => customer_groups?.find((g) => g.id === id))
-            .filter(Boolean)
-            .map((cg) => cg?.name),
-        }),
+        names.length === 1
+          ? t("customers.groups.add.successOne", { groups: names[0] })
+          : t("customers.groups.add.successMany", {
+              groups: names.join(", "),
+            }),
       );
 
       handleSuccess(`/customers/${customerId}`);


### PR DESCRIPTION
## Summary
Mirrors the vendor Customers fixes onto the admin panel (same Medusa/table patterns used in the vendor PRs), covering all 8 sub-issues referenced by MER-224:

- **MER-201** — Customers list defaults to newest-first; the order-by menu reflects the default (`use-customer-table-query` defaults `order`, `defaultOrder="-created_at"` on the table).
- **MER-203** — Customer detail Orders section now renders the order-group filters (reusing `useOrderGroupTableFilters`, dropping the redundant customer filter since it's already scoped).
- **MER-204** — Orders section shows the default sort (`-display_id`) as selected.
- **MER-205** — Customer Groups section defaults sort to newest-first and reflects it in the menu.
- **MER-206** — Customer Groups empty state uses design copy + no icon.
- **MER-208** — Addresses empty state uses addresses-specific copy.
- **MER-209** — Remove-from-group confirmation uses a dedicated "Remove customer" heading and group-name aware singular/plural supporting text.
- **MER-210** — Add/remove-from-group toasts use singular vs plural, group-name aware copy.

i18n keys and `$schema.json` updated to match the new copy (consistent with the vendor changes).

## Linear
[MER-224](https://linear.app/rigbyjs/issue/MER-224)

## Test plan
- [x] `bun run build` (turbo `@mercurjs/admin` incl. DTS type-check) passes
- [x] `oxlint` clean on changed files
- [ ] Customers list loads newest-first with the order-by menu pre-selected
- [ ] Customer detail Orders section: filters apply, default sort selected
- [ ] Customer detail Groups section: default sort, empty-state copy/icon, remove prompt + toast wording (single vs multiple)
- [ ] Addresses empty state copy
- [ ] Add-to-group toast wording (single vs multiple)