### PR TITLE
feat(storefront): offer-based buy box with compare offers modal

### DIFF
--- a/apps/storefront/src/components/cells/ProductDetailsHeader/ProductDetailsHeader.tsx
+++ b/apps/storefront/src/components/cells/ProductDetailsHeader/ProductDetailsHeader.tsx
@@ -1,10 +1,12 @@
 "use client"
 
+import { useState } from "react"
+
 import { Button } from "@/components/atoms"
-import { HttpTypes } from "@medusajs/types"
-import { ProductVariants } from "@/components/molecules"
-import useGetAllSearchParams from "@/hooks/useGetAllSearchParams"
-import { getProductPrice } from "@/lib/helpers/get-product-price"
+import { HttpTypes, OfferDTO } from "@mercurjs/types"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { CompareOffersModal } from "@/components/organisms/CompareOffersModal/CompareOffersModal"
+import { getPricesForVariant } from "@/lib/helpers/get-product-price"
 import { Chat } from "@/components/organisms/Chat/Chat"
 import { SellerProps } from "@/types/seller"
 import { WishlistButton } from "../WishlistButton/WishlistButton"
@@ -12,146 +14,134 @@ import { Wishlist } from "@/types/wishlist"
 import { toast } from "@/lib/helpers/toast"
 import { useCartContext } from "@/components/providers"
 
