### PR TITLE
docs: link release notes button to all releases

### DIFF
--- a/apps/docs/welcome.mdx
+++ b/apps/docs/welcome.mdx
@@ -15,7 +15,7 @@ mode: "custom"
       <a href="/getting-started/installation" className="inline-flex items-center px-5 py-2.5 rounded-lg bg-black dark:bg-white text-white dark:text-black font-medium text-sm hover:opacity-90 transition-opacity no-underline">
         Get Started
       </a>
-      <a href="https://github.com/mercurjs/mercur/releases/tag/v2.0.0" className="inline-flex items-center px-5 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 font-medium text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors no-underline">
+      <a href="https://github.com/mercurjs/mercur/releases" className="inline-flex items-center px-5 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 font-medium text-sm hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors no-underline">
         Release Notes
       </a>
     </div>


### PR DESCRIPTION
Updates the homepage hero button in the docs to point to the full release listing (`/releases`) instead of the pinned `v2.0.0` tag, and relabels it to **All Release Notes**.