### PR TITLE
fix(admin,vendor): polish product create step 3 attribute copy and tip

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -1714,12 +1714,24 @@
                 },
                 "uniqueSku": {
                   "type": "string"
+                },
+                "requiredAttributeSelect": {
+                  "type": "string"
+                },
+                "requiredAttributeEnter": {
+                  "type": "string"
+                },
+                "requiredAttributeMultiSelect": {
+                  "type": "string"
                 }
               },
               "required": [
                 "variants",
                 "options",
-                "uniqueSku"
+                "uniqueSku",
+                "requiredAttributeSelect",
+                "requiredAttributeEnter",
+                "requiredAttributeMultiSelect"
               ],
               "additionalProperties": false
             },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -445,6 +445,9 @@
         "options": "Please create at least one option.",
         "uniqueSku": "SKU must be unique.",
         "requiredAttribute": "This attribute is required.",
+        "requiredAttributeSelect": "This attribute is required by the marketplace. Please select value.",
+        "requiredAttributeEnter": "This attribute is required by the marketplace. Please enter value.",
+        "requiredAttributeMultiSelect": "This attribute is required by the marketplace. Please select at least one value.",
         "requiredStore": "Please select at least one store."
       },
       "inventory": {
@@ -455,7 +458,7 @@
       },
       "attributes": {
         "header": "Attributes",
-        "description": "Manage attributes and variations for your product, e.g. color, size, brand etc.\nSelect from attributes defined by the Marketplace or create your own.",
+        "description": "Manage attributes and variations for your product, e.g. color, size, brand etc.\nSelect from attributes defined by the marketplace or create your own.",
         "addExisting": "Add existing",
         "createNew": "Create new",
         "title": "Title",
@@ -466,7 +469,7 @@
         "enterValuePlaceholder": "Enter value",
         "selectValuePlaceholder": "Select value",
         "requiredAttributes": "Required attributes",
-        "requiredAttributesHint": "These attributes are required by the Marketplace. Select them before proceeding.",
+        "requiredAttributesHint": "These attributes are required by the marketplace. Select them before proceeding.",
         "useForVariants": "Use for Variations",
         "useForVariantsDescription": "If checked, you will be able to create variants using this attribute. If not, the attribute will be used for informational purposes only.",
         "tip": "Tip",

--- a/packages/admin/src/pages/products/product-create/components/product-create-attributes-form/product-create-attributes-form.tsx
+++ b/packages/admin/src/pages/products/product-create/components/product-create-attributes-form/product-create-attributes-form.tsx
@@ -1,6 +1,7 @@
 import { XMarkMini } from "@medusajs/icons"
 import {
   Button,
+  clx,
   Heading,
   Hint,
   IconButton,
@@ -640,7 +641,10 @@ const VariantAxisTip = ({ className }: { className?: string }) => {
   const { t } = useTranslation()
 
   return (
-    <InlineTip className={className} label={t("products.create.attributes.tip")}>
+    <InlineTip
+      className={clx("border-none", className)}
+      label={t("products.create.attributes.tip")}
+    >
       {t("products.create.attributes.variantAxisTip")}
     </InlineTip>
   )

--- a/packages/admin/src/pages/products/product-create/constants.ts
+++ b/packages/admin/src/pages/products/product-create/constants.ts
@@ -89,10 +89,19 @@ export const ProductCreateSchema = z
         (Array.isArray(attr.values) && attr.values.length === 0)
 
       if (isEmpty) {
+        let messageKey = "products.create.errors.requiredAttribute"
+        if (attr.type === "single_select" || attr.type === "toggle") {
+          messageKey = "products.create.errors.requiredAttributeSelect"
+        } else if (attr.type === "multi_select") {
+          messageKey = "products.create.errors.requiredAttributeMultiSelect"
+        } else if (attr.type === "text" || attr.type === "unit") {
+          messageKey = "products.create.errors.requiredAttributeEnter"
+        }
+
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: [`attributes.${index}.values`],
-          message: i18n.t("products.create.errors.requiredAttribute"),
+          message: i18n.t(messageKey),
         })
       }
     })

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -540,7 +540,7 @@
       "successToast": "Product {{title}} was successfully created.",
       "requestSuccessToast": "Product was successfully requested. You can now create offers for this product. Once the product is approved by the admin, your offers will appear on the storefront. Only offers with stock levels and prices set will be visible.",
       "attributes": {
-        "description": "Manage attributes and variations for your product, e.g. color, size, brand etc. Select from attributes defined by the Marketplace or create your own.",
+        "description": "Manage attributes and variations for your product, e.g. color, size, brand etc. Select from attributes defined by the marketplace or create your own.",
         "requiredHeading": "Required Attributes",
         "requiredDescription": "These attributes are required for products in this category.",
         "buttonLabel": "Attribute",
@@ -553,7 +553,7 @@
         "addExisting": "Add existing",
         "createNew": "Create new",
         "requiredAttributes": "Required attributes",
-        "requiredAttributesHint": "These attributes are required by the Marketplace. Select them before proceeding.",
+        "requiredAttributesHint": "These attributes are required by the marketplace. Select them before proceeding.",
         "selectValues": "Select values",
         "tip": "Tip",
         "useForVariants": "Use for variants",

--- a/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
+++ b/packages/vendor/src/pages/products/create/components/product-create-attributes-form/product-create-attributes-form.tsx
@@ -1,6 +1,7 @@
 import { XMarkMini } from "@medusajs/icons"
 import {
   Button,
+  clx,
   Heading,
   Hint,
   IconButton,
@@ -644,7 +645,10 @@ const VariantAxisTip = ({ className }: { className?: string }) => {
   const { t } = useTranslation()
 
   return (
-    <InlineTip className={className} label={t("products.create.attributes.tip")}>
+    <InlineTip
+      className={clx("border-none", className)}
+      label={t("products.create.attributes.tip")}
+    >
       {t("products.create.attributes.variantAxisTip")}
     </InlineTip>
   )


### PR DESCRIPTION
## Summary
Follow-up QA polish for the Create Product → Step 3 (Attributes) screen, completing the remaining items from MER-254 (items 2–5 were handled earlier in #1098):

- **Lowercase "marketplace"** in the Attributes description and the Required attributes hint (admin + vendor).
- **Type-aware required-attribute validation** in admin, mirroring the existing vendor behaviour: single-select/toggle → "Please select value.", multi-select → "Please select at least one value.", unit/text → "Please enter value.", all prefixed with "This attribute is required by the marketplace."
- **Borderless variant-axis tip** for required attributes (previously only the optional/add-existing tip was borderless).

## Linear
[MER-254](https://linear.app/rigbyjs/issue/MER-254/products-admin-panel-create-product-step-3)

## Test plan
- [ ] Create a product, go to Step 3; confirm both section copies read "marketplace" (lowercase).
- [ ] With a category that has required attributes, submit empty and confirm the validation message matches the attribute type.
- [ ] Confirm the tip under a required variant-axis (multi-select) attribute has no border.
- [x] `bun run build` (admin + vendor, incl. DTS type-check)