### PR TITLE
fix(admin): remove order status filter from orders lists

### DIFF
--- a/packages/admin/src/pages/orders/order-list/components/order-list-table/use-order-table-filters.tsx
+++ b/packages/admin/src/pages/orders/order-list/components/order-list-table/use-order-table-filters.tsx
@@ -69,19 +69,6 @@ export const useOrderGroupTableFilters = () => {
       })
     }
 
-    filters.push({
-      key: "status",
-      label: t("fields.status"),
-      type: "select",
-      multiple: true,
-      options: [
-        { label: "Pending", value: "pending" },
-        { label: "Completed", value: "completed" },
-        { label: "Canceled", value: "canceled" },
-        { label: "Requires action", value: "requires_action" },
-      ],
-    })
-
     filters.push(
       {
         key: "created_at",


### PR DESCRIPTION
## Summary
- Remove the **Status** filter from the shared order-group filters hook (`useOrderGroupTableFilters`). The exposed statuses (`pending`/`completed`/`canceled`/`requires_action`) don't align with Medusa's order filtering logic — basic Medusa has no such order-group statuses.
- Because both the admin **Orders list** and the **Customer detail → Orders** section consume this hook, the filter is dropped from both surfaces in one change.
- The request/store filters that were working correctly are left untouched.

## Linear
- [MER-240](https://linear.app/rigbyjs/issue/MER-240) — Orders list status filter
- [MER-223](https://linear.app/rigbyjs/issue/MER-223) — Customer orders status filter

## Test plan
- [ ] Admin Orders list: filter dropdown no longer offers a Status option; Customer, Store, Sales Channel, Created/Updated filters remain
- [ ] Customer detail → Orders: same, with the Customer filter still scoped out
- [x] `bun run build` (admin package compiles, DTS included)