### PR TITLE
fix(vendor): correct custom attribute switch copy on product details

### DIFF
--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -557,7 +557,7 @@
         "selectValues": "Select values",
         "tip": "Tip",
         "useForVariants": "Use for variants",
-        "useForVariantsDescription": "If checked, we will create variants with this attribute. You can define them in the next step. If not, the attribute will be used for informational purposes only.",
+        "useForVariantsDescription": "If checked, you will be able to create variants using this attribute. If not, the attribute will be used for informational purposes only.",
         "variantAxisTip": "This attribute will create variants. You can define them in the next step.",
         "editVariantAxisTip": "You will be able to create variants using this attribute.",
         "warning": "Warning",


### PR DESCRIPTION
## Summary
- Update the "use for variants" switch hint on the vendor product details "Add Custom Attributes" flow.
- The old copy referenced defining variants "in the next step", but this drawer has no next step — it closes immediately on save. New copy: _"If checked, you will be able to create variants using this attribute. If not, the attribute will be used for informational purposes only."_
- English (canonical) translation only; non-English locales retain their existing machine translations.

## Linear
[MER-249](https://linear.app/rigbyjs/issue/MER-249)

## Test plan
- [ ] Open the vendor panel → a product → Attributes → Create new; confirm the switch hint reads the new copy and there is no next step.
- [x] `en.json` is valid JSON; i18n key-parity test unaffected (value-only change; the one pre-existing failure `store.validation.nameTooLong` is unrelated and present on `canary`).