### PR TITLE
fix(vendor): return all product images on detail query

### DIFF
--- a/integration-tests/http/product/vendor/product.spec.ts
+++ b/integration-tests/http/product/vendor/product.spec.ts
@@ -355,5 +355,60 @@ medusaIntegrationTestRunner({
         expect(idsB).not.toContain(restrictedToA)
       })
     })
+
+    // MER-246: creating a product with several images persisted only one in the
+    // UI. The images survive the create workflow, but the vendor detail query
+    // omits the relation from its server defaults, so the bare `*images` the
+    // panel requested resolved against nothing and returned no images — leaving
+    // only the scalar `thumbnail`. The panel now spells the relation out
+    // (`images.id,images.url,images.rank`); this guards that contract.
+    describe("Vendor - product images", () => {
+      let appContainer: MedusaContainer
+      let sellerHeaders: any
+
+      beforeAll(() => {
+        appContainer = getContainer()
+      })
+
+      beforeEach(async () => {
+        const res = await createSellerUser(appContainer, {
+          email: "vendor-images@test.com",
+          name: "Vendor Images Store",
+        })
+        sellerHeaders = res.headers
+      })
+
+      it("returns every image on the detail query, not just the thumbnail", async () => {
+        const images = [
+          { url: "https://example.com/mer-246-1.png" },
+          { url: "https://example.com/mer-246-2.png" },
+          { url: "https://example.com/mer-246-3.png" },
+        ]
+
+        const created = await api.post(
+          "/vendor/products",
+          {
+            status: "published",
+            title: "Multi Image Product",
+            images,
+            thumbnail: images[0].url,
+            variants: [{ title: "Default" }],
+          },
+          sellerHeaders
+        )
+        const productId = created.data.product.id
+
+        const res = await api.get(
+          `/vendor/products/${productId}?fields=images.id,images.url,images.rank`,
+          sellerHeaders
+        )
+
+        const returned: { url: string }[] = res.data.product.images ?? []
+        expect(returned).toHaveLength(images.length)
+        expect(returned.map((i) => i.url).sort()).toEqual(
+          images.map((i) => i.url).sort()
+        )
+      })
+    })
   },
 })

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -1,32 +1,9 @@
 export const PRODUCT_VARIANT_IDS_KEY = "product_variant_ids"
 
-/**
- * Fields appended to Medusa defaults for product detail queries.
- * Uses `*` prefix to add relations without replacing Medusa's built-in defaults.
- *
- * Mercur links surfaced here:
- *   - `scoped_attributes` — product-scoped inline attributes (read-only link)
- *   - `product_attribute_values` — product-level linked attribute values (the
- *     `product_attribute_value_link` pivot; SPEC-014 — NOT `attribute_values`,
- *     which is not a relation on `product`). The enricher reads
- *     `product_attribute_values.attribute(.values)` to build the unified
- *     `product.attributes[]` array (selected `values` + full `all_values`).
- *
- * NOTE: native `options` and `variants` are intentionally NOT requested — on
- * the 2.16 options-preview build the product → variants/options populate
- * crashes the remote joiner ("Cannot resolve alias path \"variants\"" /
- * `expandDotPaths`). `-variants` strips the variant subtree the query-config
- * defaults would otherwise pull in. Variant data is read from the
- * `/vendor/products/:id/variants` endpoint instead (variant section + the
- * active edit-request block). Axis options + `is_exclusive` are read from the
- * `product_option` side.
- *
- * `images` is spelled out field-by-field rather than as a bare `*images`
- * wildcard: the vendor product query-config omits it from the server defaults
- * (the 2.16 remote joiner rejects bare `*relation` wildcards there), so a
- * client-side `*images` resolves against nothing and silently returns no
- * images — leaving only the scalar `thumbnail` on the product (MER-246).
- */
+// `-variants`: the 2.16 options-preview joiner crashes on product →
+// variants/options populate; variants are read from /vendor/products/:id/variants.
+// `images` is spelled out (not `*images`): the query-config server defaults omit
+// it, and the 2.16 joiner returns nothing for a bare `*relation` wildcard.
 export const PRODUCT_DETAIL_FIELDS = [
   "-variants",
   "images.id",

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -20,10 +20,18 @@ export const PRODUCT_VARIANT_IDS_KEY = "product_variant_ids"
  * `/vendor/products/:id/variants` endpoint instead (variant section + the
  * active edit-request block). Axis options + `is_exclusive` are read from the
  * `product_option` side.
+ *
+ * `images` is spelled out field-by-field rather than as a bare `*images`
+ * wildcard: the vendor product query-config omits it from the server defaults
+ * (the 2.16 remote joiner rejects bare `*relation` wildcards there), so a
+ * client-side `*images` resolves against nothing and silently returns no
+ * images — leaving only the scalar `thumbnail` on the product (MER-246).
  */
 export const PRODUCT_DETAIL_FIELDS = [
   "-variants",
-  "*images",
+  "images.id",
+  "images.url",
+  "images.rank",
   "*categories",
   "+additional_data",
   "*scoped_attributes",


### PR DESCRIPTION
## Summary
- Vendor products created with multiple images appeared to save only one (MER-246). The images **are** persisted by the create workflow — but the vendor detail query never returned them, so the panel showed only the scalar `thumbnail`.
- Root cause: `PRODUCT_DETAIL_FIELDS` requested images with a bare `*images` wildcard. The vendor product `query-config` omits `images` from its server defaults (the Medusa 2.16 remote joiner rejects bare `*relation` wildcards there), so a client-side `*images` resolves against nothing and returns no images. Every *other* relation the panel requests is already in the defaults, which is why only images broke.
- Fix: spell the relation out (`images.id,images.url,images.rank`), matching how the backend spells out every relation on this build.

## Linear
[MER-246](https://linear.app/rigbyjs/issue/MER-246)

## Test plan
- [ ] Vendor panel → create a product with 3 images → save → open detail → all 3 images present
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test:integration:http -- product/vendor/product` (added regression test asserting the detail query returns every image, not just the thumbnail)