### PR TITLE
fix(vendor,admin): refine product attributes section icons and labels

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -553,7 +553,8 @@
       }
     },
     "attributes": "Attributes",
-    "attributeVariantsDescription": "Attributes used for variations",
+    "attributeVariations": "Variations",
+    "attributeVariantsDescription": "Attributes used for variants",
     "attributeProductInformation": "Product Information",
     "attributeProductInformationDescription": "Attributes used for informational purposes",
     "attributeRequiredByMarketplace": "This attribute is required by the Marketplace",

--- a/packages/admin/src/pages/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
@@ -1,5 +1,4 @@
 import {
-  ListBullet,
   Plus,
   Trash,
   Swatch,
@@ -220,12 +219,12 @@ export const ProductAttributeSection = ({
                 {
                   label: t("products.create.attributes.addExisting"),
                   to: "attributes/add",
-                  icon: <ListBullet />,
+                  icon: <Plus />,
                 },
                 {
                   label: t("products.create.attributes.createNew"),
                   to: "attributes/create",
-                  icon: <Plus />,
+                  icon: <PencilSquare />,
                 },
               ],
             },
@@ -236,7 +235,7 @@ export const ProductAttributeSection = ({
       {variantAttributes.length > 0 && (
         <AttributeGroup
           icon={<Swatch />}
-          title={t("products.create.tabs.variants")}
+          title={t("products.attributeVariations")}
           description={t("products.attributeVariantsDescription")}
           attributes={variantAttributes}
           productId={product.id}

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -2566,6 +2566,9 @@
         "attributes": {
           "type": "string"
         },
+        "attributeVariations": {
+          "type": "string"
+        },
         "attributeVariantsDescription": {
           "type": "string"
         },
@@ -3711,6 +3714,7 @@
         "deleteWarning",
         "variants",
         "attributes",
+        "attributeVariations",
         "attributeVariantsDescription",
         "attributeProductInformation",
         "attributeProductInformationDescription",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -631,7 +631,8 @@
       }
     },
     "attributes": "Attributes",
-    "attributeVariantsDescription": "Attributes used for variations",
+    "attributeVariations": "Variations",
+    "attributeVariantsDescription": "Attributes used for variants",
     "attributeProductInformation": "Product Information",
     "attributeProductInformationDescription": "Attributes used for informational purposes",
     "attributeRequiredByMarketplace": "This attribute is required by the Marketplace",

--- a/packages/vendor/src/pages/products/[id]/_components/product-attribute-section/product-attribute-section.tsx
+++ b/packages/vendor/src/pages/products/[id]/_components/product-attribute-section/product-attribute-section.tsx
@@ -1,5 +1,4 @@
 import {
-  ListBullet,
   Plus,
   Trash,
   Swatch,
@@ -236,12 +235,12 @@ export const ProductAttributeSection = ({
                 {
                   label: t("products.create.attributes.addExisting"),
                   to: "attributes/add",
-                  icon: <ListBullet />,
+                  icon: <Plus />,
                 },
                 {
                   label: t("products.create.attributes.createNew"),
                   to: "attributes/create",
-                  icon: <Plus />,
+                  icon: <PencilSquare />,
                 },
               ],
             },
@@ -252,7 +251,7 @@ export const ProductAttributeSection = ({
       {variantAttributes.length > 0 && (
         <AttributeGroup
           icon={<Swatch />}
-          title={t("products.create.tabs.variants")}
+          title={t("products.attributeVariations")}
           description={t("products.attributeVariantsDescription")}
           attributes={variantAttributes}
           productId={product.id}


### PR DESCRIPTION
## Summary
- Swap the Attributes-section action-menu icons to match the design: plus for **Add existing**, pencil for **Create new** (vendor + admin product detail).
- Rename the variant attribute group title to **Variations**.
- Update its supporting text to **Attributes used for variants**.

## Linear
[MER-248](https://linear.app/rigbyjs/issue/MER-248)

## Test plan
- [ ] Open a product detail page (vendor and admin) that has variant-axis and informational attributes
- [ ] Confirm the Attributes header menu shows a plus icon for "Add existing" and a pencil icon for "Create new"
- [ ] Confirm the variant group reads "Variations" with subtext "Attributes used for variants"
- [x] `bun run build`