### PR TITLE
fix(admin): show store offers on store details

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -15406,11 +15406,15 @@
             },
             "description": {
               "type": "string"
+            },
+            "storeDescription": {
+              "type": "string"
             }
           },
           "required": [
             "heading",
-            "description"
+            "description",
+            "storeDescription"
           ],
           "additionalProperties": false
         },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -4031,7 +4031,8 @@
     "domain": "Offers",
     "empty": {
       "heading": "No offers yet",
-      "description": "Stores haven't published any offers on this marketplace yet."
+      "description": "Stores haven't published any offers on this marketplace yet.",
+      "storeDescription": "This store doesn't have any offers"
     },
     "filtered": {
       "heading": "No matching offers",

--- a/packages/admin/src/pages/stores/store-details/components/store-details.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-details.tsx
@@ -15,7 +15,7 @@ import { StoreAddressSection } from "./store-address-section";
 import { StoreMembersSection } from "./store-members-section";
 import { StoreRequestSection } from "./store-request-section";
 import { StoreOrdersSection } from "./store-orders-section";
-import { StoreProductsSection } from "./store-products-section";
+import { StoreOffersSection } from "./store-offers-section";
 import {
   StoreDetailHeader,
   StoreDetailTitle,
@@ -23,7 +23,7 @@ import {
   StoreDetailEditButton,
 } from "./store-detail-header";
 
-const TABS = ["orders", "products", "users", "timeOff"] as const;
+const TABS = ["orders", "offers", "users", "timeOff"] as const;
 
 type Tab = (typeof TABS)[number];
 
@@ -39,7 +39,7 @@ const TabBar = ({
   const labels: Record<Tab, string> = {
     orders: t("orders.domain"),
     users: t("users.domain"),
-    products: t("products.domain"),
+    offers: t("offers.domain"),
     timeOff: t("store.timeOff.header"),
   };
 
@@ -127,13 +127,13 @@ const Root = ({ children }: { children?: ReactNode }) => {
             <StoreMembersSection sellerId={seller.id} />
           </div>
         )}
-        {activeTab === "products" && (
+        {activeTab === "offers" && (
           <div
             role="tabpanel"
-            id="store-detail-tab-panel-products"
-            aria-labelledby="store-detail-tab-products"
+            id="store-detail-tab-panel-offers"
+            aria-labelledby="store-detail-tab-offers"
           >
-            <StoreProductsSection sellerId={seller.id} />
+            <StoreOffersSection sellerId={seller.id} />
           </div>
         )}
         {activeTab === "timeOff" && (

--- a/packages/admin/src/pages/stores/store-details/components/store-offers-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-offers-section.tsx
@@ -4,43 +4,44 @@ import { keepPreviousData } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
 import { _DataTable } from "../../../../components/table/data-table";
-import { useSellerProducts } from "../../../../hooks/api/sellers";
-import { useProductTableColumns } from "../../../../hooks/table/columns/use-product-table-columns";
-import { useProductTableFilters } from "../../../../hooks/table/filters/use-product-table-filters";
-import { useProductTableQuery } from "../../../../hooks/table/query/use-product-table-query";
+import { useProducts } from "../../../../hooks/api/products";
 import { useDataTable } from "../../../../hooks/use-data-table";
+import { OfferProduct } from "../../../offers/common/types";
+import { useOfferTableColumns } from "../../../offers/_components/use-offer-table-columns";
+import { useOfferTableFilters } from "../../../offers/_components/use-offer-table-filters";
+import { useOfferTableQuery } from "../../../offers/_components/use-offer-table-query";
 
 const PAGE_SIZE = 10;
-const PREFIX = "store-products";
+const PREFIX = "store-offers";
 
-type StoreProductsSectionProps = {
+type StoreOffersSectionProps = {
   sellerId: string;
 };
 
-export const StoreProductsSection = ({
-  sellerId,
-}: StoreProductsSectionProps) => {
+export const StoreOffersSection = ({ sellerId }: StoreOffersSectionProps) => {
   const { t } = useTranslation();
 
-  const { searchParams, raw } = useProductTableQuery({
+  const { searchParams, raw } = useOfferTableQuery({
     pageSize: PAGE_SIZE,
     prefix: PREFIX,
   });
+  searchParams.seller_id = [sellerId];
 
-  const { products, count, isPending, isError, error } = useSellerProducts(
-    sellerId,
+  const { products, count, isPending, isError, error } = useProducts(
     searchParams,
     {
       placeholderData: keepPreviousData,
     },
   );
 
-  const columns = useProductTableColumns();
-  const filters = useProductTableFilters(["product_types"]);
+  const rows = (products ?? []) as unknown as OfferProduct[];
+
+  const columns = useOfferTableColumns().filter((c) => c.id !== "select");
+  const filters = useOfferTableFilters().filter((f) => f.key !== "seller_id");
 
   const { table } = useDataTable({
     columns,
-    data: products ?? [],
+    data: rows,
     count,
     getRowId: (row) => row.id,
     pageSize: PAGE_SIZE,
@@ -52,13 +53,13 @@ export const StoreProductsSection = ({
   }
 
   return (
-    <Container className="divide-y p-0" data-testid="store-products-section">
+    <Container className="divide-y p-0" data-testid="store-offers-section">
       <div
         className="flex items-center justify-between px-6 py-4"
-        data-testid="store-products-section-header"
+        data-testid="store-offers-section-header"
       >
-        <Heading level="h2" data-testid="store-products-section-heading">
-          {t("products.domain")}
+        <Heading level="h2" data-testid="store-offers-section-heading">
+          {t("offers.domain")}
         </Heading>
       </div>
       <_DataTable
@@ -68,7 +69,7 @@ export const StoreProductsSection = ({
         columns={columns}
         count={count}
         pageSize={PAGE_SIZE}
-        navigateTo={({ original }) => `/products/${original.id}`}
+        navigateTo={({ original }) => `/offers/${original.id}`}
         orderBy={[
           { key: "title", label: t("fields.title") },
           { key: "created_at", label: t("fields.createdAt") },
@@ -79,11 +80,8 @@ export const StoreProductsSection = ({
         pagination
         prefix={PREFIX}
         noRecords={{
-          title: t("stores.emptyStates.products.title", "No products yet"),
-          message: t(
-            "stores.emptyStates.products.message",
-            "Products published by this store will appear here.",
-          ),
+          title: t("offers.empty.heading"),
+          message: t("offers.empty.storeDescription"),
           icon: <Tag className="text-ui-fg-subtle" />,
         }}
       />


### PR DESCRIPTION
## What

Updates the admin **Store Details** page to present the store's **Offers** instead of products ([MER-243](https://linear.app/rigbyjs/issue/MER-243/stores-admin-panel-update-store-details)).

- **Products → Offers (real offer data).** Replaces `store-products-section.tsx` with `store-offers-section.tsx`, which reuses the existing `/offers` machinery scoped to the seller: `useOfferTableQuery` (namespaced with a `store-offers` param prefix) with `seller_id` forced to the store, `has_offer=true`, and offer fields via `useProducts`. Columns reuse `useOfferTableColumns` minus the bulk-select checkbox; filters reuse `useOfferTableFilters` minus the redundant Store filter. Rows navigate to `/offers/:id`. Tab + section heading now read **Offers**.
- **Empty state.** Tag icon with "No offers yet" / "This store doesn't have any offers" (new `offers.empty.storeDescription` key added to `en.json` and `$schema.json`).
- **White rows.** No code change required — the shared data table only greys nested rows; this flat table already renders white, matching the design.

## Design

- Offers section: Figma node `40014397-28943`
- Empty state: Figma node `40014397-659611`

## Testing

- `tsc` — no errors in touched files (pre-existing unrelated repo errors remain).
- `oxlint` on touched files — clean.
- `bun run build` (admin) — success, including DTS.
- i18n validation — new key balanced across `en.json` / `$schema.json` (the suite's only failure is a pre-existing, unrelated `sellers.*` gap on canary).