### PR TITLE
fix(vendor): correct organization fields and media loading in product update requests

### DIFF
--- a/packages/core/src/api/vendor/products/query-config.ts
+++ b/packages/core/src/api/vendor/products/query-config.ts
@@ -22,6 +22,9 @@ export const vendorProductFields = [
   "created_at",
   "updated_at",
   "metadata",
+  "images.id",
+  "images.url",
+  "images.rank",
   // Medusa 2.16's remote joiner rejects bare `*relation` wildcards in the
   // query-config defaults with "Cannot resolve alias path \"\"", so each
   // relation is spelled out.

--- a/packages/dashboard-shared/src/components/common/product-change-panel/product-change-panel.tsx
+++ b/packages/dashboard-shared/src/components/common/product-change-panel/product-change-panel.tsx
@@ -601,9 +601,7 @@ export const ProductChangePanel = ({
 
   const fieldLabel = (field: string): string => {
     if (field === "categories") {
-      return t("fields.secondary_categories", {
-        defaultValue: "Secondary categories",
-      });
+      return t("fields.category", { defaultValue: "Category" });
     }
     return t(`fields.${field}`, { defaultValue: humanizeFieldName(field) });
   };

--- a/packages/dashboard-shared/src/components/common/product-change-panel/product-change-panel.tsx
+++ b/packages/dashboard-shared/src/components/common/product-change-panel/product-change-panel.tsx
@@ -601,7 +601,7 @@ export const ProductChangePanel = ({
 
   const fieldLabel = (field: string): string => {
     if (field === "categories") {
-      return t("fields.category", { defaultValue: "Category" });
+      return t("fields.category");
     }
     return t(`fields.${field}`, { defaultValue: humanizeFieldName(field) });
   };

--- a/packages/dashboard-shared/src/lib/product-change-diff.spec.ts
+++ b/packages/dashboard-shared/src/lib/product-change-diff.spec.ts
@@ -135,4 +135,46 @@ describe("buildProductChangeView", () => {
     expect(view.attributes).toHaveLength(0)
     expect(view.deleteRequested).toBe(false)
   })
+
+  test("orders organization fields as category, collection, tags, type", () => {
+    const update = (field: string) =>
+      act(ProductChangeActionType.UPDATE, {
+        field,
+        previous_value: null,
+        value: "x",
+      })
+    const view = buildProductChangeView([
+      update("type_id"),
+      update("tags"),
+      update("collection_id"),
+      update("categories"),
+    ])
+    expect(view.productUpdated.map((d) => d.field)).toEqual([
+      "categories",
+      "collection_id",
+      "tags",
+      "type_id",
+    ])
+  })
+
+  test("keeps non-organization fields ahead of the organization block in order", () => {
+    const update = (field: string) =>
+      act(ProductChangeActionType.UPDATE, {
+        field,
+        previous_value: "old",
+        value: "new",
+      })
+    const view = buildProductChangeView([
+      update("type_id"),
+      update("title"),
+      update("categories"),
+      update("subtitle"),
+    ])
+    expect(view.productUpdated.map((d) => d.field)).toEqual([
+      "title",
+      "subtitle",
+      "categories",
+      "type_id",
+    ])
+  })
 })

--- a/packages/dashboard-shared/src/lib/product-change-diff.ts
+++ b/packages/dashboard-shared/src/lib/product-change-diff.ts
@@ -61,6 +61,27 @@ export const REFERENCE_FIELDS: ReferenceField[] = [
   "tags",
 ]
 
+// Organization fields must render in a fixed order in the request panel
+// (Category, Collection, Tags, Type) regardless of the order the staged actions
+// were created in. Fields not listed here keep their original position and sort
+// before the organization block.
+const PRODUCT_FIELD_ORDER: Record<string, number> = {
+  categories: 1,
+  collection_id: 2,
+  tags: 3,
+  type_id: 4,
+}
+
+const sortProductFieldDiffs = (diffs: FieldDiff[]): FieldDiff[] =>
+  diffs
+    .map((diff, index) => ({ diff, index }))
+    .sort((a, b) => {
+      const weightA = PRODUCT_FIELD_ORDER[a.diff.field] ?? 0
+      const weightB = PRODUCT_FIELD_ORDER[b.diff.field] ?? 0
+      return weightA !== weightB ? weightA - weightB : a.index - b.index
+    })
+    .map(({ diff }) => diff)
+
 export const isReferenceField = (field: string): field is ReferenceField =>
   (REFERENCE_FIELDS as string[]).includes(field)
 
@@ -377,7 +398,7 @@ export const buildProductChangeView = (
   )
 
   return {
-    productUpdated,
+    productUpdated: sortProductFieldDiffs(productUpdated),
     productMedia,
     attributes,
     variantsAdded,

--- a/packages/dashboard-shared/src/lib/product-change-diff.ts
+++ b/packages/dashboard-shared/src/lib/product-change-diff.ts
@@ -61,10 +61,6 @@ export const REFERENCE_FIELDS: ReferenceField[] = [
   "tags",
 ]
 
-// Organization fields must render in a fixed order in the request panel
-// (Category, Collection, Tags, Type) regardless of the order the staged actions
-// were created in. Fields not listed here keep their original position and sort
-// before the organization block.
 const PRODUCT_FIELD_ORDER: Record<string, number> = {
   categories: 1,
   collection_id: 2,

--- a/packages/vendor/src/pages/products/[id]/media/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/media/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 import { RouteFocusModal } from "@components/modals"
 import { useProduct } from "@hooks/api/products"
-import { PRODUCT_DETAIL_QUERY } from "../../common/constants"
+import { PRODUCT_MEDIA_QUERY } from "../../common/constants"
 import { ProductMediaView } from "./product-media-view"
 
 export const Component = () => {
@@ -12,7 +12,7 @@ export const Component = () => {
 
   const { product, isLoading, isError, error } = useProduct(
     id!,
-    PRODUCT_DETAIL_QUERY,
+    PRODUCT_MEDIA_QUERY,
   )
 
   const ready = !isLoading && product

--- a/packages/vendor/src/pages/products/[id]/media/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/media/index.tsx
@@ -3,13 +3,17 @@ import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 import { RouteFocusModal } from "@components/modals"
 import { useProduct } from "@hooks/api/products"
+import { PRODUCT_DETAIL_QUERY } from "../../common/constants"
 import { ProductMediaView } from "./product-media-view"
 
 export const Component = () => {
   const { t } = useTranslation()
   const { id } = useParams()
 
-  const { product, isLoading, isError, error } = useProduct(id!)
+  const { product, isLoading, isError, error } = useProduct(
+    id!,
+    PRODUCT_DETAIL_QUERY,
+  )
 
   const ready = !isLoading && product
 

--- a/packages/vendor/src/pages/products/[id]/media/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/media/index.tsx
@@ -3,17 +3,13 @@ import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 import { RouteFocusModal } from "@components/modals"
 import { useProduct } from "@hooks/api/products"
-import { PRODUCT_MEDIA_QUERY } from "../../common/constants"
 import { ProductMediaView } from "./product-media-view"
 
 export const Component = () => {
   const { t } = useTranslation()
   const { id } = useParams()
 
-  const { product, isLoading, isError, error } = useProduct(
-    id!,
-    PRODUCT_MEDIA_QUERY,
-  )
+  const { product, isLoading, isError, error } = useProduct(id!)
 
   const ready = !isLoading && product
 

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -20,3 +20,15 @@ export const PRODUCT_DETAIL_FIELDS = [
 
 export const PRODUCT_DETAIL_QUERY = { fields: PRODUCT_DETAIL_FIELDS } as const
 
+// The product media gallery and editor only need the image relation on top of
+// the route's base fields. `images` is added with `+` because the query-config
+// server defaults omit it; a bare `*images` wildcard returns nothing on the 2.16
+// joiner, so the subfields are spelled out.
+export const PRODUCT_MEDIA_FIELDS = [
+  "+images.id",
+  "+images.url",
+  "+images.rank",
+].join(",")
+
+export const PRODUCT_MEDIA_QUERY = { fields: PRODUCT_MEDIA_FIELDS } as const
+

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -1,14 +1,10 @@
 export const PRODUCT_VARIANT_IDS_KEY = "product_variant_ids"
 
-// `-variants`: the 2.16 options-preview joiner crashes on product →
-// variants/options populate; variants are read from /vendor/products/:id/variants.
-// `images` is spelled out (not `*images`): the query-config server defaults omit
-// it, and the 2.16 joiner returns nothing for a bare `*relation` wildcard.
 export const PRODUCT_DETAIL_FIELDS = [
   "-variants",
-  "images.id",
-  "images.url",
-  "images.rank",
+  "+images.id",
+  "+images.url",
+  "+images.rank",
   "*categories",
   "+additional_data",
   "*scoped_attributes",

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -20,11 +20,3 @@ export const PRODUCT_DETAIL_FIELDS = [
 
 export const PRODUCT_DETAIL_QUERY = { fields: PRODUCT_DETAIL_FIELDS } as const
 
-export const PRODUCT_MEDIA_FIELDS = [
-  "+images.id",
-  "+images.url",
-  "+images.rank",
-].join(",")
-
-export const PRODUCT_MEDIA_QUERY = { fields: PRODUCT_MEDIA_FIELDS } as const
-

--- a/packages/vendor/src/pages/products/common/constants.ts
+++ b/packages/vendor/src/pages/products/common/constants.ts
@@ -20,10 +20,6 @@ export const PRODUCT_DETAIL_FIELDS = [
 
 export const PRODUCT_DETAIL_QUERY = { fields: PRODUCT_DETAIL_FIELDS } as const
 
-// The product media gallery and editor only need the image relation on top of
-// the route's base fields. `images` is added with `+` because the query-config
-// server defaults omit it; a bare `*images` wildcard returns nothing on the 2.16
-// joiner, so the subfields are spelled out.
 export const PRODUCT_MEDIA_FIELDS = [
   "+images.id",
   "+images.url",


### PR DESCRIPTION
## Summary
- Label the staged `categories` change as **Category** instead of "Secondary categories", and order the organization fields as **Category, Collection, Tags, Type** in the product update request panel.
- Load the product's images in the vendor media route. The route previously fetched the product without image fields, so the media gallery/edit form showed only a single thumbnail-derived entry. Submitting that then staged spurious *removed* and *added* images in the resulting request. With images loaded, the edit form shows every image and the request diff is accurate.

## Linear
[MER-247](https://linear.app/rigbyjs/issue/MER-247)

## Changes
- `packages/dashboard-shared/src/components/common/product-change-panel/product-change-panel.tsx` — `categories` field now labelled "Category".
- `packages/dashboard-shared/src/lib/product-change-diff.ts` — sort product field diffs so organization fields render Category → Collection → Tags → Type.
- `packages/vendor/src/pages/products/[id]/media/index.tsx` — fetch the product with `PRODUCT_DETAIL_QUERY` so `product.images` is populated for the gallery and edit form.

## Test plan
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bunx vitest run src/lib/product-change-diff.spec.ts` (dashboard-shared) — added ordering tests
- [ ] Manually: open a vendor product with multiple images → edit media shows all images; change category/collection/tags/type → request panel labels "Category" and orders Category, Collection, Tags, Type; media request shows only the images actually added/removed.