### PR TITLE
fix(admin): use monochrome menu icons for category/collection media roles

### DIFF
--- a/packages/admin/src/pages/categories/common/components/category-image-fields/category-media-input.tsx
+++ b/packages/admin/src/pages/categories/common/components/category-image-fields/category-media-input.tsx
@@ -2,6 +2,8 @@ import {
   EllipsisHorizontal,
   InformationCircleSolid,
   Photo,
+  QueueList,
+  StackPerspective,
   ThumbnailBadge,
   Trash,
   XMark,
@@ -174,7 +176,7 @@ const CategoryMediaItemMenu = ({
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
         <MenuItemWithTooltip
-          icon={<ThumbnailBadge />}
+          icon={<StackPerspective />}
           label={
             item.is_thumbnail
               ? t("categories.media.actions.removeThumbnail")
@@ -184,7 +186,7 @@ const CategoryMediaItemMenu = ({
           onClick={onToggleThumbnail}
         />
         <MenuItemWithTooltip
-          icon={<ListBadge />}
+          icon={<QueueList />}
           label={
             item.is_banner
               ? t("categories.media.actions.removeBanner")

--- a/packages/admin/src/pages/collections/common/components/collection-image-fields/collection-media-input.tsx
+++ b/packages/admin/src/pages/collections/common/components/collection-image-fields/collection-media-input.tsx
@@ -2,6 +2,8 @@ import {
   EllipsisHorizontal,
   InformationCircleSolid,
   Photo,
+  QueueList,
+  StackPerspective,
   ThumbnailBadge,
   Trash,
   XMark,
@@ -174,7 +176,7 @@ const CollectionMediaItemMenu = ({
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
         <MenuItemWithTooltip
-          icon={<ThumbnailBadge />}
+          icon={<StackPerspective />}
           label={
             item.is_thumbnail
               ? t("collections.media.actions.removeThumbnail")
@@ -184,7 +186,7 @@ const CollectionMediaItemMenu = ({
           onClick={onToggleThumbnail}
         />
         <MenuItemWithTooltip
-          icon={<ListBadge />}
+          icon={<QueueList />}
           label={
             item.is_banner
               ? t("collections.media.actions.removeBanner")


### PR DESCRIPTION
## Summary
- Swap the colored `ThumbnailBadge`/`ListBadge` for the monochrome `StackPerspective` (thumbnail) and `QueueList` (banner) icons in the category & collection **media upload dropdown menu**, matching the design.
- The colored badges remain on the media rows as state indicators (per design), so only the menu action icons change.

This is the remaining follow-up on MER-233 (point 3 — "Incorrect icons … not blue"). Points 2, 4 and 5 already shipped via #1091; point 1 (radio buttons) was decided as won't-do — the single-select combobox keeps the default control.

## Linear
[MER-233](https://linear.app/rigbyjs/issue/MER-233)

## Test plan
- [ ] Admin → Categories → Create category → upload an image → open the row `…` menu: thumbnail/banner icons render monochrome (grey), trash unchanged.
- [ ] Same check on Collections → Create collection.
- [ ] Row badges (after marking thumbnail/banner) stay as the colored badges.
- [x] `bun run build`