### PR TITLE
fix(admin): require a value when editing commission

### DIFF
--- a/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Heading, toast } from "@medusajs/ui";
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
@@ -16,16 +17,29 @@ import {
 } from "../../../hooks/api/commissions";
 import { CommissionValueFields } from "../common/components/commission-value-fields";
 import { useStoreCurrencies } from "../common/hooks/use-store-currencies";
+import { addCommissionValueIssues, optionalAmount } from "../common/schema";
 import { CommissionRate } from "../common/types";
 import { buildValuesPayload, fixedValuesFromRate } from "../common/utils";
 
 const EditCommissionSchema = zod.object({
   type: zod.enum(["percentage", "fixed"]),
-  value: zod.coerce.number().min(0),
-  fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
+  value: optionalAmount,
+  fixed_values: zod.record(zod.string(), optionalAmount).optional(),
   include_tax: zod.boolean(),
   include_shipping: zod.boolean(),
 });
+
+type EditCommissionSchemaType = zod.infer<typeof EditCommissionSchema>;
+
+const createEditCommissionSchema = (currencies: string[]) =>
+  EditCommissionSchema.superRefine((data, ctx) => {
+    addCommissionValueIssues(ctx, {
+      type: data.type,
+      value: data.value,
+      fixedValues: data.fixed_values,
+      currencies,
+    });
+  });
 
 const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
   const { t } = useTranslation();
@@ -37,7 +51,12 @@ const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
     { value: "fixed", label: t("commissions.fields.type.fixed") },
   ];
 
-  const form = useForm<zod.infer<typeof EditCommissionSchema>>({
+  const resolver = useMemo(
+    () => zodResolver(createEditCommissionSchema(currencies)),
+    [currencies]
+  );
+
+  const form = useForm<EditCommissionSchemaType>({
     defaultValues: {
       type: rule.type,
       value: rule.value,
@@ -45,7 +64,7 @@ const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
       include_tax: rule.include_tax,
       include_shipping: rule.include_shipping,
     },
-    resolver: zodResolver(EditCommissionSchema),
+    resolver,
   });
 
   const { mutateAsync, isPending } = useUpdateCommissionRule(rule.id);

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/schema.ts
@@ -1,15 +1,8 @@
 import i18n from "i18next";
 import * as zod from "zod";
 
+import { addCommissionValueIssues, optionalAmount } from "../../../common/schema";
 import { SCOPE_TYPE_DIMENSIONS } from "../../../common/types";
-
-const optionalAmount = zod.preprocess((val) => {
-  if (val === "" || val === null || val === undefined) {
-    return undefined;
-  }
-  const parsed = typeof val === "number" ? val : Number(val);
-  return Number.isNaN(parsed) ? undefined : parsed;
-}, zod.number().optional());
 
 const baseCommissionRuleSchema = zod.object({
   title: zod
@@ -64,26 +57,12 @@ export const createCommissionRuleSchema = (currencies: string[] = []) =>
       });
     }
 
-    if (data.commissionType === "percentage") {
-      if (data.value === undefined || Number.isNaN(data.value)) {
-        ctx.addIssue({
-          code: zod.ZodIssueCode.custom,
-          path: ["value"],
-          message: i18n.t("commissions.validation.value"),
-        });
-      }
-    } else {
-      currencies.forEach((code) => {
-        const amount = data.fixed_values?.[code];
-        if (amount === undefined || Number.isNaN(amount)) {
-          ctx.addIssue({
-            code: zod.ZodIssueCode.custom,
-            path: ["fixed_values", code],
-            message: i18n.t("commissions.validation.value"),
-          });
-        }
-      });
-    }
+    addCommissionValueIssues(ctx, {
+      type: data.commissionType,
+      value: data.value,
+      fixedValues: data.fixed_values,
+      currencies,
+    });
   });
 
 export type CreateCommissionRuleSchemaType = zod.infer<

--- a/packages/admin/src/pages/commissions/common/schema.ts
+++ b/packages/admin/src/pages/commissions/common/schema.ts
@@ -1,0 +1,44 @@
+import i18n from "i18next";
+import * as zod from "zod";
+
+export const optionalAmount = zod.preprocess((val) => {
+  if (val === "" || val === null || val === undefined) {
+    return undefined;
+  }
+  const parsed = typeof val === "number" ? val : Number(val);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}, zod.number().optional());
+
+type CommissionValueInput = {
+  type: "percentage" | "fixed";
+  value?: number;
+  fixedValues?: Record<string, number | undefined>;
+  currencies?: string[];
+};
+
+export const addCommissionValueIssues = (
+  ctx: zod.RefinementCtx,
+  { type, value, fixedValues, currencies = [] }: CommissionValueInput
+) => {
+  if (type === "percentage") {
+    if (value === undefined || Number.isNaN(value)) {
+      ctx.addIssue({
+        code: zod.ZodIssueCode.custom,
+        path: ["value"],
+        message: i18n.t("commissions.validation.value"),
+      });
+    }
+    return;
+  }
+
+  currencies.forEach((code) => {
+    const amount = fixedValues?.[code];
+    if (amount === undefined || Number.isNaN(amount)) {
+      ctx.addIssue({
+        code: zod.ZodIssueCode.custom,
+        path: ["fixed_values", code],
+        message: i18n.t("commissions.validation.value"),
+      });
+    }
+  });
+};

