### PR TITLE
fix(admin): add variants search to create-product step 4

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -490,7 +490,6 @@
           "placeholder": "Small, Medium, Large"
         },
         "productVariants": {
-          "searchPlaceholder": "Search",
           "label": "Product variants",
           "hint": "This ranking will affect the variants' display order.",
           "alert": "Add values to your variant attributes to generate variants.",

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -490,6 +490,7 @@
           "placeholder": "Small, Medium, Large"
         },
         "productVariants": {
+          "searchPlaceholder": "Search",
           "label": "Product variants",
           "hint": "This ranking will affect the variants' display order.",
           "alert": "Add values to your variant attributes to generate variants.",

--- a/packages/admin/src/pages/products/product-create/components/product-create-variants-form/product-create-variants-form.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-variants-form/product-create-variants-form.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { Input } from "@medusajs/ui";
+import { useMemo, useState } from "react";
 import { useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
@@ -13,8 +14,11 @@ import { ProductCreateVariantSchema } from "../../constants";
 import { ProductCreateSchemaType } from "../../types";
 
 const Root = () => {
+  const { t } = useTranslation();
   const form = useTabbedForm<ProductCreateSchemaType>();
   const { setCloseOnEscape } = useRouteModal();
+
+  const [search, setSearch] = useState("");
 
   const variants = useWatch({
     control: form.control,
@@ -55,6 +59,37 @@ const Root = () => {
     return ret;
   }, [variants]);
 
+  const filteredVariantData = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) {
+      return variantData;
+    }
+
+    return variantData.filter((variant) => {
+      const haystack = [
+        variant.title,
+        variant.sku,
+        ...Object.values(variant.options ?? {}),
+      ];
+
+      return haystack.some((value) => value?.toLowerCase().includes(query));
+    });
+  }, [variantData, search]);
+
+  const headerContent = (
+    <Input
+      type="search"
+      size="small"
+      autoComplete="off"
+      value={search}
+      onChange={(event) => setSearch(event.target.value)}
+      placeholder={t(
+        "products.create.variants.productVariants.searchPlaceholder",
+      )}
+      data-testid="product-create-variants-search-input"
+    />
+  );
+
   return (
     <div
       className="flex size-full flex-col divide-y overflow-hidden"
@@ -66,9 +101,10 @@ const Root = () => {
       >
         <DataGrid
           columns={columns}
-          data={variantData}
+          data={filteredVariantData}
           state={form}
           onEditingChange={(editing) => setCloseOnEscape(!editing)}
+          headerContent={headerContent}
         />
       </div>
     </div>

--- a/packages/admin/src/pages/products/product-create/components/product-create-variants-form/product-create-variants-form.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-variants-form/product-create-variants-form.tsx
@@ -83,9 +83,7 @@ const Root = () => {
       autoComplete="off"
       value={search}
       onChange={(event) => setSearch(event.target.value)}
-      placeholder={t(
-        "products.create.variants.productVariants.searchPlaceholder",
-      )}
+      placeholder={t("general.search")}
       data-testid="product-create-variants-search-input"
     />
   );


### PR DESCRIPTION
## Summary
- Adds the header search input to Step 4 (Variants) of the **admin** create-product wizard, matching the vendor panel. It filters the variants table by title, SKU, and option values.
- The "cannot scroll" and "cannot clear search" bugs (the second part of this ticket, shared with MER-245) were already fixed for admin in #1099 — this PR completes the missing-search part.

## Linear
[MER-255](https://linear.app/rigbyjs/issue/MER-255)

## Test plan
- [ ] Admin panel → Products → Create → reach Step 4 (Variants) with enough variants to overflow; type in the search box and confirm the table filters by title/SKU/options.
- [ ] Delete the search text with Backspace/Delete — text clears and grid cells are unaffected.
- [ ] `bun run lint`
- [ ] `bun run build`