### PR TITLE
feat(offers): add variant count to grouped offers list

### DIFF
--- a/packages/admin/src/pages/offers/_components/use-offer-table-columns.tsx
+++ b/packages/admin/src/pages/offers/_components/use-offer-table-columns.tsx
@@ -103,6 +103,23 @@ export const useOfferTableColumns = (options?: {
         },
       }),
       columnHelper.display({
+        id: "variants",
+        header: () => (
+          <div className="flex h-full w-full items-center">
+            <span>{t("fields.variants")}</span>
+          </div>
+        ),
+        cell: ({ row }) => {
+          const count = row.original.variant_count
+          if (!count) return <PlaceholderCell />
+          return (
+            <Text size="small" leading="compact" className="truncate">
+              {t("products.variantCount", { count })}
+            </Text>
+          )
+        },
+      }),
+      columnHelper.display({
         id: "status",
         header: () => <ProductStatusHeader />,
         cell: ({ row }) => {

--- a/packages/admin/src/pages/offers/_components/use-offer-table-query.tsx
+++ b/packages/admin/src/pages/offers/_components/use-offer-table-query.tsx
@@ -6,6 +6,7 @@ const OFFER_LIST_FIELDS = [
   "seller_id",
   "variant_id",
   "sku",
+  "variant_count",
   "created_at",
   "updated_at",
   "product.id",

--- a/packages/core/src/api/admin/offers/query-config.ts
+++ b/packages/core/src/api/admin/offers/query-config.ts
@@ -8,6 +8,7 @@ export const defaultAdminOfferFields = [
   "ean",
   "upc",
   "created_by",
+  "variant_count",
   "metadata",
   "created_at",
   "updated_at",

--- a/packages/core/src/modules/offer/models/offer.ts
+++ b/packages/core/src/modules/offer/models/offer.ts
@@ -11,6 +11,7 @@ const Offer = model
     ean: model.text().searchable().nullable(),
     upc: model.text().searchable().nullable(),
     created_by: model.text(),
+    variant_count: model.number().computed(),
     metadata: model.json().nullable(),
   })
   .indexes([

--- a/packages/core/src/modules/offer/service.ts
+++ b/packages/core/src/modules/offer/service.ts
@@ -118,6 +118,27 @@ class OfferModuleService extends MedusaService({
     const rank = new Map(ids.map((id, index) => [id, index]))
     offers.sort((a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0))
 
+    const countRows = (await scoped()
+      .groupBy("product_id", "seller_id")
+      .select("product_id", "seller_id")
+      .count({ variant_count: "*" })) as Array<{
+      product_id: string
+      seller_id: string
+      variant_count: string | number
+    }>
+
+    const variantCountByGroup = new Map(
+      countRows.map((row) => [
+        `${row.product_id}:${row.seller_id}`,
+        Number(row.variant_count),
+      ])
+    )
+
+    for (const offer of offers) {
+      offer.variant_count =
+        variantCountByGroup.get(`${offer.product_id}:${offer.seller_id}`) ?? 0
+    }
+
     return [offers, count]
   }
 }

--- a/packages/types/src/offer/common.ts
+++ b/packages/types/src/offer/common.ts
@@ -56,6 +56,12 @@ export interface OfferDTO {
   updated_at: Date
   deleted_at: Date | null
   /**
+   * Number of offers the seller has for this product, computed only when
+   * offers are grouped by seller (`group_by_seller`). One offer per variant,
+   * so this is effectively the variant count for the grouped row.
+   */
+  variant_count?: number | null
+  /**
    * Joined through the writable `offer ↔ price` list-link defined in
    * `packages/core/src/links/offer-price-link.ts`. Carries the offer's
    * Price rows on the variant's shared `PriceSet` (filtered by the


### PR DESCRIPTION
## What

Adds a **Variants** count column to the admin offers list, mirroring the products list.

## How

- **Model** (`offer.ts`): added `variant_count: model.number().computed()` — computed, so no migration/column.
- **Service** (`service.ts`): in `listGroupedOffersBySeller_`, after fetching the representative offers, runs a grouped `COUNT(*)` over the same scoped query keyed by `(product_id, seller_id)` and stamps each grouped row's `variant_count`.
- **Query config** + **admin query fields**: request `variant_count`.
- **Types** (`OfferDTO`): `variant_count?: number | null` (matches the computed-field inference).
- **Admin column**: renders `products.variantCount` i18n, placeholder when zero.

The value is only populated on the grouped (`group_by_seller`) path, which is what the admin offers list uses.

## Verification

`bun run build` passes on both `packages/types` and `packages/core`. Integration tests rely on CI (worktree env limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)