### PR TITLE
fix(admin): align product detail organize order, attribute tooltip and name truncation

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -562,7 +562,7 @@
     "attributeVariantsDescription": "Attributes used for variants",
     "attributeProductInformation": "Product Information",
     "attributeProductInformationDescription": "Attributes used for informational purposes",
-    "attributeRequiredByMarketplace": "This attribute is required by the Marketplace",
+    "attributeRequiredByMarketplace": "This attribute is required by the marketplace.",
     "attributeRequiredDeleteDisabledTooltip": "Required attributes cannot be removed.",
     "addAttribute": "Add Attribute",
     "deleteAttributeWarning": "Are you sure you want to delete the attribute \"{{title}}\"? This action cannot be undone.",

--- a/packages/admin/src/pages/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
@@ -16,11 +16,53 @@ import {
   usePrompt,
 } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
+import { useEffect, useRef, useState } from "react";
 import { ActionMenu } from "../../../../../components/common/action-menu";
 import { ProductAttributeDTO, ProductDTO } from "@mercurjs/types";
 import { useRemoveAttributeFromProduct } from "../../../../../hooks/api/products";
 
 type ProductWithAttributes = Pick<ProductDTO, "id" | "attributes">;
+
+const AttributeName = ({ name }: { name: string }) => {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    const checkTruncation = () => {
+      setIsTruncated(el.scrollHeight > el.clientHeight);
+    };
+
+    checkTruncation();
+
+    const observer = new ResizeObserver(checkTruncation);
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, [name]);
+
+  const text = (
+    <Text
+      ref={ref}
+      size="small"
+      weight="plus"
+      leading="compact"
+      className="line-clamp-3 min-w-0"
+    >
+      {name}
+    </Text>
+  );
+
+  if (!isTruncated) {
+    return text;
+  }
+
+  return <Tooltip content={name}>{text}</Tooltip>;
+};
 
 const AttributeActions = ({
   productId,
@@ -135,9 +177,7 @@ const AttributeGroup = ({
               >
                 <div className="grid grid-cols-[1fr_1fr_28px] items-center gap-4 px-4 py-3 bg-ui-bg-component">
                   <div className="flex items-center gap-x-2 text-ui-fg-subtle">
-                    <Text size="small" weight="plus" leading="compact">
-                      {attr.name}
-                    </Text>
+                    <AttributeName name={attr.name} />
                     {attr.description && (
                       <Tooltip content={attr.description}>
                         <span className="text-ui-fg-muted flex items-center">

--- a/packages/admin/src/pages/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
@@ -23,7 +23,7 @@ import { useRemoveAttributeFromProduct } from "../../../../../hooks/api/products
 
 type ProductWithAttributes = Pick<ProductDTO, "id" | "attributes">;
 
-const AttributeName = ({ name }: { name: string }) => {
+const AttributeValue = ({ value }: { value: string }) => {
   const ref = useRef<HTMLParagraphElement>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
@@ -43,17 +43,16 @@ const AttributeName = ({ name }: { name: string }) => {
     observer.observe(el);
 
     return () => observer.disconnect();
-  }, [name]);
+  }, [value]);
 
   const text = (
     <Text
       ref={ref}
       size="small"
-      weight="plus"
       leading="compact"
-      className="line-clamp-3 min-w-0"
+      className="line-clamp-3 min-w-0 text-ui-fg-subtle"
     >
-      {name}
+      {value}
     </Text>
   );
 
@@ -61,7 +60,7 @@ const AttributeName = ({ name }: { name: string }) => {
     return text;
   }
 
-  return <Tooltip content={name}>{text}</Tooltip>;
+  return <Tooltip content={value}>{text}</Tooltip>;
 };
 
 const AttributeActions = ({
@@ -177,7 +176,9 @@ const AttributeGroup = ({
               >
                 <div className="grid grid-cols-[1fr_1fr_28px] items-center gap-4 px-4 py-3 bg-ui-bg-component">
                   <div className="flex items-center gap-x-2 text-ui-fg-subtle">
-                    <AttributeName name={attr.name} />
+                    <Text size="small" weight="plus" leading="compact">
+                      {attr.name}
+                    </Text>
                     {attr.description && (
                       <Tooltip content={attr.description}>
                         <span className="text-ui-fg-muted flex items-center">
@@ -206,19 +207,19 @@ const AttributeGroup = ({
                         </Badge>
                       ))
                     ) : (
-                      <Text
-                        size="small"
-                        leading="compact"
-                        className="text-ui-fg-subtle"
-                      >
-                        {attr.type === "toggle"
-                          ? values
-                              .map((val) =>
-                                val === "true" ? t("general.yes") : t("general.no")
-                              )
-                              .join(", ") || "-"
-                          : values.join(", ") || "-"}
-                      </Text>
+                      <AttributeValue
+                        value={
+                          attr.type === "toggle"
+                            ? values
+                                .map((val) =>
+                                  val === "true"
+                                    ? t("general.yes")
+                                    : t("general.no")
+                                )
+                                .join(", ") || "-"
+                            : values.join(", ") || "-"
+                        }
+                      />
                     )}
                   </div>
 

--- a/packages/admin/src/pages/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
@@ -16,52 +16,11 @@ import {
   usePrompt,
 } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
-import { useEffect, useRef, useState } from "react";
 import { ActionMenu } from "../../../../../components/common/action-menu";
 import { ProductAttributeDTO, ProductDTO } from "@mercurjs/types";
 import { useRemoveAttributeFromProduct } from "../../../../../hooks/api/products";
 
 type ProductWithAttributes = Pick<ProductDTO, "id" | "attributes">;
-
-const AttributeValue = ({ value }: { value: string }) => {
-  const ref = useRef<HTMLParagraphElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) {
-      return;
-    }
-
-    const checkTruncation = () => {
-      setIsTruncated(el.scrollHeight > el.clientHeight);
-    };
-
-    checkTruncation();
-
-    const observer = new ResizeObserver(checkTruncation);
-    observer.observe(el);
-
-    return () => observer.disconnect();
-  }, [value]);
-
-  const text = (
-    <Text
-      ref={ref}
-      size="small"
-      leading="compact"
-      className="line-clamp-3 min-w-0 text-ui-fg-subtle"
-    >
-      {value}
-    </Text>
-  );
-
-  if (!isTruncated) {
-    return text;
-  }
-
-  return <Tooltip content={value}>{text}</Tooltip>;
-};
 
 const AttributeActions = ({
   productId,
@@ -207,19 +166,19 @@ const AttributeGroup = ({
                         </Badge>
                       ))
                     ) : (
-                      <AttributeValue
-                        value={
-                          attr.type === "toggle"
-                            ? values
-                                .map((val) =>
-                                  val === "true"
-                                    ? t("general.yes")
-                                    : t("general.no")
-                                )
-                                .join(", ") || "-"
-                            : values.join(", ") || "-"
-                        }
-                      />
+                      <Text
+                        size="small"
+                        leading="compact"
+                        className="text-ui-fg-subtle"
+                      >
+                        {attr.type === "toggle"
+                          ? values
+                              .map((val) =>
+                                val === "true" ? t("general.yes") : t("general.no")
+                              )
+                              .join(", ") || "-"
+                          : values.join(", ") || "-"}
+                      </Text>
                     )}
                   </div>
 

--- a/packages/admin/src/pages/products/product-detail/components/product-organization-section/product-organization-section.tsx
+++ b/packages/admin/src/pages/products/product-detail/components/product-organization-section/product-organization-section.tsx
@@ -42,31 +42,19 @@ export const ProductOrganizationSection = ({
       </div>
 
       <SectionRow
-        title={t("fields.tags")}
+        title={t("fields.category")}
         value={
-          product.tags?.length
-            ? product.tags.map((tag) => (
+          product.categories?.length
+            ? product.categories.map((pcat) => (
                 <OrganizationTag
-                  key={tag.id}
-                  label={tag.value}
-                  to={`/settings/product-tags/${tag.id}`}
+                  key={pcat.id}
+                  label={pcat.name}
+                  to={`/categories/${pcat.id}`}
                 />
               ))
             : undefined
         }
-        data-testid="product-tags-row"
-      />
-      <SectionRow
-        title={t("fields.type")}
-        value={
-          product.type ? (
-            <OrganizationTag
-              label={product.type.value}
-              to={`/settings/product-types/${product.type_id}`}
-            />
-          ) : undefined
-        }
-        data-testid="product-type-row"
+        data-testid="product-categories-row"
       />
 
       <SectionRow
@@ -83,19 +71,32 @@ export const ProductOrganizationSection = ({
       />
 
       <SectionRow
-        title={t("fields.categories")}
+        title={t("fields.tags")}
         value={
-          product.categories?.length
-            ? product.categories.map((pcat) => (
+          product.tags?.length
+            ? product.tags.map((tag) => (
                 <OrganizationTag
-                  key={pcat.id}
-                  label={pcat.name}
-                  to={`/categories/${pcat.id}`}
+                  key={tag.id}
+                  label={tag.value}
+                  to={`/settings/product-tags/${tag.id}`}
                 />
               ))
             : undefined
         }
-        data-testid="product-categories-row"
+        data-testid="product-tags-row"
+      />
+
+      <SectionRow
+        title={t("fields.type")}
+        value={
+          product.type ? (
+            <OrganizationTag
+              label={product.type.value}
+              to={`/settings/product-types/${product.type_id}`}
+            />
+          ) : undefined
+        }
+        data-testid="product-type-row"
       />
     </Container>
   );


### PR DESCRIPTION
## Summary
- Reorder the product detail **Organize** section to **Category → Collection → Tags → Type** and relabel "Categories" to the singular **"Category"**, matching the vendor panel.
- Lowercase "marketplace" (and add a trailing period) in the required-attribute tooltip: *"This attribute is required by the marketplace."*

Item 3 (truncating long attribute text) is out of scope and has been dropped. Item 4 (attribute section icons/labels, shared with MER-248) already shipped via #1105 and is untouched here.

## Linear
[MER-258](https://linear.app/rigbyjs/issue/MER-258)

## Test plan
- [ ] Open an admin product detail page; confirm Organize rows read Category, Collection, Tags, Type and the label is singular "Category".
- [ ] Hover the required-attribute info icon; confirm the tooltip reads "This attribute is required by the marketplace."
- [x] `bun run build`