### PR TITLE
fix(admin): default category add-products sort to Title

### DIFF
--- a/packages/admin/src/pages/categories/category-products/components/edit-category-products-form/edit-category-products-form.tsx
+++ b/packages/admin/src/pages/categories/category-products/components/edit-category-products-form/edit-category-products-form.tsx
@@ -163,6 +163,7 @@ export const EditCategoryProductsForm = ({
               { key: "created_at", label: t("fields.createdAt") },
               { key: "updated_at", label: t("fields.updatedAt") },
             ]}
+            defaultOrder={searchParams.order}
             prefix={PREFIX}
             isLoading={isPending}
             layout="fill"


### PR DESCRIPTION
## What

The "Add products" modal on the category **Products** section never passed `defaultOrder` to its data table. As a result the sort menu rendered with **no field selected** (only a direction highlighted), even though the API was silently defaulting to `-title`.

This addresses point **4** of [MER-235](https://linear.app/rigbyjs/issue/MER-235/categories-admin-panel-add-products-to-category) — "Missing default filtering by Title" — which was reported as **Not Fixed** after [#1086](https://github.com/mercurjs/mercur/pull/1086).

## Change

Pass `defaultOrder={searchParams.order}` to `_DataTable`, matching the pattern already used by the main product list (`product-list-table.tsx`). `useProductTableQuery` already defaults `order` to `-title`, so the sort menu now reflects **Title** as the selected default field and the displayed direction matches the actual API ordering.

```diff
               { key: "updated_at", label: t("fields.updatedAt") },
             ]}
+            defaultOrder={searchParams.order}
             prefix={PREFIX}
```

## Testing

UI-only default prop pass-through; no logic to unit-test. Verified the touched file type-checks (remaining `tsc` errors are pre-existing on canary and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)