### PR TITLE
fix(ci): tolerate transient Pages deploy status errors

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,6 +53,16 @@ jobs:
         with:
           path: _site
 
+      # The deploy itself is reliable; what's flaky is the action's status
+      # poll — GitHub's Pages backend occasionally returns a transient error
+      # while still provisioning, which the action treats as terminal
+      # ("Deployment failed, try again later") even though the deploy then
+      # succeeds. A higher error_count rides through those transient errors
+      # instead of aborting on the first one.
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+        with:
+          timeout: 600000
+          error_count: 25
+          reporting_interval: 5000


### PR DESCRIPTION
## Problem

`Deploy Pages` intermittently fails with:

```
Error: Deployment failed, try again later.
```

The deployment actually **succeeds** server-side — the Pages API reports `{"status":"succeed"}` for the same commit and the site serves `200`. The failure is a false negative: `actions/deploy-pages` polls GitHub's Pages backend for status, and while the backend is still provisioning it occasionally returns a transient error on one poll. The action treats that single response as terminal and aborts, even though the deploy completes moments later.

## Fix

Raise `error_count` (and pin `timeout`/`reporting_interval`) so the status poll rides through transient errors instead of failing on the first one. A plain full re-run already succeeds with the same artifact — this makes that resilience automatic.