### PR TITLE
fix(pages): remove symlink that breaks the registry Pages deploy

### DIFF
--- a/.claude/skills/playwright-skill
+++ b/.claude/skills/playwright-skill
@@ -1,1 +1,0 @@
-../../.agents/skills/playwright-skill


### PR DESCRIPTION
The registry Pages deploy (registry.mercurjs.com, legacy branch deploy of `main`) has failed since #1140 landed: GitHub Pages rejects symlinked content during `syncing_files`, and the promote introduced `.claude/skills/playwright-skill` as a symlink to `.agents/skills/playwright-skill` — the only symlink in the tree.

Removing it unblocks the deploy. The same symlink (and its target) is already removed on `docs/rc-channel-and-brand-styling`, which targets `canary` — once that lands, the next promote won't reintroduce it.