### PR TITLE
fix(core): clearer error when a product already has an active update request

### DIFF
--- a/integration-tests/http/product-edit/vendor/product-edit.spec.ts
+++ b/integration-tests/http/product-edit/vendor/product-edit.spec.ts
@@ -187,6 +187,9 @@ medusaIntegrationTestRunner({
             .catch((e) => e.response)
 
           expect(res.status).toBeGreaterThanOrEqual(400)
+          expect(res.data.message).toBe(
+            "There is already an active update request for this product. Only one request can be active at a time.",
+          )
         })
       })
 

--- a/packages/core/src/workflows/product-edit/steps/validate-no-pending-product-change.ts
+++ b/packages/core/src/workflows/product-edit/steps/validate-no-pending-product-change.ts
@@ -48,7 +48,7 @@ export const validateNoPendingProductChangeStep = createStep(
     if (conflicts.size) {
       throw new MedusaError(
         MedusaError.Types.NOT_ALLOWED,
-        `Product(s) [${[...conflicts].join(", ")}] already have a pending product change.`,
+        `There is already an active update request for this product. Only one request can be active at a time.`,
       )
     }
 


### PR DESCRIPTION
## Summary
- Replace the internal-sounding `Product(s) [...] already have a pending product change.` error with the user-facing copy: _"There is already an active update request for this product. Only one request can be active at a time."_ — this is what the vendor panel surfaces as a toast.
- Strengthen the existing "rejects a second pending edit" integration test to assert the new message.

## Linear
[MER-250](https://linear.app/rigbyjs/issue/MER-250)

## Test plan
- [ ] `bun run build` (✅ `@mercurjs/core` builds)
- [ ] `bun run test:integration:http -- product-edit/vendor/product-edit`
- [ ] In the vendor panel, create an update request for a product, then attempt a second one → toast shows the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)