--- a/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Heading, Input, toast } from "@medusajs/ui";
 import i18n from "i18next";
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
@@ -16,31 +17,33 @@ import {
 } from "../../../hooks/api/commissions";
 import { CommissionValueFields } from "../common/components/commission-value-fields";
 import { useStoreCurrencies } from "../common/hooks/use-store-currencies";
+import { addCommissionValueIssues, optionalAmount } from "../common/schema";
 import { CommissionRate } from "../common/types";
 import { buildValuesPayload, fixedValuesFromRate } from "../common/utils";
 
-const EditGlobalCommissionSchema = zod
-  .object({
-    code: zod
-      .string()
-      .min(1, { message: i18n.t("commissions.validation.codeRequired") }),
-    type: zod.enum(["percentage", "fixed"]),
-    value: zod.coerce.number().optional(),
-    fixed_values: zod.record(zod.string(), zod.coerce.number()).optional(),
-    include_tax: zod.boolean(),
-    include_shipping: zod.boolean(),
-  })
-  .superRefine((data, ctx) => {
-    if (
-      data.type === "percentage" &&
-      (data.value === undefined || Number.isNaN(data.value))
-    ) {
-      ctx.addIssue({
-        code: zod.ZodIssueCode.custom,
-        path: ["value"],
-        message: i18n.t("commissions.validation.valueRequired"),
-      });
-    }
+const EditGlobalCommissionSchema = zod.object({
+  code: zod
+    .string()
+    .min(1, { message: i18n.t("commissions.validation.codeRequired") }),
+  type: zod.enum(["percentage", "fixed"]),
+  value: optionalAmount,
+  fixed_values: zod.record(zod.string(), optionalAmount).optional(),
+  include_tax: zod.boolean(),
+  include_shipping: zod.boolean(),
+});
+
+type EditGlobalCommissionSchemaType = zod.infer<
+  typeof EditGlobalCommissionSchema
+>;
+
+const createEditGlobalCommissionSchema = (currencies: string[]) =>
+  EditGlobalCommissionSchema.superRefine((data, ctx) => {
+    addCommissionValueIssues(ctx, {
+      type: data.type,
+      value: data.value,
+      fixedValues: data.fixed_values,
+      currencies,
+    });
   });
 
 const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
@@ -53,7 +56,12 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
     { value: "fixed", label: t("commissions.fields.type.fixed") },
   ];
 
-  const form = useForm<zod.infer<typeof EditGlobalCommissionSchema>>({
+  const resolver = useMemo(
+    () => zodResolver(createEditGlobalCommissionSchema(currencies)),
+    [currencies]
+  );
+
+  const form = useForm<EditGlobalCommissionSchemaType>({
     defaultValues: {
       code: rate.code,
       type: rate.type,
@@ -62,7 +70,7 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
       include_tax: rate.include_tax,
       include_shipping: rate.include_shipping,
     },
-    resolver: zodResolver(EditGlobalCommissionSchema),
+    resolver,
   });
 
   const { mutateAsync, isPending } = useUpdateCommissionRule(rate.id);


### PR DESCRIPTION
## Summary
- Editing a commission (per-rule drawer and global drawer) now requires a value before saving instead of silently coercing an empty percentage to `0`.
- The global-commission drawer was referencing a translation key (`commissions.validation.valueRequired`) that doesn't exist in `en.json`, so the empty-value error rendered as the raw key. Both drawers now surface the canonical `commissions.validation.value` → **"Please enter a value"** message, matching the create flow.
- Fixed-type commissions are validated per store currency, same as create.
- Extracted the shared `optionalAmount` preprocess + value-required refinement into `pages/commissions/common/schema.ts`, removing the duplicated logic across the create and edit schemas.

## Linear
[MER-251](https://linear.app/rigbyjs/issue/MER-251)

## Test plan
- [ ] Admin → Commissions → edit a commission rate, clear the percentage value, Save → shows "Please enter a value"
- [ ] Same for the global commission drawer (percentage and fixed types)
- [ ] Entering a valid value saves successfully
- [ ] `bun run build` (admin package builds + DTS type-check passes)
- [ ] `oxlint` clean on `packages/admin/src/pages/commissions`