### PR TITLE
fix(ci): deploy registry schemas via slim Pages artifact

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+    # registry.mercurjs.com only serves the two JSON Schema files below, so a
+    # deploy is only needed when they (or the CNAME) change.
+    paths:
+      - registry.json
+      - registry-item.json
+      - CNAME
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never cancel an in-flight deployment; let it finish so Pages doesn't get
+# left in a half-synced state.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy registry schemas
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      # registry.mercurjs.com is only used as the $schema host for the registry
+      # (see packages/cli/src/registry/constants.ts). Publishing just these
+      # files keeps the Pages artifact tiny and symlink-free — the legacy build
+      # published the whole monorepo (node_modules and all), which is what made
+      # the "syncing_files" step fail intermittently.
+      - name: Assemble site
+        run: |
+          mkdir -p _site
+          cp registry.json registry-item.json CNAME _site/
+          touch _site/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Problem

The `pages-build-deployment` runs fail intermittently at the `syncing_files` step with:

```
Current status: syncing_files
Error: Deployment failed, try again later.
```

Pages is configured as a **legacy** build (`build_type: legacy`) deploying from `main` root `/`, so it publishes the **entire monorepo** — thousands of files plus `node_modules` symlinks — just to serve two small JSON Schema files. That oversized, symlink-laden artifact is what makes the sync flaky.

`registry.mercurjs.com` is only used as the `$schema` host for the registry (see `packages/cli/src/registry/constants.ts`); actual blocks are fetched from `raw.githubusercontent.com`. So the site only needs to serve `registry.json` and `registry-item.json`.

## Fix

Add a dedicated GitHub Actions Pages workflow that assembles a minimal `_site/` (the two schema files + `CNAME` + `.nojekyll`) and deploys via `upload-pages-artifact` + `deploy-pages`. Tiny, symlink-free artifact → no more `syncing_files` failures. Runs only when those files change.

## ⚠️ Required manual step

The Pages **source must be switched from "Deploy from a branch" to "GitHub Actions"** for this workflow to take over (Settings → Pages → Build and deployment → Source). I could not change this shared repo setting automatically. The custom domain (`registry.mercurjs.com`) is preserved via the `CNAME` file in the artifact.