### PR TITLE
fix(admin): match vendor search placement on create-product step 4

### DIFF
--- a/packages/admin/src/components/data-grid/components/data-grid-root.tsx
+++ b/packages/admin/src/components/data-grid/components/data-grid-root.tsx
@@ -908,15 +908,15 @@ const DataGridHeader = ({
           )}
         </div>
       )}
-      {headerContent && (
-        <div
-          className="flex items-center"
-          onFocusCapture={() => onHeaderInteractionChange(true)}
-        >
-          {headerContent}
-        </div>
-      )}
       <div className="ml-auto flex items-center gap-x-2">
+        {headerContent && (
+          <div
+            className="flex items-center"
+            onFocusCapture={() => onHeaderInteractionChange(true)}
+          >
+            {headerContent}
+          </div>
+        )}
         {errorCount > 0 && (
           <Button
             size="small"


### PR DESCRIPTION
## Summary
- Follow-up to #1110 addressing the review on [MER-255](https://linear.app/rigbyjs/issue/MER-255): the step-4 variants search must look like the Vendor Panel.
- The admin DataGrid rendered `headerContent` (the search input) as a standalone child of the `justify-between` toolbar, so it floated in the middle. Moved it into the right-aligned `ml-auto` control group — now it sits at the far right next to the other grid controls, identical to the vendor `data-grid-root` layout.
- Placeholder keeps using the existing `general.search` key (no new i18n key).

## Linear
[MER-255](https://linear.app/rigbyjs/issue/MER-255)

## Test plan
- [ ] Admin → Products → Create → Step 4 (Variants): the search input is right-aligned in the grid toolbar, matching the vendor panel.
- [ ] Typing filters the variants table by title / SKU / option values; clearing restores the full list.
- [ ] `bun run lint`
- [ ] `bun run build`