### PR TITLE
i18n(dashboard): route untranslated strings through i18n

### DIFF
--- a/packages/admin/src/components/filtering/filter-group/filter-group.tsx
+++ b/packages/admin/src/components/filtering/filter-group/filter-group.tsx
@@ -1,5 +1,6 @@
 import { Button, DropdownMenu } from "@medusajs/ui"
 import { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
 import { useDocumentDirection } from "../../../hooks/use-document-direction"
 
@@ -10,6 +11,7 @@ type FilterGroupProps = {
 }
 
 export const FilterGroup = ({ filters }: FilterGroupProps) => {
+  const { t } = useTranslation()
   const [searchParams] = useSearchParams()
   const filterKeys = Object.keys(filters)
 
@@ -26,7 +28,7 @@ export const FilterGroup = ({ filters }: FilterGroupProps) => {
       {hasMore && <AddFilterMenu availableKeys={availableKeys} />}
       {isClearable && (
         <Button variant="transparent" size="small">
-          Clear all
+          {t("actions.clearAll")}
         </Button>
       )}
     </div>
@@ -38,6 +40,7 @@ type AddFilterMenuProps = {
 }
 
 const AddFilterMenu = ({ availableKeys }: AddFilterMenuProps) => {
+  const { t } = useTranslation()
   const direction = useDocumentDirection()
   return (
     <DropdownMenu
@@ -45,7 +48,7 @@ const AddFilterMenu = ({ availableKeys }: AddFilterMenuProps) => {
     >
       <DropdownMenu.Trigger asChild>
         <Button variant="secondary" size="small">
-          Add filter
+          {t("filters.addFilter")}
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>

--- a/packages/admin/src/components/forms/metadata-form/metadata-form.tsx
+++ b/packages/admin/src/components/forms/metadata-form/metadata-form.tsx
@@ -189,7 +189,7 @@ const InnerForm = <TRes,>({
                                   aria-labelledby={METADATA_KEY_LABEL_ID}
                                   {...field}
                                   disabled={isDisabled}
-                                  placeholder="Key"
+                                  placeholder={t("metadata.edit.labels.key")}
                                 />
                               </Form.Control>
                             </Form.Item>
@@ -208,7 +208,7 @@ const InnerForm = <TRes,>({
                                   {...field}
                                   value={isDisabled ? placeholder : value}
                                   disabled={isDisabled}
-                                  placeholder="Value"
+                                  placeholder={t("metadata.edit.labels.value")}
                                 />
                               </Form.Control>
                             </Form.Item>

--- a/packages/admin/src/components/layout/settings-layout/settings-layout.tsx
+++ b/packages/admin/src/components/layout/settings-layout/settings-layout.tsx
@@ -86,7 +86,7 @@ const useSettingRoutes = (): INavItem[] => {
         to: "/settings/locations",
       },
       {
-        label: t("commissions.domain", "Commissions"),
+        label: t("commissions.domain"),
         to: "/settings/commissions",
       },
       ...extensionNavItems,

--- a/packages/admin/src/components/table/data-table/data-table-filter/select-filter.tsx
+++ b/packages/admin/src/components/table/data-table/data-table-filter/select-filter.tsx
@@ -138,7 +138,7 @@ export const SelectFilter = ({
                       value={search}
                       onValueChange={setSearch}
                       className="txt-compact-small placeholder:text-ui-fg-muted bg-transparent outline-none"
-                      placeholder="Search"
+                      placeholder={t("general.search")}
                     />
                     <div className="flex h-5 w-5 items-center justify-center">
                       <button

--- a/packages/admin/src/components/table/save-view-dropdown/save-view-dropdown.tsx
+++ b/packages/admin/src/components/table/save-view-dropdown/save-view-dropdown.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import {
   DropdownMenu,
   Button,
@@ -26,14 +27,15 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
   onUpdateExisting,
   onSaveAsNew,
 }) => {
+  const { t } = useTranslation()
   const prompt = usePrompt()
 
   const handleSaveAsDefault = async () => {
     const result = await prompt({
-      title: "Save as system default",
-      description: "This will save the current configuration as the system default. All users will see this configuration by default unless they have their own personal views. Are you sure?",
-      confirmText: "Save as default",
-      cancelText: "Cancel",
+      title: t("views.prompts.saveAsDefault.title"),
+      description: t("views.prompts.saveAsDefault.description"),
+      confirmText: t("views.prompts.saveAsDefault.confirmText"),
+      cancelText: t("views.prompts.saveAsDefault.cancelText"),
     })
 
     if (result && onSaveAsDefault) {
@@ -43,10 +45,12 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
 
   const handleUpdateExisting = async () => {
     const result = await prompt({
-      title: "Update existing view",
-      description: `Update "${currentViewName}" with the current configuration?`,
-      confirmText: "Update",
-      cancelText: "Cancel",
+      title: t("views.prompts.updateExisting.title"),
+      description: t("views.prompts.updateExisting.description", {
+        name: currentViewName,
+      }),
+      confirmText: t("views.prompts.updateExisting.confirmText"),
+      cancelText: t("views.prompts.updateExisting.cancelText"),
     })
 
     if (result && onUpdateExisting) {
@@ -58,26 +62,26 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
     <DropdownMenu>
       <DropdownMenu.Trigger asChild>
         <Button variant="secondary" size="small">
-          Save
+          {t("views.save")}
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
         {isDefaultView && onSaveAsDefault && (
           <DropdownMenu.Item onClick={handleSaveAsDefault}>
             <CloudArrowUp className="h-4 w-4" />
-            Save as system default
+            {t("views.saveAsSystemDefault")}
           </DropdownMenu.Item>
         )}
         {!isDefaultView && currentViewId && onUpdateExisting && (
           <DropdownMenu.Item onClick={handleUpdateExisting}>
             <CloudArrowUp className="h-4 w-4" />
-            Update "{currentViewName}"
+            {t("views.updateNamed", { name: currentViewName })}
           </DropdownMenu.Item>
         )}
         {onSaveAsNew && (
           <DropdownMenu.Item onClick={onSaveAsNew}>
             <SquarePlusMicro className="h-4 w-4" />
-            Save as new view
+            {t("views.saveAsNew")}
           </DropdownMenu.Item>
         )}
       </DropdownMenu.Content>

--- a/packages/admin/src/components/table/table-cells/taxes/type-cell/type-cell.tsx
+++ b/packages/admin/src/components/table/table-cells/taxes/type-cell/type-cell.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@medusajs/ui"
+import { useTranslation } from "react-i18next"
 
 type CellProps = {
   is_combinable: boolean
@@ -9,12 +10,13 @@ type HeaderProps = {
 }
 
 export const TypeCell = ({ is_combinable }: CellProps) => {
+  const { t } = useTranslation()
   return (
     <div className="flex h-full w-full items-center gap-x-3 overflow-hidden">
       <span className="truncate">
         {is_combinable ? (
           <Badge size="2xsmall" color="green">
-            Combinable
+            {t("taxRegions.fields.isCombinable.true")}
           </Badge>
         ) : (
           ""

--- a/packages/admin/src/get-route-map.tsx
+++ b/packages/admin/src/get-route-map.tsx
@@ -1240,7 +1240,7 @@ export function getRouteMap({
                 errorElement: <ErrorBoundary />,
                 element: <Outlet />,
                 handle: {
-                  breadcrumb: () => t("commissions.domain", "Commissions"),
+                  breadcrumb: () => t("commissions.domain"),
                 },
                 children: [
                   {

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -605,7 +605,8 @@
       "proposed": "Proposed",
       "published": "Published",
       "requires_action": "Requires Action",
-      "rejected": "Rejected"
+      "rejected": "Rejected",
+      "accepted": "Accepted"
     },
     "request": {
       "panel": {
@@ -1088,6 +1089,7 @@
       "attributes": "Attributes",
       "requiresShipping": "Requires shipping",
       "requiresShippingHint": "Does the inventory item require shipping?",
+      "descriptionPlaceholder": "The item description",
       "successToast": "Inventory item was successfully created."
     },
     "reservation": {
@@ -1283,6 +1285,13 @@
     }
   },
   "orders": {
+    "group": {
+      "heading": "Orders in group",
+      "noOtherOrders": "No other orders in this group"
+    },
+    "commission": {
+      "total": "Total"
+    },
     "giftCardsStoreCreditLines": "Gift cards & credit lines",
     "creditLines": {
       "title": "Credit lines",
@@ -1360,6 +1369,7 @@
       "title": "Payments",
       "isReadyToBeCaptured": "Payment <0/> is ready to be captured.",
       "totalPaidByCustomer": "Total paid by customer",
+      "totalPending": "Total pending",
       "totalStoreCreditRefunds": "Total store credit refunds",
       "capture": "Capture payment",
       "capture_short": "Capture",
@@ -2384,10 +2394,16 @@
     "campaign_currency": {
       "tooltip": "This is the promotion's currency. Change it from the Details tab."
     },
+    "campaignSection": {
+      "noRecordsTitle": "Not part of a campaign",
+      "noRecordsMessage": "Add this promotion to an existing campaign",
+      "addToCampaign": "Add to Campaign"
+    },
     "form": {
       "required": "Required",
       "and": "AND",
       "selectAttribute": "Select Attribute",
+      "selectOperator": "Select Operator",
       "campaign": {
         "existing": {
           "title": "Existing Campaign",
@@ -2644,7 +2660,9 @@
         "successToast_other": "Successfully deleted prices for {{count}} products."
       },
       "add": {
-        "successToast": "Prices were successfully added to the price list."
+        "successToast": "Prices were successfully added to the price list.",
+        "alreadyInPriceList": "This product is already in the price list",
+        "noVariants": "This product has no variants"
       },
       "edit": {
         "successToast": "Prices were successfully updated."
@@ -2762,7 +2780,8 @@
     "domain": "Marketplace",
     "manageMarketplaceDetails": "Manage your marketplace's details",
     "edit": {
-      "header": "Edit Marketplace"
+      "header": "Edit Marketplace",
+      "namePlaceholder": "ACME"
     }
   },
   "store": {
@@ -3119,12 +3138,21 @@
       "lastUsedAtLabel": "Last used at",
       "revokedByLabel": "Revoked by",
       "revokedAtLabel": "Revoked at",
-      "createdByLabel": "Created by"
+      "createdByLabel": "Created by",
+      "tokenLabel": "Token"
     }
   },
   "attributes": {
     "domain": "Product Attributes",
     "subtitle": "Manage product attributes and their possible values.",
+    "editRanking": {
+      "successToast": "Ranking updated successfully."
+    },
+    "possibleValues": {
+      "editRanking": "Edit ranking",
+      "noRecordsTitle": "No created values",
+      "noRecordsMessage": "Create attribute to organize your products"
+    },
     "list": {
       "title": "Product Attributes",
       "noRecordsMessage": "No product attributes have been created yet."
@@ -3197,7 +3225,9 @@
       "isFilterable": "Filterable attribute",
       "isFilterableHint": "If checked, customers will be able to filter products using this attribute.",
       "isGlobal": "Global attribute",
-      "isGlobalHint": "If checked, this attribute applies to all products across all categories."
+      "isGlobalHint": "If checked, this attribute applies to all products across all categories.",
+      "isVariantAxis": "Use for variants",
+      "isVariantAxisHint": "If checked, this attribute will define product variants (e.g. size, color)."
     },
     "type": {
       "select": "Single Select",
@@ -3484,6 +3514,7 @@
     "yes": "Yes",
     "no": "No",
     "amount": "Amount",
+    "commission": "Commission",
     "reference": "Reference",
     "reference_id": "Reference ID",
     "refundAmount": "Refund amount",
@@ -3693,8 +3724,10 @@
   "views": {
     "save": "Save",
     "saveAsNew": "Save as new view",
+    "saveAsSystemDefault": "Save as system default",
     "updateDefaultForEveryone": "Update default for everyone",
     "updateViewName": "Update view",
+    "updateNamed": "Update \"{{name}}\"",
     "prompts": {
       "updateDefault": {
         "title": "Update default view",
@@ -3705,6 +3738,18 @@
       "updateView": {
         "title": "Update view",
         "description": "Are you sure you want to update \"{{name}}\"?",
+        "confirmText": "Update",
+        "cancelText": "Cancel"
+      },
+      "saveAsDefault": {
+        "title": "Save as system default",
+        "description": "This will save the current configuration as the system default. All users will see this configuration by default unless they have their own personal views. Are you sure?",
+        "confirmText": "Save as default",
+        "cancelText": "Cancel"
+      },
+      "updateExisting": {
+        "title": "Update existing view",
+        "description": "Update \"{{name}}\" with the current configuration?",
         "confirmText": "Update",
         "cancelText": "Cancel"
       }
@@ -3725,6 +3770,17 @@
   "stores": {
     "domain": "Stores",
     "handleTooltip": "The handle is used as the URL slug for the store. Leave empty to auto-generate from the name.",
+    "emptyStates": {
+      "users": {
+        "title": "No users yet"
+      },
+      "products": {
+        "title": "No products yet"
+      },
+      "orders": {
+        "title": "No orders yet"
+      }
+    },
     "fields": {
       "name": "Name",
       "handle": "Handle",

--- a/packages/admin/src/lib/table/cell-renderers.tsx
+++ b/packages/admin/src/lib/table/cell-renderers.tsx
@@ -95,15 +95,15 @@ const StatusRenderer: CellRenderer = (value, row, column, t) => {
     const lowerStatus = status.toLowerCase()
     switch (lowerStatus) {
       case "active":
-        return t("general.active", "Active") as string
+        return t("general.active") as string
       case "accepted":
-        return t("products.productStatus.accepted", "Accepted") as string
+        return t("products.productStatus.accepted") as string
       case "draft":
-        return t("orders.status.draft", "Draft") as string
+        return t("orders.status.draft") as string
       case "pending":
-        return t("orders.status.pending", "Pending") as string
+        return t("orders.status.pending") as string
       case "canceled":
-        return t("orders.status.canceled", "Canceled") as string
+        return t("orders.status.canceled") as string
       default:
         // Try generic status translation with fallback
         return t(`status.${lowerStatus}`, status) as string
@@ -183,7 +183,7 @@ const CustomerNameRenderer: CellRenderer = (_, row, _column, t) => {
     return row.customer.phone
   }
 
-  return t ? t("customers.guest", "Guest") : "Guest"
+  return t ? t("customers.guest") : "Guest"
 }
 
 const AddressSummaryRenderer: CellRenderer = (_, row, column, _t) => {
@@ -306,7 +306,7 @@ export function getCellRenderer(
     case "boolean":
       return (value, _row, _column, t) => {
         if (t) {
-          return value ? t("fields.yes", "Yes") : t("fields.no", "No")
+          return value ? t("fields.yes") : t("fields.no")
         }
         return value ? "Yes" : "No"
       }

--- a/packages/admin/src/pages/api-key-management/api-key-management-list/components/api-key-management-list-table/use-api-key-management-table-columns.tsx
+++ b/packages/admin/src/pages/api-key-management/api-key-management-list/components/api-key-management-list-table/use-api-key-management-table-columns.tsx
@@ -30,7 +30,7 @@ export const useApiKeyManagementTableColumns = () => {
         ),
       }),
       columnHelper.accessor("redacted", {
-        header: "Token",
+        header: t("apiKeyManagement.fields.tokenLabel"),
         cell: ({ getValue }) => {
           const token = getValue();
           return <Badge size="2xsmall">{prettifyRedactedToken(token)}</Badge>;

--- a/packages/admin/src/pages/attributes/attribute-create/components/attribute-create-details-tab.tsx
+++ b/packages/admin/src/pages/attributes/attribute-create/components/attribute-create-details-tab.tsx
@@ -92,7 +92,7 @@ const Root = () => {
           <SwitchBox
             control={form.control}
             name="is_required"
-            label={t("attributes.fields.isRequired", "Required attribute")}
+            label={t("attributes.fields.isRequired")}
             description={t(
               "attributes.fields.isRequiredHint",
               "If checked, a value must be set to this attribute.",
@@ -103,7 +103,7 @@ const Root = () => {
           <SwitchBox
             control={form.control}
             name="is_filterable"
-            label={t("attributes.fields.isFilterable", "Filterable attribute")}
+            label={t("attributes.fields.isFilterable")}
             description={t(
               "attributes.fields.isFilterableHint",
               "If checked, customers will be able to filter products using this attribute.",
@@ -114,7 +114,7 @@ const Root = () => {
           <SwitchBox
             control={form.control}
             name="is_global"
-            label={t("attributes.fields.isGlobal", "Global attribute")}
+            label={t("attributes.fields.isGlobal")}
             description={t(
               "attributes.fields.isGlobalHint",
               "If checked, this attribute applies to all products across all categories.",

--- a/packages/admin/src/pages/attributes/attribute-create/components/attribute-create-type-tab.tsx
+++ b/packages/admin/src/pages/attributes/attribute-create/components/attribute-create-type-tab.tsx
@@ -43,10 +43,7 @@ const Root = () => {
         <div>
           <Heading level="h2">{t("attributes.fields.type")}</Heading>
           <Text size="small" className="text-ui-fg-subtle mt-1">
-            {t(
-              "attributes.create.typeDescription",
-              "Select the type of this attribute and define its values."
-            )}
+            {t("attributes.create.typeDescription")}
           </Text>
         </div>
 
@@ -64,10 +61,7 @@ const Root = () => {
                 >
                   <Select.Trigger data-testid="attribute-create-type-trigger">
                     <Select.Value
-                      placeholder={t(
-                        "attributes.fields.typePlaceholder",
-                        "Select Type"
-                      )}
+                      placeholder={t("attributes.fields.typePlaceholder")}
                     />
                   </Select.Trigger>
                   <Select.Content>
@@ -92,11 +86,8 @@ const Root = () => {
           <SwitchBox
             control={form.control}
             name="is_variant_axis"
-            label={t("attributes.fields.isVariantAxis", "Use for variants")}
-            description={t(
-              "attributes.fields.isVariantAxisHint",
-              "If checked, this attribute will define product variants (e.g. size, color)."
-            )}
+            label={t("attributes.fields.isVariantAxis")}
+            description={t("attributes.fields.isVariantAxisHint")}
             data-testid="attribute-create-variant-axis-switch"
           />
         )}

--- a/packages/admin/src/pages/attributes/attribute-create/components/multi-select-category.tsx
+++ b/packages/admin/src/pages/attributes/attribute-create/components/multi-select-category.tsx
@@ -126,7 +126,7 @@ export const MultiSelectCategory = ({
               className="text-ui-fg-subtle"
               data-testid="attribute-form-category-multiselect-placeholder"
             >
-              {t("attributes.fields.categories", "Select categories")}
+              {t("attributes.selectCategory.placeholder")}
             </Text>
           )}
         </div>
@@ -162,7 +162,7 @@ export const MultiSelectCategory = ({
               className="p-3 text-ui-fg-subtle"
               data-testid="attribute-form-category-multiselect-empty"
             >
-              {t("general.noResultsTitle", "No categories found.")}
+              {t("general.noResultsTitle")}
             </div>
           ) : (
             currentCategories.map((category) => {

--- a/packages/admin/src/pages/attributes/attribute-detail/components/attribute-possible-values-section/attribute-possible-values-section.tsx
+++ b/packages/admin/src/pages/attributes/attribute-detail/components/attribute-possible-values-section/attribute-possible-values-section.tsx
@@ -186,7 +186,7 @@ export const AttributePossibleValuesSection = ({
           />
           <Button variant="secondary" size="small" asChild>
             <Link to="edit-ranking">
-              {t("attributes.possibleValues.editRanking", "Edit ranking")}
+              {t("attributes.possibleValues.editRanking")}
             </Link>
           </Button>
           <Button variant="secondary" size="small" asChild>
@@ -207,8 +207,8 @@ export const AttributePossibleValuesSection = ({
       ) : (
         <NoRecords
           className="border-t"
-          title={t("attributes.possibleValues.noRecordsTitle", "No created values")}
-          message={t("attributes.possibleValues.noRecordsMessage", "Create attribute to organize your products")}
+          title={t("attributes.possibleValues.noRecordsTitle")}
+          message={t("attributes.possibleValues.noRecordsMessage")}
           action={{
             to: "create-possible-value",
             label: t("actions.create"),

--- a/packages/admin/src/pages/attributes/attribute-edit-ranking/attribute-edit-ranking.tsx
+++ b/packages/admin/src/pages/attributes/attribute-edit-ranking/attribute-edit-ranking.tsx
@@ -133,7 +133,7 @@ const EditRankingInner = () => {
   const { mutateAsync: upsertValues, isPending: isSaving } =
     useUpsertProductAttributeValues(id!, {
       onSuccess: () => {
-        toast.success(t("attributes.editRanking.successToast", "Ranking updated successfully."))
+        toast.success(t("attributes.editRanking.successToast"))
         handleSuccess()
       },
       onError: (err) => {

--- a/packages/admin/src/pages/attributes/attribute-edit/attribute-edit.tsx
+++ b/packages/admin/src/pages/attributes/attribute-edit/attribute-edit.tsx
@@ -120,7 +120,7 @@ const AttributeEditForm = ({ attribute }: AttributeEditFormProps) => {
             <SwitchBox
               control={form.control}
               name="is_required"
-              label={t("attributes.fields.isRequired", "Required attribute")}
+              label={t("attributes.fields.isRequired")}
               description={t(
                 "attributes.fields.isRequiredHint",
                 "If checked, vendors must set a value for this attribute.",
@@ -131,7 +131,7 @@ const AttributeEditForm = ({ attribute }: AttributeEditFormProps) => {
             <SwitchBox
               control={form.control}
               name="is_filterable"
-              label={t("attributes.fields.isFilterable", "Filterable attribute")}
+              label={t("attributes.fields.isFilterable")}
               description={t(
                 "attributes.fields.isFilterableHint",
                 "If checked, buyers will be able to filter products using this attribute.",

--- a/packages/admin/src/pages/attributes/attribute-edit/components/attribute-form.tsx
+++ b/packages/admin/src/pages/attributes/attribute-edit/components/attribute-form.tsx
@@ -218,36 +218,24 @@ export const AttributeForm = forwardRef<AttributeFormRef, AttributeFormProps>(
         <SwitchBox
           control={form.control}
           name="is_filterable"
-          label={t("attributes.fields.isFilterable", "Filterable attribute")}
-          description={t(
-            "attributes.fields.isFilterableHint",
-            "If checked, buyers will be able to filter products using this attribute."
-          )}
+          label={t("attributes.fields.isFilterable")}
+          description={t("attributes.fields.isFilterableHint")}
           data-testid="attribute-form-filterable-switch"
         />
 
         <SwitchBox
           control={form.control}
           name="is_required"
-          label={t("attributes.fields.isRequired", "Required attribute")}
-          description={t(
-            "attributes.fields.isRequiredHint",
-            "If checked, vendors must set a value for this attribute."
-          )}
+          label={t("attributes.fields.isRequired")}
+          description={t("attributes.fields.isRequiredHint")}
           data-testid="attribute-form-required-switch"
         />
 
         <SwitchBox
           control={form.control}
           name="is_variant_axis"
-          label={t(
-            "attributes.fields.isVariantAxis",
-            "Use for Variants"
-          )}
-          description={t(
-            "attributes.fields.isVariantAxisHint",
-            "If checked, this attribute can be used to create product variants."
-          )}
+          label={t("attributes.fields.isVariantAxis")}
+          description={t("attributes.fields.isVariantAxisHint")}
           data-testid="attribute-form-variant-axis-switch"
         />
       </div>
@@ -272,10 +260,7 @@ export const AttributeForm = forwardRef<AttributeFormRef, AttributeFormProps>(
                 >
                   <Select.Trigger data-testid="attribute-form-type-trigger">
                     <Select.Value
-                      placeholder={t(
-                        "attributes.fields.typePlaceholder",
-                        "Select Type"
-                      )}
+                      placeholder={t("attributes.fields.typePlaceholder")}
                     />
                   </Select.Trigger>
                   <Select.Content>

--- a/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-commission-edit/commission-rule-commission-edit.tsx
@@ -85,9 +85,7 @@ const EditCommissionForm = ({ rule }: { rule: CommissionRate }) => {
       {
         onSuccess: () => {
           toast.success(
-            t("commissions.commissionEdit.successToast", {
-              defaultValue: "Commission was successfully updated.",
-            })
+            t("commissions.commissionEdit.successToast")
           );
           handleSuccess();
         },

--- a/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-create/components/create-commission-rule-form/create-commission-rule-form.tsx
@@ -71,9 +71,7 @@ export const CreateCommissionRuleForm = () => {
       {
         onSuccess: ({ commission_rate }) => {
           toast.success(
-            t("commissions.create.successToast", {
-              defaultValue: "Commission rule was successfully created.",
-            })
+            t("commissions.create.successToast")
           );
           handleSuccess(`/settings/commissions/${commission_rate.id}`);
         },

--- a/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-edit/commission-rule-edit.tsx
@@ -151,9 +151,7 @@ const EditCommissionRuleForm = ({ rule }: { rule: CommissionRate }) => {
       }
 
       toast.success(
-        t("commissions.edit.successToast", {
-          defaultValue: "Commission rule was successfully updated.",
-        })
+        t("commissions.edit.successToast")
       );
       handleSuccess();
     } catch (e) {

--- a/packages/admin/src/pages/commissions/common/hooks/use-delete-commission-rule-action.tsx
+++ b/packages/admin/src/pages/commissions/common/hooks/use-delete-commission-rule-action.tsx
@@ -31,9 +31,7 @@ export const useDeleteCommissionRuleAction = (rule: {
     await mutateAsync(undefined, {
       onSuccess: () => {
         toast.success(
-          t("commissions.delete.successToast", {
-            defaultValue: "Commission rule was successfully deleted.",
-          })
+          t("commissions.delete.successToast")
         );
         navigate("/settings/commissions");
       },

--- a/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
+++ b/packages/admin/src/pages/commissions/global-commission-edit/global-commission-edit.tsx
@@ -91,9 +91,7 @@ const EditGlobalCommissionForm = ({ rate }: { rate: CommissionRate }) => {
     await mutateAsync(payload, {
       onSuccess: () => {
         toast.success(
-          t("commissions.global.edit.successToast", {
-            defaultValue: "Global commission was successfully updated.",
-          })
+          t("commissions.global.edit.successToast")
         );
         handleSuccess();
       },

--- a/packages/admin/src/pages/inventory/inventory-create/components/inventory-create-form/inventory-create-details-tab.tsx
+++ b/packages/admin/src/pages/inventory/inventory-create/components/inventory-create-form/inventory-create-details-tab.tsx
@@ -62,7 +62,7 @@ const Root = () => {
                     {t("products.fields.description.label")}
                   </Form.Label>
                   <Form.Control data-testid="inventory-create-form-description-control">
-                    <Textarea {...field} placeholder="The item description" data-testid="inventory-create-form-description-textarea" />
+                    <Textarea {...field} placeholder={t("inventory.create.descriptionPlaceholder")} data-testid="inventory-create-form-description-textarea" />
                   </Form.Control>
                   <Form.ErrorMessage data-testid="inventory-create-form-description-error" />
                 </Form.Item>

--- a/packages/admin/src/pages/inventory/inventory-stock/hooks/use-inventory-stock-columns.tsx
+++ b/packages/admin/src/pages/inventory/inventory-stock/hooks/use-inventory-stock-columns.tsx
@@ -20,8 +20,8 @@ export const useInventoryStockColumns = (
     () => [
       helper.column({
         id: "title",
-        name: "Title",
-        header: "Title",
+        name: t("fields.title"),
+        header: t("fields.title"),
         cell: (context) => {
           const item = context.row.original
           return (
@@ -34,8 +34,8 @@ export const useInventoryStockColumns = (
       }),
       helper.column({
         id: "sku",
-        name: "SKU",
-        header: "SKU",
+        name: t("fields.sku"),
+        header: t("fields.sku"),
         cell: (context) => {
           const item = context.row.original
 

--- a/packages/admin/src/pages/marketplace/marketplace-edit/components/edit-marketplace-form/edit-marketplace-form.tsx
+++ b/packages/admin/src/pages/marketplace/marketplace-edit/components/edit-marketplace-form/edit-marketplace-form.tsx
@@ -105,7 +105,7 @@ export const EditMarketplaceForm = ({ store }: EditMarketplaceFormProps) => {
                 <Form.Item data-testid="store-edit-form-name-item">
                   <Form.Label data-testid="store-edit-form-name-label">{t("fields.name")}</Form.Label>
                   <Form.Control data-testid="store-edit-form-name-control">
-                    <Input placeholder="ACME" {...field} data-testid="store-edit-form-name-input" />
+                    <Input placeholder={t("marketplace.edit.namePlaceholder")} {...field} data-testid="store-edit-form-name-input" />
                   </Form.Control>
                   <Form.ErrorMessage data-testid="store-edit-form-name-error" />
                 </Form.Item>

--- a/packages/admin/src/pages/orders/order-detail/components/order-commission-section/order-commission-section.tsx
+++ b/packages/admin/src/pages/orders/order-detail/components/order-commission-section/order-commission-section.tsx
@@ -35,7 +35,7 @@ export const OrderCommissionSection = ({
   return (
     <Container className="divide-y p-0" data-testid="order-commission-section">
       <div className="flex items-center justify-between px-6 py-4">
-        <Heading level="h2">{t("fields.commission", "Commission")}</Heading>
+        <Heading level="h2">{t("fields.commission")}</Heading>
       </div>
       <div className="divide-y">
         {commission_lines.map((line) => {
@@ -59,7 +59,7 @@ export const OrderCommissionSection = ({
       </div>
       <div className="flex items-center justify-between px-6 py-4">
         <Text size="small" weight="plus" leading="compact">
-          {t("orders.commission.total", "Total")}
+          {t("orders.commission.total")}
         </Text>
         <Text size="small" weight="plus" leading="compact">
           {getLocaleAmount(total, order.currency_code)}

--- a/packages/admin/src/pages/orders/order-detail/components/order-payment-section/order-payment-section.tsx
+++ b/packages/admin/src/pages/orders/order-detail/components/order-payment-section/order-payment-section.tsx
@@ -491,7 +491,7 @@ const Total = ({ order }: { order: AdminOrder }) => {
           data-testid="order-payment-total-pending"
         >
           <Text size="small" weight="plus" leading="compact">
-            Total pending
+            {t("orders.payment.totalPending")}
           </Text>
 
           <Text size="small" weight="plus" leading="compact">

--- a/packages/admin/src/pages/orders/order-detail/components/order-remaining-orders-group-section/order-remaining-orders-group-section.tsx
+++ b/packages/admin/src/pages/orders/order-detail/components/order-remaining-orders-group-section/order-remaining-orders-group-section.tsx
@@ -80,7 +80,7 @@ export const OrderRemainingOrdersGroupSection = () => {
         data-testid="order-remaining-orders-group-header"
       >
         <Heading level="h2" data-testid="order-remaining-orders-group-heading">
-          {t("orders.domain")} in group
+          {t("orders.group.heading")}
         </Heading>
       </div>
       <_DataTable
@@ -91,7 +91,7 @@ export const OrderRemainingOrdersGroupSection = () => {
         isLoading={isLoading}
         pageSize={orders.length}
         noRecords={{
-          message: "No other orders in this group",
+          message: t("orders.group.noOtherOrders"),
         }}
       />
     </Container>

--- a/packages/admin/src/pages/orders/order-list/components/order-list-table/components/save-view-dropdown.tsx
+++ b/packages/admin/src/pages/orders/order-list/components/order-list-table/components/save-view-dropdown.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import { Button, DropdownMenu, usePrompt } from "@medusajs/ui"
 import { ChevronDownMini } from "@medusajs/icons"
 
@@ -18,14 +19,15 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
   onSaveAsNew,
 }) => {
 
+  const { t } = useTranslation()
   const prompt = usePrompt()
 
   const handleSaveAsDefault = async () => {
     const result = await prompt({
-      title: "Update default view",
-      description: "This will update the default view for all users. Are you sure?",
-      confirmText: "Update for everyone",
-      cancelText: "Cancel",
+      title: t("views.prompts.updateDefault.title"),
+      description: t("views.prompts.updateDefault.description"),
+      confirmText: t("views.prompts.updateDefault.confirmText"),
+      cancelText: t("views.prompts.updateDefault.cancelText"),
     })
 
     if (result) {
@@ -35,10 +37,12 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
 
   const handleUpdateExisting = async () => {
     const result = await prompt({
-      title: "Update view",
-      description: `Are you sure you want to update "${currentViewName}"?`,
-      confirmText: "Update",
-      cancelText: "Cancel",
+      title: t("views.prompts.updateView.title"),
+      description: t("views.prompts.updateView.description", {
+        name: currentViewName,
+      }),
+      confirmText: t("views.prompts.updateView.confirmText"),
+      cancelText: t("views.prompts.updateView.cancelText"),
     })
 
     if (result) {
@@ -50,7 +54,7 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
     <DropdownMenu>
       <DropdownMenu.Trigger asChild>
         <Button variant="secondary" size="small">
-          Save
+          {t("views.save")}
           <ChevronDownMini />
         </Button>
       </DropdownMenu.Trigger>
@@ -58,19 +62,19 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
         {isDefaultView ? (
           <>
             <DropdownMenu.Item onClick={handleSaveAsDefault}>
-              Update default for everyone
+              {t("views.updateDefaultForEveryone")}
             </DropdownMenu.Item>
             <DropdownMenu.Item onClick={onSaveAsNew}>
-              Save as new view
+              {t("views.saveAsNew")}
             </DropdownMenu.Item>
           </>
         ) : (
           <>
             <DropdownMenu.Item onClick={handleUpdateExisting}>
-              Update "{currentViewName}"
+              {t("views.updateNamed", { name: currentViewName })}
             </DropdownMenu.Item>
             <DropdownMenu.Item onClick={onSaveAsNew}>
-              Save as new view
+              {t("views.saveAsNew")}
             </DropdownMenu.Item>
           </>
         )}

--- a/packages/admin/src/pages/price-lists/price-list-prices-add/components/price-list-prices-add-form/price-list-prices-add-product-ids-form.tsx
+++ b/packages/admin/src/pages/price-lists/price-list-prices-add/components/price-list-prices-add-form/price-list-prices-add-product-ids-form.tsx
@@ -162,6 +162,7 @@ const Root = ({
 const columnHelper = createColumnHelper<HttpTypes.AdminProduct>()
 
 const useColumns = () => {
+  const { t } = useTranslation()
   const base = useProductTableColumns()
 
   return useMemo(
@@ -206,7 +207,7 @@ const useColumns = () => {
 
           if (isPreselected) {
             return (
-              <Tooltip content="This product is already in the price list">
+              <Tooltip content={t("priceLists.products.add.alreadyInPriceList")}>
                 {Component}
               </Tooltip>
             )
@@ -214,7 +215,7 @@ const useColumns = () => {
 
           if (isDisabled) {
             return (
-              <Tooltip content="This product has no variants">
+              <Tooltip content={t("priceLists.products.add.noVariants")}>
                 {Component}
               </Tooltip>
             )
@@ -225,7 +226,7 @@ const useColumns = () => {
       }),
       ...base,
     ],
-    [base]
+    [base, t]
   )
 }
 

--- a/packages/admin/src/pages/promotions/common/edit-rules/components/rules-form-field/rules-form-field.tsx
+++ b/packages/admin/src/pages/promotions/common/edit-rules/components/rules-form-field/rules-form-field.tsx
@@ -314,7 +314,7 @@ export const RulesFormField = ({
                                   className="bg-ui-bg-base"
                                   data-testid={`rules-form-field-rule-${ruleType}-${index}-operator-select-trigger`}
                                 >
-                                  <Select.Value placeholder="Select Operator" />
+                                  <Select.Value placeholder={t('promotions.form.selectOperator')} />
                                 </Select.Trigger>
 
                                 <Select.Content

--- a/packages/admin/src/pages/promotions/promotion-create/components/create-promotion-form/promotion-details-tab.tsx
+++ b/packages/admin/src/pages/promotions/promotion-create/components/create-promotion-form/promotion-details-tab.tsx
@@ -587,16 +587,8 @@ const Root = ({ currentTemplate }: PromotionDetailsTabProps) => {
 
                       <RadioGroup.ChoiceBox
                         value="once"
-                        label={t("promotions.form.allocation.once.title", {
-                          defaultValue: "Once",
-                        })}
-                        description={t(
-                          "promotions.form.allocation.once.description",
-                          {
-                            defaultValue:
-                              "Limit discount to max quantity",
-                          }
-                        )}
+                        label={t("promotions.form.allocation.once.title")}
+                        description={t("promotions.form.allocation.once.description")}
                         className={clx("basis-1/2")}
                         data-testid="promotion-create-form-allocation-option-once"
                       />

--- a/packages/admin/src/pages/promotions/promotion-detail/components/campaign-section/campaign-section.tsx
+++ b/packages/admin/src/pages/promotions/promotion-detail/components/campaign-section/campaign-section.tsx
@@ -87,11 +87,11 @@ export const CampaignSection = ({
         <div data-testid="promotion-campaign-section-no-records">
           <NoRecords
             className="h-[180px] pt-4 text-center"
-            title="Not part of a campaign"
-            message="Add this promotion to an existing campaign"
+            title={t("promotions.campaignSection.noRecordsTitle")}
+            message={t("promotions.campaignSection.noRecordsMessage")}
             action={{
               to: `/promotions/${id}/add-to-campaign`,
-              label: "Add to Campaign",
+              label: t("promotions.campaignSection.addToCampaign"),
             }}
             buttonVariant="transparentIconLeft"
             dataTestId="promotion-campaign-section-add-to-campaign-button"

--- a/packages/admin/src/pages/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
+++ b/packages/admin/src/pages/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
@@ -414,13 +414,8 @@ return (
 
                         <RadioGroup.ChoiceBox
                           value="once"
-                          label={t("promotions.form.allocation.once.title", {
-                            defaultValue: "Once",
-                          })}
-                          description={t(
-                            "promotions.form.allocation.once.description",
-                            { defaultValue: "Limit discount to max quantity" }
-                          )}
+                          label={t("promotions.form.allocation.once.title")}
+                          description={t("promotions.form.allocation.once.description")}
                           data-testid="promotion-edit-details-form-allocation-option-once"
                         />
                           </RadioGroup>

--- a/packages/admin/src/pages/stores/store-address-edit/components/store-address-edit-form.tsx
+++ b/packages/admin/src/pages/stores/store-address-edit/components/store-address-edit-form.tsx
@@ -118,7 +118,7 @@ export const StoreAddressEditForm = ({
             render={({ field }) => (
               <Form.Item>
                 <Form.Label optional>
-                  {t("store.address.apartmentLabel", "Apartment, suite, etc.")}
+                  {t("store.address.apartmentLabel")}
                 </Form.Label>
                 <Form.Control>
                   <Input size="small" {...field} />

--- a/packages/admin/src/pages/stores/store-create/components/store-create-details-tab.tsx
+++ b/packages/admin/src/pages/stores/store-create/components/store-create-details-tab.tsx
@@ -83,7 +83,7 @@ const Root = () => {
                 <Form.Control>
                   <Select {...field} onValueChange={onChange}>
                     <Select.Trigger ref={ref}>
-                      <Select.Value placeholder={t("fields.selectPlaceholder", "Select")} />
+                      <Select.Value placeholder={t("fields.selectPlaceholder")} />
                     </Select.Trigger>
                     <Select.Content>
                       {store?.supported_currencies?.map((sc) => (

--- a/packages/admin/src/pages/stores/store-create/components/store-create-form.tsx
+++ b/packages/admin/src/pages/stores/store-create/components/store-create-form.tsx
@@ -50,7 +50,7 @@ export const StoreCreateForm = ({ children }: StoreCreateFormProps) => {
       });
 
       toast.success(
-        t("stores.create.successToast", "Store was successfully created."),
+        t("stores.create.successToast"),
       );
       handleSuccess();
     } catch (error) {

--- a/packages/admin/src/pages/stores/store-details/components/store-members-section/store-members-data-table.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-members-section/store-members-data-table.tsx
@@ -169,7 +169,7 @@ export const StoreMembersDataTable = ({
         { key: "updated_at", label: t("fields.updatedAt") },
       ]}
       noRecords={{
-        title: t("stores.emptyStates.users.title", "No users yet"),
+        title: t("stores.emptyStates.users.title"),
         message: t(
           "stores.emptyStates.users.message",
           "Invite the first user to manage this store.",
@@ -202,7 +202,7 @@ const useColumns = (sellerId: string) => {
                 color="grey"
                 className="flex-shrink-0"
               >
-                {t("stores.members.mainAdmin", "Admin")}
+                {t("stores.members.mainAdmin")}
               </Badge>
             )}
           </div>

--- a/packages/admin/src/pages/stores/store-details/components/store-members-section/store-members-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-members-section/store-members-section.tsx
@@ -14,10 +14,10 @@ export const StoreMembersSection = ({ sellerId }: StoreMembersSectionProps) => {
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
-        <Heading level="h2">{t("users.domain", "Users")}</Heading>
+        <Heading level="h2">{t("users.domain")}</Heading>
         <Link to="invite">
           <Button size="small" variant="secondary">
-            {t("stores.members.addUser.action", "Add")}
+            {t("stores.members.addUser.action")}
           </Button>
         </Link>
       </div>

--- a/packages/admin/src/pages/stores/store-details/components/store-orders-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-orders-section.tsx
@@ -85,7 +85,7 @@ export const StoreOrdersSection = ({ sellerId }: StoreOrdersSectionProps) => {
         queryObject={raw}
         prefix={PREFIX}
         noRecords={{
-          title: t("stores.emptyStates.orders.title", "No orders yet"),
+          title: t("stores.emptyStates.orders.title"),
           message: t(
             "stores.emptyStates.orders.message",
             "Orders placed at this store will appear here.",

--- a/packages/admin/src/pages/stores/store-details/components/store-products-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-products-section.tsx
@@ -79,7 +79,7 @@ export const StoreProductsSection = ({
         pagination
         prefix={PREFIX}
         noRecords={{
-          title: t("stores.emptyStates.products.title", "No products yet"),
+          title: t("stores.emptyStates.products.title"),
           message: t(
             "stores.emptyStates.products.message",
             "Products published by this store will appear here.",

--- a/packages/admin/src/pages/stores/store-details/components/store-request-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-request-section.tsx
@@ -71,7 +71,7 @@ export const StoreRequestSection = ({ seller }: StoreRequestSectionProps) => {
               {t("stores.request.confirm")}
             </Button>
           }
-          title={t("stores.request.confirmTitle", "Confirm request")}
+          title={t("stores.request.confirmTitle")}
           description={t(
             "stores.request.confirmDescription",
             "You are about to confirm this store request.",
@@ -98,7 +98,7 @@ export const StoreRequestSection = ({ seller }: StoreRequestSectionProps) => {
               {t("stores.request.reject")}
             </Button>
           }
-          title={t("stores.request.rejectTitle", "Reject request")}
+          title={t("stores.request.rejectTitle")}
           description={t(
             "stores.request.rejectDescription",
             "You are about to reject this store request.",
@@ -168,9 +168,9 @@ const RequestActionPrompt = ({
         <div className="border-ui-border-base border-t mt-3" />
         <div className="flex flex-col gap-y-3 px-6 py-3">
           <Text size="small" weight="plus" className="text-ui-fg-base">
-            {t("stores.request.noteLabel", "Notes for vendor")}{" "}
+            {t("stores.request.noteLabel")}{" "}
             <span className="text-ui-fg-muted font-normal">
-              ({t("fields.optional", "Optional")})
+              ({t("fields.optional")})
             </span>
           </Text>
           <Textarea

--- a/packages/admin/src/pages/stores/store-list/components/store-list-table/store-list-header.tsx
+++ b/packages/admin/src/pages/stores/store-list/components/store-list-table/store-list-header.tsx
@@ -4,9 +4,10 @@ import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
 
 export const StoreListTitle = () => {
+  const { t } = useTranslation()
   return (
     <div>
-      <Heading level="h2">Stores</Heading>
+      <Heading level="h2">{t("stores.domain")}</Heading>
     </div>
   )
 }

--- a/packages/admin/src/pages/stores/store-member-invite/components/invite-member-form.tsx
+++ b/packages/admin/src/pages/stores/store-member-invite/components/invite-member-form.tsx
@@ -206,7 +206,7 @@ export const InviteMemberForm = () => {
                 <Form.Control>
                   <Select {...field} onValueChange={onChange}>
                     <Select.Trigger ref={ref}>
-                      <Select.Value placeholder={t("fields.selectPlaceholder", "Select")} />
+                      <Select.Value placeholder={t("fields.selectPlaceholder")} />
                     </Select.Trigger>
                     <Select.Content>
                       {ROLE_OPTIONS.map((role) => (

--- a/packages/vendor/src/components/filtering/filter-group/filter-group.tsx
+++ b/packages/vendor/src/components/filtering/filter-group/filter-group.tsx
@@ -1,5 +1,6 @@
 import { Button, DropdownMenu } from "@medusajs/ui"
 import { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
 import { useDocumentDirection } from "../../../hooks/use-document-direction"
 
@@ -10,6 +11,7 @@ type FilterGroupProps = {
 }
 
 export const FilterGroup = ({ filters }: FilterGroupProps) => {
+  const { t } = useTranslation()
   const [searchParams] = useSearchParams()
   const filterKeys = Object.keys(filters)
 
@@ -26,7 +28,7 @@ export const FilterGroup = ({ filters }: FilterGroupProps) => {
       {hasMore && <AddFilterMenu availableKeys={availableKeys} />}
       {isClearable && (
         <Button variant="transparent" size="small">
-          Clear all
+          {t("actions.clearAll")}
         </Button>
       )}
     </div>
@@ -38,6 +40,7 @@ type AddFilterMenuProps = {
 }
 
 const AddFilterMenu = ({ availableKeys }: AddFilterMenuProps) => {
+  const { t } = useTranslation()
   const direction = useDocumentDirection()
   return (
     <DropdownMenu
@@ -45,7 +48,7 @@ const AddFilterMenu = ({ availableKeys }: AddFilterMenuProps) => {
     >
       <DropdownMenu.Trigger asChild>
         <Button variant="secondary" size="small">
-          Add filter
+          {t("filters.addFilter")}
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>

--- a/packages/vendor/src/components/forms/metadata-form/metadata-form.tsx
+++ b/packages/vendor/src/components/forms/metadata-form/metadata-form.tsx
@@ -189,7 +189,7 @@ const InnerForm = <TRes,>({
                                   aria-labelledby={METADATA_KEY_LABEL_ID}
                                   {...field}
                                   disabled={isDisabled}
-                                  placeholder="Key"
+                                  placeholder={t("metadata.edit.labels.key")}
                                 />
                               </Form.Control>
                             </Form.Item>
@@ -208,7 +208,7 @@ const InnerForm = <TRes,>({
                                   {...field}
                                   value={isDisabled ? placeholder : value}
                                   disabled={isDisabled}
-                                  placeholder="Value"
+                                  placeholder={t("metadata.edit.labels.value")}
                                 />
                               </Form.Control>
                             </Form.Item>

--- a/packages/vendor/src/components/table/data-table/data-table-filter/data-table-filter.tsx
+++ b/packages/vendor/src/components/table/data-table/data-table-filter/data-table-filter.tsx
@@ -232,6 +232,7 @@ type ClearAllFiltersProps = {
 }
 
 const ClearAllFilters = ({ filters, prefix }: ClearAllFiltersProps) => {
+  const { t } = useTranslation()
   const { removeAllFilters } = useDataTableFilterContext()
   const [_, setSearchParams] = useSearchParams()
 
@@ -259,7 +260,7 @@ const ClearAllFilters = ({ filters, prefix }: ClearAllFiltersProps) => {
         "focus-visible:shadow-borders-focus"
       )}
     >
-      Clear all
+      {t("actions.clearAll")}
     </button>
   )
 }

--- a/packages/vendor/src/components/table/data-table/data-table-filter/select-filter.tsx
+++ b/packages/vendor/src/components/table/data-table/data-table-filter/select-filter.tsx
@@ -138,7 +138,7 @@ export const SelectFilter = ({
                       value={search}
                       onValueChange={setSearch}
                       className="txt-compact-small placeholder:text-ui-fg-muted bg-transparent outline-none"
-                      placeholder="Search"
+                      placeholder={t("general.search")}
                     />
                     <div className="flex h-5 w-5 items-center justify-center">
                       <button

--- a/packages/vendor/src/components/table/save-view-dropdown/save-view-dropdown.tsx
+++ b/packages/vendor/src/components/table/save-view-dropdown/save-view-dropdown.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useTranslation } from "react-i18next"
 import {
   DropdownMenu,
   Button,
@@ -26,14 +27,15 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
   onUpdateExisting,
   onSaveAsNew,
 }) => {
+  const { t } = useTranslation()
   const prompt = usePrompt()
 
   const handleSaveAsDefault = async () => {
     const result = await prompt({
-      title: "Save as system default",
-      description: "This will save the current configuration as the system default. All users will see this configuration by default unless they have their own personal views. Are you sure?",
-      confirmText: "Save as default",
-      cancelText: "Cancel",
+      title: t("views.prompts.saveAsDefault.title"),
+      description: t("views.prompts.saveAsDefault.description"),
+      confirmText: t("views.prompts.saveAsDefault.confirmText"),
+      cancelText: t("views.prompts.saveAsDefault.cancelText"),
     })
 
     if (result && onSaveAsDefault) {
@@ -43,10 +45,12 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
 
   const handleUpdateExisting = async () => {
     const result = await prompt({
-      title: "Update existing view",
-      description: `Update "${currentViewName}" with the current configuration?`,
-      confirmText: "Update",
-      cancelText: "Cancel",
+      title: t("views.prompts.updateExisting.title"),
+      description: t("views.prompts.updateExisting.description", {
+        name: currentViewName,
+      }),
+      confirmText: t("views.prompts.updateExisting.confirmText"),
+      cancelText: t("views.prompts.updateExisting.cancelText"),
     })
 
     if (result && onUpdateExisting) {
@@ -58,26 +62,26 @@ export const SaveViewDropdown: React.FC<SaveViewDropdownProps> = ({
     <DropdownMenu>
       <DropdownMenu.Trigger asChild>
         <Button variant="secondary" size="small">
-          Save
+          {t("views.save")}
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
         {isDefaultView && onSaveAsDefault && (
           <DropdownMenu.Item onClick={handleSaveAsDefault}>
             <CloudArrowUp className="h-4 w-4" />
-            Save as system default
+            {t("views.saveAsSystemDefault")}
           </DropdownMenu.Item>
         )}
         {!isDefaultView && currentViewId && onUpdateExisting && (
           <DropdownMenu.Item onClick={handleUpdateExisting}>
             <CloudArrowUp className="h-4 w-4" />
-            Update "{currentViewName}"
+            {t("views.updateNamed", { name: currentViewName })}
           </DropdownMenu.Item>
         )}
         {onSaveAsNew && (
           <DropdownMenu.Item onClick={onSaveAsNew}>
             <SquarePlusMicro className="h-4 w-4" />
-            Save as new view
+            {t("views.saveAsNew")}
           </DropdownMenu.Item>
         )}
       </DropdownMenu.Content>

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -129,6 +129,7 @@
     "duplicate": "Duplicate",
     "publish": "Publish",
     "create": "Create",
+    "request": "Request",
     "delete": "Delete",
     "remove": "Remove",
     "revoke": "Revoke",
@@ -916,6 +917,7 @@
     "createCollection": "Create Collection",
     "createCollectionHint": "Create a new collection to organize your products.",
     "createSuccess": "Collection created successfully.",
+    "requestSuccess": "Collection requested successfully",
     "editCollection": "Edit Collection",
     "handleTooltip": "The handle is used to reference the collection in your storefront. If not specified, the handle will be generated from the collection title.",
     "deleteWarning": "You are about to delete the collection {{title}}. This action cannot be undone.",
@@ -1053,6 +1055,7 @@
       "attributes": "Attributes",
       "requiresShipping": "Requires shipping",
       "requiresShippingHint": "Does the inventory item require shipping?",
+      "descriptionPlaceholder": "The item description",
       "successToast": "Inventory item was successfully created."
     },
     "reservation": {
@@ -1104,6 +1107,7 @@
     "subtitle": "Manage your catalog listings",
     "create": {
       "header": "Create offer",
+      "description": "Select variants and configure stock levels and prices to create offers.",
       "successToast": "Offer was successfully published. Only offers with stock levels and prices set will be visible on the storefront.",
       "publish": "Publish",
       "tipLabel": "Tip:",
@@ -1478,6 +1482,7 @@
         "partiallyCaptured": "Partially captured",
         "refunded": "Refunded",
         "canceled": "Canceled",
+        "pending": "Pending",
         "requiresAction": "Requires action"
       },
       "capturePayment": "Payment of {{amount}} will be captured.",
@@ -2540,10 +2545,16 @@
     "campaign_currency": {
       "tooltip": "This is the promotion's currency. Change it from the Details tab."
     },
+    "campaignSection": {
+      "noRecordsTitle": "Not part of a campaign",
+      "noRecordsMessage": "Add this promotion to an existing campaign",
+      "addToCampaign": "Add to Campaign"
+    },
     "form": {
       "required": "Required",
       "and": "AND",
       "selectAttribute": "Select Attribute",
+      "selectOperator": "Select Operator",
       "campaign": {
         "existing": {
           "title": "Existing Campaign",
@@ -2810,10 +2821,17 @@
         "successToast_other": "Successfully deleted prices for {{count}} products."
       },
       "add": {
-        "successToast": "Prices were successfully added to the price list."
+        "successToast": "Prices were successfully added to the price list.",
+        "atLeastOnePrice": "At least one price must be added.",
+        "alreadyInPriceList": "This product is already in the price list",
+        "noVariants": "This product has no variants",
+        "title": "Add Products to Price List",
+        "description": "Add products and set prices for the price list"
       },
       "edit": {
-        "successToast": "Prices were successfully updated."
+        "successToast": "Prices were successfully updated.",
+        "title": "Edit Prices for {{title}}",
+        "description": "Update prices for products in the price list"
       }
     },
     "fields": {
@@ -3742,8 +3760,10 @@
     "subtitle": "Organize your products into types.",
     "create": {
       "header": "Create Product Type",
+      "requestHeader": "Request Product Type",
       "hint": "Create a new product type to categorize your products.",
-      "successToast": "Product type {{value}} was successfully created."
+      "successToast": "Product type {{value}} was successfully created.",
+      "requestSuccessToast": "Product type requested successfully"
     },
     "edit": {
       "header": "Edit Product Type",
@@ -4025,8 +4045,10 @@
   "views": {
     "save": "Save",
     "saveAsNew": "Save as new view",
+    "saveAsSystemDefault": "Save as system default",
     "updateDefaultForEveryone": "Update default for everyone",
     "updateViewName": "Update view",
+    "updateNamed": "Update \"{{name}}\"",
     "prompts": {
       "updateDefault": {
         "title": "Update default view",
@@ -4037,6 +4059,18 @@
       "updateView": {
         "title": "Update view",
         "description": "Are you sure you want to update \"{{name}}\"?",
+        "confirmText": "Update",
+        "cancelText": "Cancel"
+      },
+      "saveAsDefault": {
+        "title": "Save as system default",
+        "description": "This will save the current configuration as the system default. All users will see this configuration by default unless they have their own personal views. Are you sure?",
+        "confirmText": "Save as default",
+        "cancelText": "Cancel"
+      },
+      "updateExisting": {
+        "title": "Update existing view",
+        "description": "Update \"{{name}}\" with the current configuration?",
         "confirmText": "Update",
         "cancelText": "Cancel"
       }

--- a/packages/vendor/src/pages/categories/_components/category-list-table/category-list-header.tsx
+++ b/packages/vendor/src/pages/categories/_components/category-list-table/category-list-header.tsx
@@ -8,7 +8,7 @@ export const CategoryListTitle = () => {
     <div>
       <Heading>{t("categories.domain")}</Heading>
       <Text className="text-ui-fg-subtle" size="small">
-        Organize products into categories.
+        {t("categories.subtitle")}
       </Text>
     </div>
   );

--- a/packages/vendor/src/pages/collections/create/create-collection-form/create-collection-form.tsx
+++ b/packages/vendor/src/pages/collections/create/create-collection-form/create-collection-form.tsx
@@ -36,7 +36,7 @@ export const CreateCollectionForm = () => {
     await mutateAsync(data, {
       onSuccess: () => {
         handleSuccess()
-        toast.success("Collection requested successfully")
+        toast.success(t("collections.requestSuccess"))
       },
       onError: (error) => {
         toast.error(error.message)

--- a/packages/vendor/src/pages/inventory/create/inventory-create-form/inventory-create-form.tsx
+++ b/packages/vendor/src/pages/inventory/create/inventory-create-form/inventory-create-form.tsx
@@ -297,7 +297,7 @@ export function InventoryCreateForm({ locations }: InventoryCreateFormProps) {
                             <Form.Control>
                               <Textarea
                                 {...field}
-                                placeholder="The item description"
+                                placeholder={t("inventory.create.descriptionPlaceholder")}
                               />
                             </Form.Control>
                           </Form.Item>

--- a/packages/vendor/src/pages/offers/create/offer-create-page.tsx
+++ b/packages/vendor/src/pages/offers/create/offer-create-page.tsx
@@ -1,18 +1,21 @@
+import { useTranslation } from "react-i18next"
 import { RouteFocusModal } from "../../../components/modals"
 import { CreateOfferForm } from "./create-offer-form"
 
-export const OfferCreatePage = () => (
-  <RouteFocusModal>
-    <RouteFocusModal.Title asChild>
-      <span className="sr-only">Create offer</span>
-    </RouteFocusModal.Title>
-    <RouteFocusModal.Description asChild>
-      <span className="sr-only">
-        Select variants and configure stock levels and prices to create offers.
-      </span>
-    </RouteFocusModal.Description>
-    <CreateOfferForm />
-  </RouteFocusModal>
-)
+export const OfferCreatePage = () => {
+  const { t } = useTranslation()
+
+  return (
+    <RouteFocusModal>
+      <RouteFocusModal.Title asChild>
+        <span className="sr-only">{t("offers.create.header")}</span>
+      </RouteFocusModal.Title>
+      <RouteFocusModal.Description asChild>
+        <span className="sr-only">{t("offers.create.description")}</span>
+      </RouteFocusModal.Description>
+      <CreateOfferForm />
+    </RouteFocusModal>
+  )
+}
 
 export const Component = OfferCreatePage

--- a/packages/vendor/src/pages/orders/[id]/_components/order-payment-section/order-payment-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-payment-section/order-payment-section.tsx
@@ -129,24 +129,24 @@ const Total = ({ order }: { order: HttpTypes.AdminOrder }) => {
 
 const getPaymentStatus = (
   payment: HttpTypes.AdminPayment
-): { label: string; color: "green" | "orange" | "red" | "grey" } => {
+): { labelKey: string; color: "green" | "orange" | "red" | "grey" } => {
   const refundedAmount = (payment.refunds ?? []).reduce(
     (acc: number, r: { amount?: number }) => acc + (r.amount ?? 0),
     0
   )
   if (payment.canceled_at) {
-    return { label: "Canceled", color: "red" }
+    return { labelKey: "orders.payment.status.canceled", color: "red" }
   }
   if (refundedAmount > 0 && refundedAmount >= (payment.amount as number)) {
-    return { label: "Refunded", color: "grey" }
+    return { labelKey: "orders.payment.status.refunded", color: "grey" }
   }
   if (refundedAmount > 0) {
-    return { label: "Partly refunded", color: "orange" }
+    return { labelKey: "orders.payment.status.partiallyRefunded", color: "orange" }
   }
   if (payment.captured_at) {
-    return { label: "Captured", color: "green" }
+    return { labelKey: "orders.payment.status.captured", color: "green" }
   }
-  return { label: "Pending", color: "orange" }
+  return { labelKey: "orders.payment.status.pending", color: "orange" }
 }
 
 const PaymentRow = ({
@@ -205,7 +205,7 @@ const PaymentRow = ({
 
         <div className="flex items-center gap-x-3">
           <StatusBadge color={status.color} className="text-nowrap">
-            {status.label}
+            {t(status.labelKey)}
           </StatusBadge>
           <Text
             size="small"

--- a/packages/vendor/src/pages/price-lists/[id]/products/[variant_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/products/[variant_id]/edit/index.tsx
@@ -1,4 +1,5 @@
 // Route: /price-lists/:id/products/:variant_id/edit
+import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 import { RouteFocusModal } from "@components/modals"
 import { usePriceList, usePriceListProducts } from "@hooks/api/price-lists"
@@ -6,6 +7,7 @@ import { usePriceListCurrencyData } from "../../../../common/hooks/use-price-lis
 import { PriceListPricesEditForm } from "./price-list-prices-edit-form"
 
 export const Component = () => {
+  const { t } = useTranslation()
   const { id } = useParams()
   const { price_list, isLoading, isError, error } = usePriceList(id!)
 
@@ -36,10 +38,12 @@ export const Component = () => {
   return (
     <RouteFocusModal>
       <RouteFocusModal.Title asChild>
-        <span className="sr-only">Edit Prices for {price_list?.title}</span>
+        <span className="sr-only">
+          {t("priceLists.products.edit.title", { title: price_list?.title })}
+        </span>
       </RouteFocusModal.Title>
       <RouteFocusModal.Description className="sr-only">
-        Update prices for products in the price list
+        {t("priceLists.products.edit.description")}
       </RouteFocusModal.Description>
       {ready && (
         <PriceListPricesEditForm

--- a/packages/vendor/src/pages/price-lists/[id]/products/add/index.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/products/add/index.tsx
@@ -1,4 +1,5 @@
 // Route: /price-lists/:id/products/add
+import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 import { RouteFocusModal } from "@components/modals"
 import { usePriceList } from "@hooks/api/price-lists"
@@ -6,6 +7,7 @@ import { usePriceListCurrencyData } from "../../../common/hooks/use-price-list-c
 import { PriceListPricesAddForm } from "./price-list-prices-add-form"
 
 export const Component = () => {
+  const { t } = useTranslation()
   const { id } = useParams<{ id: string }>()
 
   const { price_list, isPending, isError, error } = usePriceList(id!)
@@ -20,10 +22,10 @@ export const Component = () => {
   return (
     <RouteFocusModal>
       <RouteFocusModal.Title asChild>
-        <span className="sr-only">Add Products to Price List</span>
+        <span className="sr-only">{t("priceLists.products.add.title")}</span>
       </RouteFocusModal.Title>
       <RouteFocusModal.Description className="sr-only">
-        Add products and set prices for the price list
+        {t("priceLists.products.add.description")}
       </RouteFocusModal.Description>
       {ready && (
         <PriceListPricesAddForm priceList={price_list} {...currencyData} />

--- a/packages/vendor/src/pages/price-lists/[id]/products/add/price-list-prices-add-form/price-list-prices-add-form.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/products/add/price-list-prices-add-form/price-list-prices-add-form.tsx
@@ -84,7 +84,7 @@ export const PriceListPricesAddForm = ({
     },
     (errors) => {
       if (errors.products) {
-        toast.error("At least one price must be added.");
+        toast.error(t("priceLists.products.add.atLeastOnePrice"));
       }
     },
   );

--- a/packages/vendor/src/pages/price-lists/[id]/products/add/price-list-prices-add-form/price-list-prices-add-product-ids-form.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/products/add/price-list-prices-add-form/price-list-prices-add-product-ids-form.tsx
@@ -163,6 +163,7 @@ export const PriceListPricesAddProductIdsForm = ({
 const columnHelper = createColumnHelper<HttpTypes.AdminProduct>();
 
 const useColumns = () => {
+  const { t } = useTranslation();
   const base = useProductTableColumns();
 
   return useMemo(
@@ -207,7 +208,7 @@ const useColumns = () => {
 
           if (isPreselected) {
             return (
-              <Tooltip content="This product is already in the price list">
+              <Tooltip content={t("priceLists.products.add.alreadyInPriceList")}>
                 {Component}
               </Tooltip>
             );
@@ -215,7 +216,7 @@ const useColumns = () => {
 
           if (isDisabled) {
             return (
-              <Tooltip content="This product has no variants">
+              <Tooltip content={t("priceLists.products.add.noVariants")}>
                 {Component}
               </Tooltip>
             );
@@ -226,6 +227,6 @@ const useColumns = () => {
       }),
       ...base,
     ],
-    [base],
+    [base, t],
   );
 };

--- a/packages/vendor/src/pages/price-lists/[id]/products/edit/index.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/products/edit/index.tsx
@@ -1,10 +1,12 @@
 import { RouteFocusModal } from "@/components/modals";
+import { useTranslation } from "react-i18next";
 import { useParams, useSearchParams } from "react-router-dom";
 import { PriceListPricesEditForm } from "../[variant_id]/edit/price-list-prices-edit-form";
 import { usePriceListCurrencyData } from "@/pages/price-lists/common/hooks/use-price-list-currency-data";
 import { usePriceList, useProducts } from "@/hooks/api";
 
 export const Component = () => {
+  const { t } = useTranslation();
   const { id } = useParams();
   const [searchParams] = useSearchParams();
   const ids = searchParams.get("ids[]");
@@ -46,10 +48,12 @@ export const Component = () => {
   return (
     <RouteFocusModal>
       <RouteFocusModal.Title asChild>
-        <span className="sr-only">Edit Prices for {price_list?.title}</span>
+        <span className="sr-only">
+          {t("priceLists.products.edit.title", { title: price_list?.title })}
+        </span>
       </RouteFocusModal.Title>
       <RouteFocusModal.Description className="sr-only">
-        Update prices for products in the price list
+        {t("priceLists.products.edit.description")}
       </RouteFocusModal.Description>
       {ready && (
         <PriceListPricesEditForm

--- a/packages/vendor/src/pages/price-lists/create/index.tsx
+++ b/packages/vendor/src/pages/price-lists/create/index.tsx
@@ -1,19 +1,21 @@
 // Route: /price-lists/create
+import { useTranslation } from "react-i18next"
 import { RouteFocusModal } from "@components/modals"
 import { usePriceListCurrencyData } from "../common/hooks/use-price-list-currency-data"
 import { PriceListCreateForm } from "./price-list-create-form"
 
 export const Component = () => {
+  const { t } = useTranslation()
   const { isReady, regions, currencies, pricePreferences } =
     usePriceListCurrencyData()
 
   return (
     <RouteFocusModal>
       <RouteFocusModal.Title asChild>
-        <span className="sr-only">Create Price List</span>
+        <span className="sr-only">{t("priceLists.create.header")}</span>
       </RouteFocusModal.Title>
       <RouteFocusModal.Description className="sr-only">
-        Create a new price list with custom pricing
+        {t("priceLists.create.subheader")}
       </RouteFocusModal.Description>
       {isReady && (
         <PriceListCreateForm

--- a/packages/vendor/src/pages/promotions/[id]/_components/campaign-section/campaign-section.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/_components/campaign-section/campaign-section.tsx
@@ -78,11 +78,11 @@ export const CampaignSection = ({
       ) : (
         <NoRecords
           className="h-[180px] pt-4 text-center"
-          title="Not part of a campaign"
-          message="Add this promotion to an existing campaign"
+          title={t("promotions.campaignSection.noRecordsTitle")}
+          message={t("promotions.campaignSection.noRecordsMessage")}
           action={{
             to: `/promotions/${id}/add-to-campaign`,
-            label: "Add to Campaign",
+            label: t("promotions.campaignSection.addToCampaign"),
           }}
           buttonVariant="transparentIconLeft"
         />

--- a/packages/vendor/src/pages/promotions/common/edit-rules/components/rules-form-field/rules-form-field.tsx
+++ b/packages/vendor/src/pages/promotions/common/edit-rules/components/rules-form-field/rules-form-field.tsx
@@ -268,7 +268,7 @@ export const RulesFormField = ({
                                   ref={ref}
                                   className="bg-ui-bg-base"
                                 >
-                                  <Select.Value placeholder="Select Operator" />
+                                  <Select.Value placeholder={t('promotions.form.selectOperator')} />
                                 </Select.Trigger>
 
                                 <Select.Content>

--- a/packages/vendor/src/pages/settings/locations/[location_id]/edit/_components/edit-location-form.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/edit/_components/edit-location-form.tsx
@@ -62,7 +62,7 @@ export const EditLocationForm = ({ location }: EditLocationFormProps) => {
       },
       {
         onSuccess: () => {
-          toast.success("Stock location updated")
+          toast.success(t("locations.toast.update"))
           handleSuccess()
         },
         onError: (e) => {

--- a/packages/vendor/src/pages/settings/product-types/create/_components/create-product-type-form.tsx
+++ b/packages/vendor/src/pages/settings/product-types/create/_components/create-product-type-form.tsx
@@ -32,7 +32,7 @@ export const CreateProductTypeForm = () => {
     async (values: z.infer<typeof CreateProductTypeSchema>) => {
       await mutateAsync(values, {
         onSuccess: () => {
-          toast.success("Product type requested successfully")
+          toast.success(t("productTypes.create.requestSuccessToast"))
 
           handleSuccess()
         },
@@ -62,14 +62,14 @@ export const CreateProductTypeForm = () => {
               type="submit"
               isLoading={isPending}
             >
-              Request
+              {t("actions.request")}
             </Button>
           </div>
         </RouteFocusModal.Header>
         <RouteFocusModal.Body className="flex flex-col items-center overflow-y-auto p-16">
           <div className="flex w-full max-w-[720px] flex-col gap-y-8">
             <div>
-              <Heading>Request Product Type</Heading>
+              <Heading>{t("productTypes.create.requestHeader")}</Heading>
               <Text size="small" className="text-ui-fg-subtle">
                 {t("productTypes.create.hint")}
               </Text>


### PR DESCRIPTION
## What

Audited `packages/admin` and `packages/vendor` for user-facing text that bypassed the `useTranslation()` / `t()` system and routed it through i18n. Existing translation keys are reused wherever they exist; new keys are added only to each package's `en.json`.

## Changes

**Shared components (both dashboards)**
- `save-view-dropdown` — wired all prompt/menu strings to the pre-existing (but unused) `views.*` block, extended with `saveAsDefault` / `updateExisting` / `updateNamed` / `saveAsSystemDefault`
- `filter-group` → `actions.clearAll`, `filters.addFilter`
- `metadata-form` → `metadata.edit.labels.key/value`
- `select-filter` → `general.search`
- vendor `data-table-filter` "Clear all" → `actions.clearAll`

**Fully untranslated literals**
- promotions campaign-section `NoRecords`, rules "Select Operator" placeholder
- price-list add-product tooltips, inventory description placeholder
- admin store-list heading, order "Total pending" / "orders in group"
- inventory / api-key column headers, tax `type-cell` badge (reuses `taxRegions.fields.isCombinable.true`), marketplace placeholder

**Vendor pages**
- category subtitle, product-type / collection / location toasts, price-list "at least one price" validation
- order payment status labels (refactored `getPaymentStatus` to return a translation key)
- `sr-only` modal titles for offers and price-list create/add/edit

**Fallback cleanup**
- stripped ~40 `t("key", "English default")` / `{ defaultValue }` fallbacks across stores, attributes, commissions, promotions and orders (verified each key resolves in `en.json`)

## Left intentionally as-is
zod validation messages, `aria-label`s, pure format-example placeholders (`KR-26`, `SUMMER15`), `toast.error(e.message)`, and the dynamic-key `"-"` fallback in `campaign-details.tsx`.

## Notes
- Only `en.json` is updated; other locale files are untouched.
- New keys are **not** mirrored into `$schema.json`. The i18n `$schema.json` parity test is already red on `canary` (pre-existing key drift in both directions), so this PR does not touch it to keep the change focused; a schema resync can follow separately.

## Verification
- Both `en.json` files validate as JSON
- `tsc` shows no new type errors from these changes (fixed two `useColumns` closures that needed `t` in scope)