-const optionsAsKeymap = (
-  variantOptions: HttpTypes.StoreProductVariant["options"]
-) => {
-  return variantOptions?.reduce(
-    (
-      acc: Record<string, string>,
-      varopt: HttpTypes.StoreProductOptionValue
-    ) => {
-      acc[varopt.option?.title.toLowerCase() || ""] = varopt.value
-
-      return acc
-    },
-    {}
-  )
-}
-
 export const ProductDetailsHeader = ({
   product,
+  offers,
   locale,
   user,
   wishlist,
 }: {
   product: HttpTypes.StoreProduct & { seller?: SellerProps }
+  offers: OfferDTO[]
   locale: string
   user: HttpTypes.StoreCustomer | null
   wishlist?: Wishlist
 }) => {
   const { addToCart, onAddToCart, cart, isAddingItem } = useCartContext()
-  const { allSearchParams } = useGetAllSearchParams()
+  const [isCompareOpen, setIsCompareOpen] = useState(false)
 
-  const { cheapestVariant, cheapestPrice } = getProductPrice({
-    product,
-  })
+  const cheapestOffer = offers[0] ?? null
+  const offerPrice = cheapestOffer
+    ? getPricesForVariant({ calculated_price: cheapestOffer.calculated_price })
+    : null
 
-  // Check if product has any valid prices in current region
-  const hasAnyPrice = cheapestPrice !== null && cheapestVariant !== null
+  const hasOffer = !!cheapestOffer && !!offerPrice
+  const inStock = !!cheapestOffer?.in_stock
 
-  // set default variant
-  const selectedVariant = hasAnyPrice
-    ? {
-        ...optionsAsKeymap(cheapestVariant.options ?? null),
-        ...allSearchParams,
-      }
-    : allSearchParams
+  const quantityInCart =
+    cart?.items?.find(
+      (item) =>
+        (item.metadata as { offer_id?: string } | null)?.offer_id ===
+        cheapestOffer?.id
+    )?.quantity ?? 0
 
-  // get selected variant id
-  const variantId =
-    product.variants?.find(({ options }: { options: any }) =>
-      options?.every((option: any) =>
-        selectedVariant[option.option?.title.toLowerCase() || ""]?.includes(
-          option.value
-        )
-      )
-    )?.id || ""
+  const isStockLimitReached =
+    quantityInCart >= (cheapestOffer?.inventory_quantity ?? 0)
 
-  // get variant price
-  const { variantPrice } = getProductPrice({
-    product,
-    variantId,
-  })
+  const isAddToCartDisabled = !hasOffer || !inStock || isStockLimitReached
 
-  const variantStock =
-    product.variants?.find(({ id }) => id === variantId)?.inventory_quantity ||
-    0
-
-  const variantHasPrice = !!product.variants?.find(({ id }) => id === variantId)
-    ?.calculated_price
-
-  const isVariantStockMaxLimitReached =
-    (cart?.items?.find((item) => item.variant_id === variantId)?.quantity ??
-      0) >= variantStock
-
-  // add the selected variant to the cart
   const handleAddToCart = async () => {
-    if (!variantId || !hasAnyPrice || isVariantStockMaxLimitReached) return
+    if (!cheapestOffer || !offerPrice || isStockLimitReached) return
 
-    const subtotal = +(variantPrice?.calculated_price_without_tax_number || 0)
-    const total = +(variantPrice?.calculated_price_number || 0)
+    const subtotal = +(offerPrice.calculated_price_without_tax_number || 0)
+    const total = +(offerPrice.calculated_price_number || 0)
 
-    const storeCartLineItem = {
-      thumbnail: product.thumbnail || "",
-      product_title: product.title,
-      quantity: 1,
-      subtotal,
-      total,
-      tax_total: total - subtotal,
-      variant_id: variantId,
-      product_id: product.id,
-      variant: product.variants?.find(({ id }) => id === variantId),
-    }
-
-    // Optimistic update
-    onAddToCart(storeCartLineItem, variantPrice?.currency_code || "eur")
+    onAddToCart(
+      {
+        thumbnail: product.thumbnail || "",
+        product_title: product.title,
+        quantity: 1,
+        subtotal,
+        total,
+        tax_total: total - subtotal,
+        variant_id: cheapestOffer.variant_id,
+        product_id: product.id,
+        variant: product.variants?.find(
+          ({ id }) => id === cheapestOffer.variant_id
+        ),
+        metadata: { offer_id: cheapestOffer.id },
+      },
+      offerPrice.currency_code || "eur"
+    )
 
     try {
       await addToCart({
-        variantId: variantId,
+        offerId: cheapestOffer.id,
         quantity: 1,
         countryCode: locale,
       })
     } catch (error) {
       toast.error({
         title: "Error adding to cart",
-        description: "Some variant does not have the required inventory",
+        description: "This offer does not have the required inventory",
       })
     }
   }
-
-  const isAddToCartDisabled = !variantStock || !variantHasPrice || !hasAnyPrice || isVariantStockMaxLimitReached
 
   return (
     <div className="border rounded-sm p-5" data-testid="product-details-header">
       <div className="flex justify-between">
         <div>
-          <h2 className="label-md text-secondary">
-            {/* {product?.brand || "No brand"} */}
-          </h2>
-          <h1 className="heading-lg text-primary" data-testid="product-title">{product.title}</h1>
-          <div className="mt-2 flex gap-2 items-center" data-testid="product-price-container">
-            {hasAnyPrice && variantPrice ? (
+          <h1 className="heading-lg text-primary" data-testid="product-title">
+            {product.title}
+          </h1>
+          <div
+            className="mt-2 flex gap-2 items-center"
+            data-testid="product-price-container"
+          >
+            {hasOffer && offerPrice ? (
               <>
-                <span className="heading-md text-primary" data-testid="product-price-current">
-                  {variantPrice.calculated_price}
+                <span
+                  className="heading-md text-primary"
+                  data-testid="product-price-current"
+                >
+                  {offerPrice.calculated_price}
                 </span>
-                {variantPrice.calculated_price_number !==
-                  variantPrice.original_price_number && (
-                  <span className="label-md text-secondary line-through" data-testid="product-price-original">
-                    {variantPrice.original_price}
+                {offerPrice.calculated_price_number !==
+                  offerPrice.original_price_number && (
+                  <span
+                    className="label-md text-secondary line-through"
+                    data-testid="product-price-original"
+                  >
+                    {offerPrice.original_price}
                   </span>
                 )}
               </>
             ) : (
-              <span className="label-md text-secondary pt-2 pb-4" data-testid="product-price-unavailable">
+              <span
+                className="label-md text-secondary pt-2 pb-4"
+                data-testid="product-price-unavailable"
+              >
                 Not available in your region
               </span>
             )}
           </div>
+          {cheapestOffer?.seller && (
+            <p
+              className="label-md text-secondary mt-2"
+              data-testid="product-offer-seller"
+            >
+              Sold by{" "}
+              <LocalizedClientLink
+                href={`/sellers/${cheapestOffer.seller.handle}`}
+                className="text-primary underline"
+              >
+                {cheapestOffer.seller.name}
+              </LocalizedClientLink>
+            </p>
+          )}
         </div>
         <div>
-          {/* Add to Wishlist */}
           <WishlistButton
             productId={product.id}
             wishlist={wishlist}
@@ -159,26 +149,33 @@ export const ProductDetailsHeader = ({
           />
         </div>
       </div>
-      {/* Product Variants */}
-      {hasAnyPrice && (
-        <ProductVariants product={product} selectedVariant={selectedVariant} />
-      )}
-      {/* Add to Cart */}
+
       <Button
         onClick={handleAddToCart}
         disabled={isAddToCartDisabled}
         loading={isAddingItem}
-        className="w-full uppercase mb-4 py-3 flex justify-center"
+        className="w-full uppercase mt-4 mb-2 py-3 flex justify-center"
         size="large"
         data-testid="product-add-to-cart-button"
       >
-        {!hasAnyPrice
+        {!hasOffer
           ? "NOT AVAILABLE IN YOUR REGION"
-          : variantStock && variantHasPrice
+          : inStock
           ? "ADD TO CART"
           : "OUT OF STOCK"}
       </Button>
-      {/* Seller message */}
+
+      {offers.length > 1 && (
+        <Button
+          onClick={() => setIsCompareOpen(true)}
+          variant="tonal"
+          className="w-full uppercase mb-4 py-3 flex justify-center"
+          size="large"
+          data-testid="product-compare-offers-button"
+        >
+          {`Compare other offers (${offers.length - 1})`}
+        </Button>
+      )}
 
       {user && product.seller && (
         <Chat
@@ -186,6 +183,15 @@ export const ProductDetailsHeader = ({
           seller={product.seller}
           buttonClassNames="w-full uppercase"
           product={product}
+        />
+      )}
+
+      {isCompareOpen && (
+        <CompareOffersModal
+          product={product}
+          offers={offers}
+          locale={locale}
+          onClose={() => setIsCompareOpen(false)}
         />
       )}
     </div>

--- a/apps/storefront/src/components/organisms/CompareOffersModal/CompareOffersModal.tsx
+++ b/apps/storefront/src/components/organisms/CompareOffersModal/CompareOffersModal.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { HttpTypes, OfferDTO } from "@mercurjs/types"
+
+import { Button } from "@/components/atoms"
+import { Modal } from "@/components/molecules"
+import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
+import { useCartContext } from "@/components/providers"
+import { getPricesForVariant } from "@/lib/helpers/get-product-price"
+import { toast } from "@/lib/helpers/toast"
+import { SellerProps } from "@/types/seller"
+
+export const CompareOffersModal = ({
+  product,
+  offers,
+  locale,
+  onClose,
+}: {
+  product: HttpTypes.StoreProduct & { seller?: SellerProps }
+  offers: OfferDTO[]
+  locale: string
+  onClose: () => void
+}) => {
+  const { addToCart, onAddToCart, isAddingItem } = useCartContext()
+
+  const handleAddOffer = async (offer: OfferDTO) => {
+    const price = getPricesForVariant({ calculated_price: offer.calculated_price })
+    if (!price) return
+
+    const subtotal = +(price.calculated_price_without_tax_number || 0)
+    const total = +(price.calculated_price_number || 0)
+
+    onAddToCart(
+      {
+        thumbnail: product.thumbnail || "",
+        product_title: product.title,
+        quantity: 1,
+        subtotal,
+        total,
+        tax_total: total - subtotal,
+        variant_id: offer.variant_id,
+        product_id: product.id,
+        variant: product.variants?.find(({ id }) => id === offer.variant_id),
+        metadata: { offer_id: offer.id },
+      },
+      price.currency_code || "eur"
+    )
+
+    onClose()
+
+    try {
+      await addToCart({ offerId: offer.id, quantity: 1, countryCode: locale })
+      toast.success({
+        title: "Added to cart",
+        description: `Offer from ${offer.seller?.name ?? "seller"} added to your cart`,
+      })
+    } catch (error) {
+      toast.error({
+        title: "Error adding to cart",
+        description: "This offer does not have the required inventory",
+      })
+    }
+  }
+
+  return (
+    <Modal
+      heading="Compare offers"
+      onClose={onClose}
+      data-testid="compare-offers-modal"
+    >
+      <div className="flex flex-col divide-y">
+        {offers.map((offer) => {
+          const price = getPricesForVariant({
+            calculated_price: offer.calculated_price,
+          })
+
+          return (
+            <div
+              key={offer.id}
+              className="flex items-center justify-between gap-4 px-4 py-4"
+              data-testid="compare-offers-row"
+            >
+              <div className="flex flex-col gap-1">
+                <LocalizedClientLink
+                  href={`/sellers/${offer.seller?.handle}`}
+                  className="label-md text-primary underline"
+                  data-testid="compare-offers-seller"
+                >
+                  {offer.seller?.name ?? "Seller"}
+                </LocalizedClientLink>
+                <span
+                  className={`label-sm ${
+                    offer.in_stock ? "text-positive" : "text-secondary"
+                  }`}
+                >
+                  {offer.in_stock ? "In stock" : "Out of stock"}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-4">
+                <span className="heading-sm text-primary">
+                  {price?.calculated_price ?? "-"}
+                </span>
+                <Button
+                  onClick={() => handleAddOffer(offer)}
+                  disabled={!offer.in_stock || !price}
+                  loading={isAddingItem}
+                  className="uppercase"
+                  size="small"
+                  data-testid="compare-offers-add-to-cart-button"
+                >
+                  Add to cart
+                </Button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </Modal>
+  )
+}

--- a/apps/storefront/src/components/organisms/ProductDetails/ProductDetails.tsx
+++ b/apps/storefront/src/components/organisms/ProductDetails/ProductDetails.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/cells"
 
 import { retrieveCustomer } from "@/lib/data/customer"
+import { listProductOffers } from "@/lib/data/offers"
 import { getUserWishlists } from "@/lib/data/wishlist"
 import { AdditionalAttributeProps } from "@/types/product"
 import { SellerProps } from "@/types/seller"
@@ -31,10 +32,16 @@ export const ProductDetails = async ({
     wishlist = await getUserWishlists({countryCode: locale})
   }
 
+  const offers = await listProductOffers({
+    productId: product.id,
+    countryCode: locale,
+  })
+
   return (
     <div>
       <ProductDetailsHeader
         product={product}
+        offers={offers}
         locale={locale}
         user={user}
         wishlist={wishlist}

--- a/apps/storefront/src/components/organisms/index.ts
+++ b/apps/storefront/src/components/organisms/index.ts
@@ -24,6 +24,7 @@ import { Addresses } from "./Addressess/Addresses"
 import { ReviewsToWrite } from "./Reviews/ReviewsToWrite"
 import { ReviewsWritten } from "./Reviews/ReviewsWritten"
 import { CartEmpty } from "./CartEmpty/CartEmpty"
+import { CompareOffersModal } from "./CompareOffersModal/CompareOffersModal"
 
 export {
   ProductCard,
@@ -52,4 +53,5 @@ export {
   ReviewsToWrite,
   ReviewsWritten,
   CartEmpty,
+  CompareOffersModal,
 }

--- a/apps/storefront/src/components/providers/Cart/CartProvider.tsx
+++ b/apps/storefront/src/components/providers/Cart/CartProvider.tsx
@@ -39,15 +39,19 @@ export function CartProvider({ cart, children }: CartProviderProps) {
   }, []);
 
   function handleAddToCart(newItem: StoreCartLineItemOptimisticUpdate, currency_code: string) {
+    const offerIdOf = (item?: { metadata?: unknown } | null) =>
+      (item?.metadata as { offer_id?: string } | null)?.offer_id;
+    const newOfferId = offerIdOf(newItem);
+
     setCartState(prev => {
       const currentItems = prev?.items || [];
       const isNewItemInCart = currentItems.find(
-        ({ variant_id }) => variant_id === newItem.variant_id
+        item => offerIdOf(item) === newOfferId
       );
 
       if (isNewItemInCart) {
         const updatedItems = currentItems.map(currentItem => {
-          if (currentItem.variant_id !== newItem.variant_id) {
+          if (offerIdOf(currentItem) !== newOfferId) {
             return currentItem;
           }
 
@@ -114,11 +118,11 @@ export function CartProvider({ cart, children }: CartProviderProps) {
   };
 
   const addToCart = async ({
-    variantId,
+    offerId,
     quantity,
     countryCode
   }: {
-    variantId: string;
+    offerId: string;
     quantity: number;
     countryCode: string;
   }) => {
@@ -127,7 +131,7 @@ export function CartProvider({ cart, children }: CartProviderProps) {
 
     try {
       await apiAddToCart({
-        variantId,
+        offerId,
         quantity,
         countryCode
       });

--- a/apps/storefront/src/components/providers/Cart/context.tsx
+++ b/apps/storefront/src/components/providers/Cart/context.tsx
@@ -8,7 +8,7 @@ interface CartContextInterface {
   cart: Cart | null;
   onAddToCart: (item: StoreCartLineItemOptimisticUpdate, currency_code: string) => void;
   addToCart: (params: {
-    variantId: string;
+    offerId: string;
     quantity: number;
     countryCode: string;
   }) => Promise<void>;

--- a/apps/storefront/src/lib/data/cart.ts
+++ b/apps/storefront/src/lib/data/cart.ts
@@ -102,16 +102,16 @@ export async function updateCart(data: HttpTypes.StoreUpdateCart) {
 }
 
 export async function addToCart({
-  variantId,
+  offerId,
   quantity,
   countryCode
 }: {
-  variantId: string;
+  offerId: string;
   quantity: number;
   countryCode: string;
 }) {
-  if (!variantId) {
-    throw new Error('Missing variant ID when adding to cart');
+  if (!offerId) {
+    throw new Error('Missing offer ID when adding to cart');
   }
 
   const cart = await getOrSetCart(countryCode);
@@ -124,7 +124,9 @@ export async function addToCart({
     ...(await getAuthHeaders())
   };
 
-  const currentItem = cart.items?.find(item => item.variant_id === variantId);
+  const currentItem = cart.items?.find(
+    item => (item.metadata as { offer_id?: string } | null)?.offer_id === offerId
+  );
 
   if (currentItem) {
     await sdk.store.cart
@@ -141,25 +143,18 @@ export async function addToCart({
         revalidateTag(cartCacheTag);
       });
   } else {
-    await sdk.store.cart
-      .createLineItem(
-        cart.id,
-        {
-          variant_id: variantId,
-          quantity
-        },
-        {},
-        headers
-      )
+    await mercur.store.carts.$id.lineItems
+      .mutate({
+        $id: cart.id,
+        offer_id: offerId,
+        quantity,
+        fetchOptions: { headers }
+      })
       .then(async () => {
         const cartCacheTag = await getCacheTag('carts');
         revalidateTag(cartCacheTag);
       })
-      .catch(medusaError)
-      .finally(async () => {
-        const cartCacheTag = await getCacheTag('carts');
-        revalidateTag(cartCacheTag);
-      });
+      .catch(medusaError);
   }
 }
 

--- a/apps/storefront/src/lib/data/offers.ts
+++ b/apps/storefront/src/lib/data/offers.ts
@@ -1,0 +1,50 @@
+'use server';
+
+import { OfferDTO } from '@mercurjs/types';
+
+import { mercur } from '../mercur';
+import { getAuthHeaders } from './cookies';
+import { getRegion } from './regions';
+
+const amountOf = (offer: OfferDTO) =>
+  offer.calculated_price?.calculated_amount ?? Number.POSITIVE_INFINITY;
+
+/**
+ * Lists every offer for a product, enriched with the per-offer calculated price
+ * and stock, sorted so `offers[0]` is the cheapest purchasable (in-stock) offer.
+ */
+export async function listProductOffers({
+  productId,
+  countryCode
+}: {
+  productId: string;
+  countryCode: string;
+}): Promise<OfferDTO[]> {
+  const region = await getRegion(countryCode);
+
+  if (!region) {
+    return [];
+  }
+
+  const headers = {
+    ...(await getAuthHeaders())
+  };
+
+  const { offers } = await mercur.store.offers
+    .query({
+      product_id: productId,
+      region_id: region.id,
+      country_code: countryCode,
+      fields: '+calculated_price,+inventory_quantity,+in_stock',
+      limit: 50,
+      fetchOptions: { headers, cache: 'no-cache' }
+    })
+    .catch(() => ({ offers: [] as OfferDTO[] }));
+
+  return [...offers].sort((a, b) => {
+    if (!!a.in_stock !== !!b.in_stock) {
+      return a.in_stock ? -1 : 1;
+    }
+    return amountOf(a) - amountOf(b);
+  });
+}


### PR DESCRIPTION
Stacks on top of #1134.

## What

Moves the storefront product page onto the offer-based commerce model and adds multi-seller offer comparison.

- **Buy box** now shows the **cheapest offer** for the product — its price and the seller that owns it — and adds to cart using `offer_id`.
- **Compare other offers** button opens a modal listing every seller's offer (seller, price, stock status) each with its own add-to-cart. Adding closes the modal and toasts.
- Cart data layer + provider migrated from `variant_id` to `offer_id` (the store line-item route already requires `offer_id`), deduping cart lines by `metadata.offer_id`.

## Why

The backend `POST /store/carts/:id/line-items` route already requires `offer_id` and rejects `variant_id`, so the storefront's variant-based add-to-cart was incompatible with the live route. This aligns the storefront with the offer model and surfaces multi-vendor price comparison to shoppers.

## Changes

- `lib/data/offers.ts` (new) — `listProductOffers()` fetching `/store/offers?product_id=…` with per-offer calculated price + stock, sorted in-stock-first then cheapest.
- `lib/data/cart.ts` — `addToCart({ offerId, quantity, countryCode })` via the offer-aware line-item route.
- `providers/Cart/*` — thread `offerId`, dedupe optimistic lines by `metadata.offer_id`.
- `ProductDetailsHeader.tsx` — cheapest-offer buy box + compare button.
- `organisms/CompareOffersModal/` (new) — offer comparison modal.
- `ProductDetails.tsx` — fetch offers server-side and pass to the buy box.

No backend changes — the offers endpoint, offer cart route, and per-seller order split already exist.

## Verification

Types verified with `tsc` (touched files clean; residual errors are pre-existing baseline). Runtime verification against a product with ≥2 offers still pending — buy box shows cheapest offer + seller, compare modal lists offers, `POST …/line-items` carries `offer_id`, and a multi-seller cart splits per seller at checkout.