### PR TITLE
docs: split Mercur Enterprise into its own section and expand License

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,15 @@ This is the Mercur development monorepo: the `@mercurjs/core` plugin, the React 
 
 Because Mercur is a plain Node.js application backed by PostgreSQL and Redis, it deploys the same way whether you ship it as a container, orchestrate it with Kubernetes, push it to a managed cloud, or lock it inside an air-gapped network. There's no proprietary runtime to adopt and no hosting tier you're forced onto, so where your marketplace lives and where its data sits stay entirely under your control. Prefer a managed backend? Mercur also deploys to [Medusa Cloud](https://medusajs.com/pricing/) with push-to-deploy and auto-scaling.
 
-Mercur Enterprise adds a licensed suite of advanced modules (EAN matching & deduplication, a Buy Box / winning-offer engine, master-data governance, multi-channel stock sync, automated split payouts, vendor KYC, and much more), all maintained, tested, and upgraded by the core team. You deploy and run Enterprise on your own infrastructure, exactly like the open-source core. It comes backed by a direct support relationship with the people who build the platform: a dedicated support channel, contractual SLAs with guaranteed response times, prioritized bug fixes and security patches, and hands-on onboarding and architecture guidance to get you to production. Higher support tiers add priority escalation and a named technical contact. [Book a demo](https://www.mercurjs.com/enterprise).
+## License
+
+This repository is **Mercur core**, licensed under the [MIT License](./LICENSE) and fully open source. It's the marketplace engine on top of [Medusa](https://medusajs.com) — vendors, multi-vendor catalogs, offers, commissions, and payouts, with the admin and vendor dashboards and APIs to run a marketplace yourself.
+
+Mercur Enterprise adds a licensed suite of advanced modules (EAN matching & deduplication, a Buy Box / winning-offer engine, master-data governance, multi-channel stock sync, automated split payouts, vendor KYC, and much more), all maintained, tested, and upgraded by the core team. You deploy and run Enterprise on your own infrastructure, exactly like the open-source core.
+
+It comes backed by a direct support relationship with the people who build the platform: a dedicated support channel, contractual SLAs with guaranteed response times, prioritized bug fixes and security patches, and hands-on onboarding and architecture guidance to get you to production. Higher support tiers add priority escalation and a named technical contact.
+
+[Book a demo](https://www.mercurjs.com/enterprise).
 
 <!-- GETTING STARTED -->
 
@@ -135,10 +143,6 @@ Discovered a 🐜 or have feature suggestion? Feel free to [create an issue](htt
 ## Upgrades
 
 Follow the [Release Notes](https://github.com/mercurjs/mercur/releases) to keep your Mercur marketplace up-to-date.
-
-## License
-
-Mercur core is licensed under the [MIT License](./LICENSE).
 
 ## Contributors
 


### PR DESCRIPTION
## Summary

- Pulls the **Mercur Enterprise** copy out of the Deployment section into its own `## Mercur Enterprise` section (placed right after Deployment), split into readable paragraphs.
- Expands the **License** section with an "Open-source vs. paid" breakdown (inspired by PostHog's README): states the repo is available under the MIT expat license and that the optional Mercur Enterprise modules are distributed separately under the Mercur Enterprise license, with transparent pricing.

Docs-only change.