### PR TITLE
feat(release): add rc release candidate channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           if [[ "${{ github.ref_name }}" == *canary* ]]; then
             echo "tag=canary" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref_name }}" == *rc* ]]; then
+            echo "tag=rc" >> "$GITHUB_OUTPUT"
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,6 +3,8 @@
 All packages are published under the `@mercurjs` scope on npm.
 
 - **Stable** releases use the `latest` npm tag (default)
+- **Release candidate** (`rc`) releases use the `rc` npm tag — a preview of an
+  upcoming stable release, published for testing before it is promoted
 - **Canary** releases use the `canary` npm tag
 
 ## Published Packages
@@ -118,11 +120,59 @@ git push origin canary --tags
 
 5. The GitHub Action detects `canary` in the tag name and publishes with `--tag canary`.
 
+### Release Candidate
+
+A release candidate is a preview of an upcoming stable release. It is believed
+shippable and is published so it can be tested before being promoted to
+`latest`. Once an `rc` is verified, cut the stable release with the same
+`2.X.Y` version (dropping the `-rc.Z` suffix).
+
+1. Bump the version in every package's `package.json`:
+
+```
+"version": "2.X.Y-rc.Z"
+```
+
+Where `Z` is the next incremental number (0, 1, 2, ...).
+
+   Also bump every internal `@mercurjs/*` cross-dependency in `packages/*` and
+   `packages/providers/*` to the same `2.X.Y-rc.Z` (see [Internal Dependencies](#internal-dependencies)).
+
+2. Bump every `@mercurjs/*` dependency version inside the `templates/basic` template to the same `2.X.Y-rc.Z` value:
+
+   - `templates/basic/package.json` — `@mercurjs/dashboard-sdk`, `@mercurjs/dashboard-shared`, `@mercurjs/client`
+   - `templates/basic/packages/api/package.json` — `@mercurjs/core`, `@mercurjs/types`, `@mercurjs/cli`
+   - `templates/basic/apps/admin/package.json` — `@mercurjs/admin`
+   - `templates/basic/apps/vendor/package.json` — `@mercurjs/vendor`
+
+3. Refresh the lockfile so workspace versions match `package.json`:
+
+```bash
+bun install
+```
+
+   Commit the updated `bun.lock` together with the version bumps — CI runs
+   `bun install --frozen-lockfile` and will fail otherwise.
+
+4. Commit and tag:
+
+```bash
+git add -A
+git commit -m "chore: v2.X.Y-rc.Z"
+git tag v2.X.Y-rc.Z
+git push origin canary --tags
+```
+
+5. The GitHub Action detects `rc` in the tag name and publishes with `--tag rc`.
+
 ## Installing Packages
 
 ```bash
 # Stable (latest)
 npm install @mercurjs/cli
+
+# Release candidate
+npm install @mercurjs/cli@rc
 
 # Canary
 npm install @mercurjs/cli@canary
@@ -133,6 +183,9 @@ npm install @mercurjs/cli@canary
 ```
 v2.0.0-canary.0   # first canary
 v2.0.0-canary.1   # second canary
+...
+v2.0.0-rc.0        # first release candidate
+v2.0.0-rc.1        # second release candidate
 ...
 v2.0.0             # stable
 v2.0.1             # patch

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -28,7 +28,9 @@ import waitOn from "wait-on";
 
 import packageJson from "../../package.json";
 
-const DEFAULT_BRANCH = packageJson.version?.includes("-canary") ? "canary" : "main";
+const IS_PRERELEASE =
+  packageJson.version?.includes("-canary") || packageJson.version?.includes("-rc");
+const DEFAULT_BRANCH = IS_PRERELEASE ? "canary" : "main";
 const MIN_SUPPORTED_NODE_VERSION = 20;
 
 const CREATE_TEMPLATES = {


### PR DESCRIPTION
## What

Adds a **release candidate** (`rc`) release channel — a preview of an upcoming stable release, published for testing before promotion to `latest`.

## Changes

- **`.github/workflows/release.yml`** — "Determine npm tag" now maps `v2.X.Y-rc.Z` tags to `--tag rc`. Previously an `rc` tag fell through to the `else` branch and would have published with `--tag latest`, overwriting the stable release with an untested candidate.
- **`packages/cli/src/commands/create.ts`** — `create` chooses its template branch by the CLI's own version. Extended the prerelease check so `-rc` versions (like `-canary`) scaffold from the `canary` branch, where the rc template pins matching `-rc.Z` deps. Without this, `npx @mercurjs/cli@rc create` would have scaffolded the stable `main` template.
- **`RELEASING.md`** — documents the `rc` tag, a Release Candidate section mirroring the canary flow, the `@rc` install command, and the version ladder.

## Result

```bash
npm install @mercurjs/cli@rc
npx @mercurjs/cli@rc create
```

Maturity path on the release track: `rc` → `latest` (stable). Canary remains a parallel continuous track.