### PR TITLE
fix(admin,core): show attribute category limitations on details page

### DIFF
--- a/packages/admin/src/pages/attributes/attribute-detail/components/attribute-general-section/attribute-general-section.tsx
+++ b/packages/admin/src/pages/attributes/attribute-detail/components/attribute-general-section/attribute-general-section.tsx
@@ -58,6 +58,8 @@ export const AttributeGeneralSection = ({
   const typeLabelKey = ATTRIBUTE_TYPE_LABELS[attribute.type]
   const typeLabel = typeLabelKey ? t(typeLabelKey) : attribute.type
 
+  const isGlobal = !(attribute.categories && attribute.categories.length > 0)
+
   return (
     <Container
       className="divide-y p-0"
@@ -127,6 +129,12 @@ export const AttributeGeneralSection = ({
           attribute.is_required ? t("fields.yes") : t("fields.no")
         }
         data-testid="attribute-general-section-required"
+      />
+
+      <SectionRow
+        title={t("attributes.fields.global")}
+        value={isGlobal ? t("fields.yes") : t("fields.no")}
+        data-testid="attribute-general-section-global"
       />
 
       <SectionRow

--- a/packages/core/src/links/product-attribute-category-link.ts
+++ b/packages/core/src/links/product-attribute-category-link.ts
@@ -3,23 +3,17 @@ import ProductModule from "@medusajs/medusa/product"
 
 import ProductAttributeModule from "../modules/product-attribute"
 
-/**
- * ProductAttribute → ProductCategory pivot link.
- *
- * Direction: the ProductAttribute is the owner — an attribute declares which
- * categories it applies to. Surfaced on the attribute as the `categories`
- * relation (explicit alias). The pivot table keeps both FK columns
- * (`product_attribute_id`, `product_category_id`), so the direction flip is a
- * pure relabel — no schema/migration change.
- */
+
 export default defineLink(
   {
     linkable: ProductAttributeModule.linkable.productAttribute.id,
     isList: true,
   },
   {
-    ...ProductModule.linkable.productCategory.id,
-    alias: "categories",
+    linkable: {
+      ...ProductModule.linkable.productCategory.id,
+      alias: "categories",
+    },
     isList: true,
   },
   {


### PR DESCRIPTION
## Problem

[MER-270](https://linear.app/rigbyjs/issue/MER-270/attributes-admin-panel-category-limitations-is-not-working) — when an attribute is limited to a category, the limitation is not shown after saving. The attribute details page should reflect whether an attribute is global, and list its categories when it is not.

## Root cause

The `ProductAttribute → ProductCategory` link declared its `categories` alias on the `defineLink` wrapper object. Medusa's `prepareServiceConfig` has two branches:

- **Bare descriptor** → honors `alias` but hardcodes `isList: false`.
- **`{ linkable, isList, alias }` wrapper** → honors `isList` but reads the alias only from the descriptor, ignoring the wrapper-level `alias`.

So the alias either resolved `categories` as a single object (`isList: false`) or failed to register entirely (`Entity 'ProductAttribute' does not have property 'categories'`).

## Fix

- Move the `categories` alias onto the linkable **descriptor** while keeping `isList: true` on the wrapper, so both survive. Linked categories now resolve as an array.
- Add a **Global** row to the attribute details page between *Required* and *Category*, derived the same way the create/edit forms define `is_global` (no categories → global `Yes`; scoped → `No`, with the existing *Category* row listing the categories).

## Notes

- The Medusa API registers links at boot — a restart is required to pick up the link change.
- Uses the existing `attributes.fields.global` i18n key.