### PR TITLE
fix(admin,vendor): correct attribute value placeholders and tip border in product create step 3

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -463,6 +463,8 @@
         "values": "Values",
         "selectValues": "Select values",
         "valuePlaceholder": "Enter values",
+        "enterValuePlaceholder": "Enter value",
+        "selectValuePlaceholder": "Select value",
         "requiredAttributes": "Required attributes",
         "requiredAttributesHint": "These attributes are required by the Marketplace. Select them before proceeding.",
         "useForVariants": "Use for Variations",

--- a/packages/admin/src/pages/products/product-create/components/product-create-attributes-form/product-create-attributes-form.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-attributes-form/product-create-attributes-form.tsx
@@ -338,7 +338,7 @@ const SelectedAttributes = ({
                       <Select.Trigger ref={ref}>
                         <Select.Value
                           placeholder={t(
-                            "products.create.attributes.selectValues"
+                            "products.create.attributes.selectValuePlaceholder"
                           )}
                         />
                       </Select.Trigger>
@@ -367,7 +367,7 @@ const SelectedAttributes = ({
                       }
                       onChange={(e) => onChange(e.target.value)}
                       placeholder={t(
-                        "products.create.attributes.valuePlaceholder"
+                        "products.create.attributes.enterValuePlaceholder"
                       )}
                     />
                   )}
@@ -385,7 +385,7 @@ const SelectedAttributes = ({
                       <Select.Trigger>
                         <Select.Value
                           placeholder={t(
-                            "products.create.attributes.selectValues"
+                            "products.create.attributes.selectValuePlaceholder"
                           )}
                         />
                       </Select.Trigger>
@@ -414,7 +414,7 @@ const SelectedAttributes = ({
                       }
                       onChange={(e) => onChange(e.target.value)}
                       placeholder={t(
-                        "products.create.attributes.valuePlaceholder"
+                        "products.create.attributes.enterValuePlaceholder"
                       )}
                     />
                   )}
@@ -423,7 +423,7 @@ const SelectedAttributes = ({
               {field.use_for_variants && (
                 <>
                   <div />
-                  <VariantAxisTip />
+                  <VariantAxisTip className="border-none" />
                 </>
               )}
             </div>
@@ -570,7 +570,7 @@ const RequiredAttributeField = ({
                 <Select.Trigger ref={ref}>
                   <Select.Value
                     placeholder={t(
-                      "products.create.attributes.valuePlaceholder"
+                      "products.create.attributes.selectValuePlaceholder"
                     )}
                   />
                 </Select.Trigger>
@@ -605,7 +605,7 @@ const RequiredAttributeField = ({
                 value={typeof value === "string" ? value : value?.[0] ?? ""}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder={t(
-                  "products.create.attributes.valuePlaceholder"
+                  "products.create.attributes.enterValuePlaceholder"
                 )}
               />
             ) : attribute.type === AttributeType.TOGGLE ? (
@@ -622,7 +622,7 @@ const RequiredAttributeField = ({
                 value={typeof value === "string" ? value : value?.[0] ?? ""}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder={t(
-                  "products.create.attributes.valuePlaceholder"
+                  "products.create.attributes.enterValuePlaceholder"
                 )}
               />
             )}
@@ -636,11 +636,11 @@ const RequiredAttributeField = ({
   )
 }
 
-const VariantAxisTip = () => {
+const VariantAxisTip = ({ className }: { className?: string }) => {
   const { t } = useTranslation()
 
   return (
-    <InlineTip label={t("products.create.attributes.tip")}>
+    <InlineTip className={className} label={t("products.create.attributes.tip")}>
       {t("products.create.attributes.variantAxisTip")}
     </InlineTip>
   )

--- a/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
@@ -424,7 +424,7 @@ const SelectedAttributes = ({
               {field.use_for_variants && (
                 <>
                   <div />
-                  <VariantAxisTip />
+                  <VariantAxisTip className="border-none" />
                 </>
               )}
             </div>
@@ -640,14 +640,11 @@ const RequiredAttributeField = ({
   )
 }
 
-const VariantAxisTip = () => {
+const VariantAxisTip = ({ className }: { className?: string }) => {
   const { t } = useTranslation()
 
   return (
-    <InlineTip
-      className="border-none"
-      label={t("products.create.attributes.tip")}
-    >
+    <InlineTip className={className} label={t("products.create.attributes.tip")}>
       {t("products.create.attributes.variantAxisTip")}
     </InlineTip>
   )

--- a/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
@@ -339,7 +339,7 @@ const SelectedAttributes = ({
                       <Select.Trigger ref={ref}>
                         <Select.Value
                           placeholder={t(
-                            "products.create.attributes.selectValues"
+                            "products.create.attributes.selectValuePlaceholder"
                           )}
                         />
                       </Select.Trigger>
@@ -368,7 +368,7 @@ const SelectedAttributes = ({
                       }
                       onChange={(e) => onChange(e.target.value)}
                       placeholder={t(
-                        "products.create.attributes.valuePlaceholder"
+                        "products.create.attributes.enterValuePlaceholder"
                       )}
                     />
                   )}
@@ -386,7 +386,7 @@ const SelectedAttributes = ({
                       <Select.Trigger>
                         <Select.Value
                           placeholder={t(
-                            "products.create.attributes.selectValues"
+                            "products.create.attributes.selectValuePlaceholder"
                           )}
                         />
                       </Select.Trigger>
@@ -415,7 +415,7 @@ const SelectedAttributes = ({
                       }
                       onChange={(e) => onChange(e.target.value)}
                       placeholder={t(
-                        "products.create.attributes.valuePlaceholder"
+                        "products.create.attributes.enterValuePlaceholder"
                       )}
                     />
                   )}
@@ -574,7 +574,7 @@ const RequiredAttributeField = ({
                 <Select.Trigger ref={ref}>
                   <Select.Value
                     placeholder={t(
-                      "products.create.attributes.valuePlaceholder"
+                      "products.create.attributes.selectValuePlaceholder"
                     )}
                   />
                 </Select.Trigger>
@@ -609,7 +609,7 @@ const RequiredAttributeField = ({
                 value={typeof value === "string" ? value : value?.[0] ?? ""}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder={t(
-                  "products.create.attributes.valuePlaceholder"
+                  "products.create.attributes.enterValuePlaceholder"
                 )}
               />
             ) : attribute.type === AttributeType.TOGGLE ? (
@@ -626,7 +626,7 @@ const RequiredAttributeField = ({
                 value={typeof value === "string" ? value : value?.[0] ?? ""}
                 onChange={(e) => onChange(e.target.value)}
                 placeholder={t(
-                  "products.create.attributes.valuePlaceholder"
+                  "products.create.attributes.enterValuePlaceholder"
                 )}
               />
             )}
@@ -644,7 +644,10 @@ const VariantAxisTip = () => {
   const { t } = useTranslation()
 
   return (
-    <InlineTip label={t("products.create.attributes.tip")}>
+    <InlineTip
+      className="border-none"
+      label={t("products.create.attributes.tip")}
+    >
       {t("products.create.attributes.variantAxisTip")}
     </InlineTip>
   )


### PR DESCRIPTION
## Summary
Applies to **both** the vendor and admin product-create step 3 (Attributes):
- Single-select and toggle attributes (required + optional) now use the **"Select value"** placeholder instead of "Select values" / "Enter values".
- Unit and text-area attributes (required + optional) now use **"Enter value"** instead of "Enter values".
- Multi-select attributes keep the plural **"Select values"** placeholder (unchanged — correct).
- The variant-axis tip is now borderless **only** on the add-existing (optional) attributes path; the required-attributes tip keeps its border.

Copy reuses the singular i18n keys (`selectValuePlaceholder`, `enterValuePlaceholder`). These already existed in the vendor package; the two keys were added to the admin `en.json`.

## Linear
[MER-244](https://linear.app/rigbyjs/issue/MER-244)

## Test plan
- [ ] Vendor (7001) and Admin (7000) → Create product → Step 3: pick a category with required attributes and verify each attribute type shows the correct placeholder.
- [ ] Add an existing variant-axis (multi-select) attribute → its tip renders without a border; a required variant-axis attribute's tip keeps its border.
- [ ] `bun run lint`
- [ ] `bun run build`