### PR TITLE
fix(admin): refine product create step 2 spacing and validation copy

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -1715,7 +1715,16 @@
                 "uniqueSku": {
                   "type": "string"
                 },
+                "requiredAttribute": {
+                  "type": "string"
+                },
+                "requiredStore": {
+                  "type": "string"
+                },
                 "requiredTitle": {
+                  "type": "string"
+                },
+                "requiredCategory": {
                   "type": "string"
                 }
               },
@@ -1723,7 +1732,10 @@
                 "variants",
                 "options",
                 "uniqueSku",
-                "requiredTitle"
+                "requiredAttribute",
+                "requiredStore",
+                "requiredTitle",
+                "requiredCategory"
               ],
               "additionalProperties": false
             },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -445,8 +445,9 @@
         "options": "Please create at least one option.",
         "uniqueSku": "SKU must be unique.",
         "requiredAttribute": "This attribute is required.",
-        "requiredStore": "Please select at least one store.",
-        "requiredTitle": "Please enter a title"
+        "requiredStore": "Please select at least one store",
+        "requiredTitle": "Please enter a title",
+        "requiredCategory": "Please select a category"
       },
       "inventory": {
         "heading": "Inventory kits",

--- a/packages/admin/src/pages/products/product-create/components/product-create-organize-form/components/product-create-organize-section/product-create-details-organize-section.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-organize-form/components/product-create-organize-section/product-create-details-organize-section.tsx
@@ -159,22 +159,24 @@ export const ProductCreateOrganizationSection = () => {
           }}
         />
       </div>
-      <SwitchBox
-        control={form.control}
-        name="discountable"
-        label={t("products.fields.discountable.label")}
-        description={t("products.fields.discountable.hint")}
-        optional
-        data-testid="product-create-organize-section-discountable-switch"
-      />
-      <SwitchBox
-        control={form.control}
-        name="globally_available"
-        label={t("products.fields.globally_available.label")}
-        description={t("products.fields.globally_available.hint")}
-        optional
-        data-testid="product-create-organize-section-globally-available-switch"
-      />
+      <div className="flex flex-col gap-y-4">
+        <SwitchBox
+          control={form.control}
+          name="discountable"
+          label={t("products.fields.discountable.label")}
+          description={t("products.fields.discountable.hint")}
+          optional
+          data-testid="product-create-organize-section-discountable-switch"
+        />
+        <SwitchBox
+          control={form.control}
+          name="globally_available"
+          label={t("products.fields.globally_available.label")}
+          description={t("products.fields.globally_available.hint")}
+          optional
+          data-testid="product-create-organize-section-globally-available-switch"
+        />
+      </div>
       {!isGloballyAvailable && (
         <Form.Field
           control={form.control}

--- a/packages/admin/src/pages/products/product-create/constants.ts
+++ b/packages/admin/src/pages/products/product-create/constants.ts
@@ -46,7 +46,7 @@ export const ProductCreateSchema = z
     globally_available: z.boolean(),
     type_id: z.string().optional(),
     collection_id: z.string().optional(),
-    category_id: z.string().min(1),
+    category_id: z.string().min(1, i18n.t("products.create.errors.requiredCategory")),
     seller_ids: z.array(z.string()).optional(),
     tags: z.array(z.string()).optional(),
     origin_country: z.string().optional(),


### PR DESCRIPTION
## Summary
- Wrap the **Discountable** and **Globally available** switches in a `gap-y-4` container so the spacing between them is 16px (was 32px from the parent `gap-y-8`).
- Add a clear required message for the category field: **"Please select a category"** (new `products.create.errors.requiredCategory` key) instead of Zod's default min-length error.
- Drop the trailing period from the store required message: **"Please select at least one store"**.

## Linear
[MER-253](https://linear.app/rigbyjs/issue/MER-253)

## Test plan
- [ ] Open Admin → Products → Create → Step 2 (Organize). Confirm 16px gap between the two switches.
- [ ] Continue without a category → "Please select a category".
- [ ] Uncheck Globally available, continue without a store → "Please select at least one store" (no trailing period).
- [x] `bun run lint`

## Notes
The `$schema.json` `products.create.errors` block was already out of sync with `en.json` (missing `requiredAttribute`/`requiredStore`); this PR brings the block fully in sync and adds the new `requiredCategory` key. Full `bun run build` could not run in the isolated worktree (missing `tsup`/node_modules bin links); admin compiles cleanly aside from that environment limitation, and CI will validate the full build.