### PR TITLE
fix(admin): validate title and scope resources on commission rule edit

### DIFF
--- a/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
@@ -28,7 +28,9 @@ import {
 
 const EditCommissionRuleSchema = zod.object({
   status: zod.enum(["active", "inactive"]),
-  name: zod.string().min(1),
+  name: zod
+    .string()
+    .min(1, { message: i18n.t("commissions.validation.titleRequired") }),
   code: zod
     .string()
     .min(1, { message: i18n.t("commissions.validation.codeRequired") }),
@@ -42,6 +44,30 @@ const EditCommissionRuleSchema = zod.object({
   stores: zod.array(zod.string()),
   productTypes: zod.array(zod.string()),
   categories: zod.array(zod.string()),
+}).superRefine((data, ctx) => {
+  const dimensions = SCOPE_TYPE_DIMENSIONS[data.scopeType];
+
+  if (dimensions.includes("seller") && data.stores.length === 0) {
+    ctx.addIssue({
+      code: zod.ZodIssueCode.custom,
+      path: ["stores"],
+      message: i18n.t("commissions.validation.storesRequired"),
+    });
+  }
+  if (dimensions.includes("product_type") && data.productTypes.length === 0) {
+    ctx.addIssue({
+      code: zod.ZodIssueCode.custom,
+      path: ["productTypes"],
+      message: i18n.t("commissions.validation.productTypesRequired"),
+    });
+  }
+  if (dimensions.includes("product_category") && data.categories.length === 0) {
+    ctx.addIssue({
+      code: zod.ZodIssueCode.custom,
+      path: ["categories"],
+      message: i18n.t("commissions.validation.categoriesRequired"),
+    });
+  }
 });
 
 type EditCommissionRuleSchemaType = zod.infer<typeof EditCommissionRuleSchema>;


### PR DESCRIPTION
## Summary
- Show **"Please enter a title"** when the rule title is empty in the commission rule edit drawer (was a generic message).
- Require at least one store / product type / category for the selected scope, so a scoped rule can no longer be saved with all its resources cleared.

These align the edit drawer with the validation already present in the create flow. The value-per-type validation called out in the same review was addressed separately by #1102.

## Linear
[MER-228](https://linear.app/rigbyjs/issue/MER-228)

## Test plan
- [ ] Admin → Settings → Commissions → edit a rule → clear the title → Save is blocked with "Please enter a title".
- [ ] Edit a store/type/category-scoped rule → remove all stores (or types/categories) → Save is blocked with the "Please select at least one ..." message.
- [x] `packages/admin` build incl. DTS type-check