### PR TITLE
fix(vendor): fix create-product variants step scroll and search

### DIFF
--- a/packages/admin/src/components/data-grid/components/data-grid-root.tsx
+++ b/packages/admin/src/components/data-grid/components/data-grid-root.tsx
@@ -908,7 +908,14 @@ const DataGridHeader = ({
           )}
         </div>
       )}
-      {headerContent}
+      {headerContent && (
+        <div
+          className="flex items-center"
+          onFocusCapture={() => onHeaderInteractionChange(true)}
+        >
+          {headerContent}
+        </div>
+      )}
       <div className="ml-auto flex items-center gap-x-2">
         {errorCount > 0 && (
           <Button

--- a/packages/admin/src/pages/products/product-create/components/product-create-variants-form/product-create-variants-form.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-variants-form/product-create-variants-form.tsx
@@ -60,7 +60,10 @@ const Root = () => {
       className="flex size-full flex-col divide-y overflow-hidden"
       data-testid="product-create-variants-form"
     >
-      <div data-testid="product-create-variants-form-datagrid">
+      <div
+        className="min-h-0 flex-1 overflow-hidden"
+        data-testid="product-create-variants-form-datagrid"
+      >
         <DataGrid
           columns={columns}
           data={variantData}

--- a/packages/vendor/src/components/data-grid/components/data-grid-root.tsx
+++ b/packages/vendor/src/components/data-grid/components/data-grid-root.tsx
@@ -909,7 +909,14 @@ const DataGridHeader = ({
         </div>
       )}
       <div className="ml-auto flex items-center gap-x-2">
-        {headerContent}
+        {headerContent && (
+          <div
+            className="flex items-center"
+            onFocusCapture={() => onHeaderInteractionChange(true)}
+          >
+            {headerContent}
+          </div>
+        )}
         {errorCount > 0 && (
           <Button
             size="small"

--- a/packages/vendor/src/pages/products/create/components/product-create-variants-form/product-create-variants-form.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-variants-form/product-create-variants-form.tsx
@@ -88,7 +88,10 @@ const Root = () => {
       className="flex size-full flex-col divide-y overflow-hidden"
       data-testid="product-create-variants-form"
     >
-      <div data-testid="product-create-variants-form-datagrid">
+      <div
+        className="min-h-0 flex-1 overflow-hidden"
+        data-testid="product-create-variants-form-datagrid"
+      >
         <DataGrid
           columns={columns}
           data={filteredVariantData}


### PR DESCRIPTION
## Summary
Fixes two bugs on Step 4 (variants) of the vendor create-product wizard:

- **Cannot scroll the table** — the DataGrid wrapper had no bounded height, so the grid's internal `overflow-auto` container never scrolled and the outer `overflow-hidden` just clipped overflowing rows. The wrapper now uses `min-h-0 flex-1` so the grid fills the available height and scrolls internally.
- **Cannot clear the search** — the DataGrid registers a global `window` keydown trap for cell editing; `Backspace`/`Delete` typed in the header search were captured by the grid (`handleDeleteKey` calls `preventDefault`), so the input could not be cleared. The grid now releases the trap when focus enters custom `headerContent`, mirroring the existing column/shortcut dropdown behaviour.

## Linear
[MER-245](https://linear.app/rigbyjs/issue/MER-245)

## Test plan
- [ ] Vendor panel → Products → Create → reach Step 4 (Variants) with enough variants to overflow; the variants table scrolls.
- [ ] Type in the variants search box, then delete the text with Backspace/Delete — text clears and grid cells are not affected.
- [ ] `bun run lint`
- [ ] `bun run build`