### PR TITLE
fix(admin): show "Please enter a title" validation on product create

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -1714,12 +1714,16 @@
                 },
                 "uniqueSku": {
                   "type": "string"
+                },
+                "requiredTitle": {
+                  "type": "string"
                 }
               },
               "required": [
                 "variants",
                 "options",
-                "uniqueSku"
+                "uniqueSku",
+                "requiredTitle"
               ],
               "additionalProperties": false
             },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -445,7 +445,8 @@
         "options": "Please create at least one option.",
         "uniqueSku": "SKU must be unique.",
         "requiredAttribute": "This attribute is required.",
-        "requiredStore": "Please select at least one store."
+        "requiredStore": "Please select at least one store.",
+        "requiredTitle": "Please enter a title"
       },
       "inventory": {
         "heading": "Inventory kits",

--- a/packages/admin/src/pages/products/product-create/components/product-create-details-form/components/product-create-details-general-section/product-create-general-section.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-details-form/components/product-create-details-general-section/product-create-general-section.tsx
@@ -24,6 +24,7 @@ export const ProductCreateGeneralSection = () => {
                   <Form.Control data-testid="product-create-general-section-title-control">
                     <Input {...field} placeholder={t("products.fields.title.placeholder")} data-testid="product-create-general-section-title-input" />
                   </Form.Control>
+                  <Form.ErrorMessage data-testid="product-create-general-section-title-error" />
                 </Form.Item>
               )
             }}

--- a/packages/admin/src/pages/products/product-create/constants.ts
+++ b/packages/admin/src/pages/products/product-create/constants.ts
@@ -36,7 +36,9 @@ export type ProductCreateVariantSchema = z.infer<
 
 export const ProductCreateSchema = z
   .object({
-    title: z.string().min(1),
+    title: z.string().min(1, {
+      message: i18n.t("products.create.errors.requiredTitle"),
+    }),
     subtitle: z.string().optional(),
     handle: z.string().optional(),
     description: z.string().optional(),


### PR DESCRIPTION
## Summary
- The Create Product (Step 1) title field validated `min(1)` but never rendered an error, so submitting with an empty title failed silently with no feedback.
- Added a translated `products.create.errors.requiredTitle` message ("Please enter a title") to the create-product schema.
- Rendered `Form.ErrorMessage` on the title field so the validation message is shown, matching the established pattern (e.g. customer-create form).

## Linear
[MER-252](https://linear.app/rigbyjs/issue/MER-252)

## Test plan
- [ ] Open Admin → Products → Create, leave Title empty, click Continue → "Please enter a title" appears under the field.
- [ ] Enter a title → error clears and the step advances.
- [x] `bun run lint`
- [x] `bun run build` (admin package)