### PR TITLE
chore(core): rename default store to Mercur Marketplace

### DIFF
--- a/packages/core/src/migration-scripts/rename-default-store.ts
+++ b/packages/core/src/migration-scripts/rename-default-store.ts
@@ -1,0 +1,13 @@
+import { ExecArgs, IStoreModuleService } from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
+
+const DEFAULT_STORE_NAME = "Medusa Store"
+const MERCUR_STORE_NAME = "Mercur Marketplace"
+
+export default async function renameDefaultStore({ container }: ExecArgs) {
+  const storeService = container.resolve<IStoreModuleService>(Modules.STORE)
+
+  const stores = await storeService.listStores({ name: DEFAULT_STORE_NAME })
+
+  await storeService.updateStores(stores[0].id, { name: MERCUR_STORE_NAME })
+}


### PR DESCRIPTION
## What

Adds a Medusa exec script that renames the default store from `Medusa Store` to `Mercur Marketplace`.

Medusa's `create-default-store` step creates the store row without a `name`, so it falls back to the store model's default (`Medusa Store`). This script updates the existing store to a Mercur-branded name.

## How

`packages/core/src/migration-scripts/rename-default-store.ts` follows the existing exec-script pattern (`ExecArgs` container), resolves the Store module service, finds the store still named `Medusa Store`, and updates it.

Run with:

```bash
medusa exec ./src/migration-scripts/rename-default-store.ts
```