### PR TITLE
feat(core): thread additional_data through vendor & admin routes

### DIFF
--- a/packages/core/src/api/admin/offers/batch/route.ts
+++ b/packages/core/src/api/admin/offers/batch/route.ts
@@ -23,7 +23,11 @@ export const POST = async (
     )
   }
 
-  const { seller_id: sellerId, offers: bodyOffers } = req.validatedBody
+  const {
+    seller_id: sellerId,
+    offers: bodyOffers,
+    additional_data,
+  } = req.validatedBody
 
   const offers: CreateOfferDTO[] = bodyOffers.map((o) => ({
     seller_id: sellerId,
@@ -39,7 +43,7 @@ export const POST = async (
   }))
 
   const { result } = await createOffersWorkflow(req.scope).run({
-    input: { offers },
+    input: { offers, additional_data },
   })
 
   const offerIds = result.map((o) => o.id)

--- a/packages/core/src/api/admin/offers/validators.ts
+++ b/packages/core/src/api/admin/offers/validators.ts
@@ -3,8 +3,10 @@ import {
   createFindParams,
   createOperatorMap,
   createSelectParams,
+  WithAdditionalData,
 } from "@medusajs/medusa/api/utils/validators"
 import { booleanString } from "@medusajs/medusa/api/utils/common-validators/common"
+import { AdditionalData } from "@medusajs/framework/types"
 
 export type AdminGetOfferParamsType = z.infer<typeof AdminGetOfferParams>
 export const AdminGetOfferParams = createSelectParams()
@@ -75,10 +77,12 @@ const AdminCreateOffersBatchItem = z
   })
   .strict()
 
-export type AdminCreateOffersBatchType = z.infer<typeof AdminCreateOffersBatch>
-export const AdminCreateOffersBatch = z
+const CreateOffersBatch = z
   .object({
     seller_id: z.string().min(1),
     offers: z.array(AdminCreateOffersBatchItem).min(1).max(100),
   })
   .strict()
+export type AdminCreateOffersBatchType = z.infer<typeof CreateOffersBatch> &
+  AdditionalData
+export const AdminCreateOffersBatch = WithAdditionalData(CreateOffersBatch)

--- a/packages/core/src/api/admin/product-changes/[id]/cancel/route.ts
+++ b/packages/core/src/api/admin/product-changes/[id]/cancel/route.ts
@@ -20,6 +20,7 @@ export const POST = async (
     input: {
       id: req.params.id,
       canceled_by: req.auth_context?.actor_id,
+      additional_data: req.validatedBody?.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/product-changes/[id]/confirm/route.ts
+++ b/packages/core/src/api/admin/product-changes/[id]/confirm/route.ts
@@ -15,6 +15,7 @@ export const POST = async (
       ids: [req.params.id],
       confirmed_by: req.auth_context?.actor_id,
       internal_note: req.validatedBody?.internal_note,
+      additional_data: req.validatedBody?.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/product-changes/validators.ts
+++ b/packages/core/src/api/admin/product-changes/validators.ts
@@ -1,19 +1,25 @@
 import { z } from "zod"
+import { WithAdditionalData } from "@medusajs/medusa/api/utils/validators"
+import { AdditionalData } from "@medusajs/framework/types"
 
+const ConfirmProductChange = z
+  .object({
+    internal_note: z.string().optional(),
+  })
+  .strict()
 export type AdminConfirmProductChangeType = z.infer<
-  typeof AdminConfirmProductChange
->
-export const AdminConfirmProductChange = z
-  .object({
-    internal_note: z.string().optional(),
-  })
-  .strict()
+  typeof ConfirmProductChange
+> &
+  AdditionalData
+export const AdminConfirmProductChange = WithAdditionalData(ConfirmProductChange)
 
-export type AdminCancelProductChangeType = z.infer<
-  typeof AdminCancelProductChange
->
-export const AdminCancelProductChange = z
+const CancelProductChange = z
   .object({
     internal_note: z.string().optional(),
   })
   .strict()
+export type AdminCancelProductChangeType = z.infer<
+  typeof CancelProductChange
+> &
+  AdditionalData
+export const AdminCancelProductChange = WithAdditionalData(CancelProductChange)

--- a/packages/core/src/api/admin/products/[id]/attributes/batch/route.ts
+++ b/packages/core/src/api/admin/products/[id]/attributes/batch/route.ts
@@ -16,11 +16,13 @@ export const POST = async (
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const productId = req.params.id
 
-  const { add, remove, update } =
-    req.validatedBody as ProductAttributeBatchInput
+  const { add, remove, update, additional_data } =
+    req.validatedBody as ProductAttributeBatchInput & {
+      additional_data?: Record<string, unknown>
+    }
 
   await createAndLinkProductAttributesToProductWorkflow(req.scope).run({
-    input: { product_id: productId, add, remove, update },
+    input: { product_id: productId, add, remove, update, additional_data },
   })
 
   const {

--- a/packages/core/src/api/admin/products/[id]/confirm/route.ts
+++ b/packages/core/src/api/admin/products/[id]/confirm/route.ts
@@ -20,6 +20,7 @@ export const POST = async (
       product_ids: [productId],
       actor_id: req.auth_context?.actor_id,
       internal_note: req.validatedBody?.internal_note,
+      additional_data: req.validatedBody?.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/products/[id]/reject/route.ts
+++ b/packages/core/src/api/admin/products/[id]/reject/route.ts
@@ -20,6 +20,7 @@ export const POST = async (
       product_id: productId,
       message: req.validatedBody?.message,
       actor_id: req.auth_context?.actor_id,
+      additional_data: req.validatedBody?.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/products/[id]/request-changes/route.ts
+++ b/packages/core/src/api/admin/products/[id]/request-changes/route.ts
@@ -20,6 +20,7 @@ export const POST = async (
       product_id: productId,
       message: req.validatedBody?.message,
       actor_id: req.auth_context?.actor_id,
+      additional_data: req.validatedBody?.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/products/validators.ts
+++ b/packages/core/src/api/admin/products/validators.ts
@@ -274,24 +274,32 @@ export const UpdateProduct = z
   .strict()
 export const AdminUpdateProduct = WithAdditionalData(UpdateProduct)
 
-export type AdminConfirmProductType = z.infer<typeof AdminConfirmProduct>
-export const AdminConfirmProduct = z
+const ConfirmProduct = z
   .object({
     internal_note: z.string().optional(),
   })
   .strict()
+export type AdminConfirmProductType = z.infer<typeof ConfirmProduct> &
+  AdditionalData
+export const AdminConfirmProduct = WithAdditionalData(ConfirmProduct)
 
-export type AdminRejectProductType = z.infer<typeof AdminRejectProduct>
-export const AdminRejectProduct = z.object({
+const RejectProduct = z.object({
   message: z.string().optional(),
 })
+export type AdminRejectProductType = z.infer<typeof RejectProduct> &
+  AdditionalData
+export const AdminRejectProduct = WithAdditionalData(RejectProduct)
 
+const RequestProductChanges = z.object({
+  message: z.string().optional(),
+})
 export type AdminRequestProductChangesType = z.infer<
-  typeof AdminRequestProductChanges
->
-export const AdminRequestProductChanges = z.object({
-  message: z.string().optional(),
-})
+  typeof RequestProductChanges
+> &
+  AdditionalData
+export const AdminRequestProductChanges = WithAdditionalData(
+  RequestProductChanges
+)
 
 const BatchVariantCreateItem = CreateProductVariant
 const BatchVariantUpdateItem = UpdateProductVariant.extend({
@@ -397,11 +405,14 @@ const BatchAttributeUpdate = z
   })
   .strict()
 
-export type AdminBatchProductAttributesType = z.infer<
-  typeof AdminBatchProductAttributes
->
-export const AdminBatchProductAttributes = z.object({
+const BatchProductAttributes = z.object({
   add: z.array(BatchAttributeAdd).optional(),
   remove: z.array(z.string()).optional(),
   update: z.array(BatchAttributeUpdate).optional(),
 })
+export type AdminBatchProductAttributesType = z.infer<
+  typeof BatchProductAttributes
+> &
+  AdditionalData
+export const AdminBatchProductAttributes =
+  WithAdditionalData(BatchProductAttributes)

--- a/packages/core/src/api/admin/sellers/[id]/address/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/address/route.ts
@@ -12,10 +12,13 @@ export const POST = async (
   req: AuthenticatedMedusaRequest<AdminUpsertSellerAddressType>,
   res: MedusaResponse<HttpTypes.AdminSellerResponse>
 ) => {
+  const { additional_data, ...data } = req.validatedBody
+
   await updateSellerAddressWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
-      data: req.validatedBody,
+      data,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/[id]/approve/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/approve/route.ts
@@ -5,15 +5,17 @@ import {
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { HttpTypes } from "@mercurjs/types"
 
+import { AdminApproveSellerType } from "../../validators"
 import { approveSellerWorkflow } from "../../../../../workflows/seller"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest,
+  req: AuthenticatedMedusaRequest<AdminApproveSellerType>,
   res: MedusaResponse<HttpTypes.AdminSellerResponse>
 ) => {
   await approveSellerWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
+      additional_data: req.validatedBody.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/[id]/payment-details/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/payment-details/route.ts
@@ -12,10 +12,13 @@ export const POST = async (
   req: AuthenticatedMedusaRequest<AdminUpsertSellerPaymentDetailsType>,
   res: MedusaResponse<HttpTypes.AdminSellerResponse>
 ) => {
+  const { additional_data, ...data } = req.validatedBody
+
   await updateSellerPaymentDetailsWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
-      data: req.validatedBody,
+      data,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/[id]/professional-details/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/professional-details/route.ts
@@ -15,10 +15,13 @@ export const POST = async (
   req: AuthenticatedMedusaRequest<AdminUpsertSellerProfessionalDetailsType>,
   res: MedusaResponse<HttpTypes.AdminSellerResponse>
 ) => {
+  const { additional_data, ...data } = req.validatedBody
+
   await updateSellerProfessionalDetailsWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
-      data: req.validatedBody,
+      data,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/[id]/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/route.ts
@@ -41,10 +41,13 @@ export const POST = async (
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  const { additional_data, ...update } = req.validatedBody
+
   await updateSellersWorkflow(req.scope).run({
     input: {
       selector: { id: req.params.id },
-      update: req.validatedBody,
+      update,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/[id]/suspend/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/suspend/route.ts
@@ -16,6 +16,7 @@ export const POST = async (
     input: {
       seller_id: req.params.id,
       reason: req.validatedBody.reason,
+      additional_data: req.validatedBody.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/[id]/terminate/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/terminate/route.ts
@@ -16,6 +16,7 @@ export const POST = async (
     input: {
       seller_id: req.params.id,
       reason: req.validatedBody.reason,
+      additional_data: req.validatedBody.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/[id]/unsuspend/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/unsuspend/route.ts
@@ -5,15 +5,17 @@ import {
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { HttpTypes } from "@mercurjs/types"
 
+import { AdminUnsuspendSellerType } from "../../validators"
 import { unsuspendSellerWorkflow } from "../../../../../workflows/seller"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest,
+  req: AuthenticatedMedusaRequest<AdminUnsuspendSellerType>,
   res: MedusaResponse<HttpTypes.AdminSellerResponse>
 ) => {
   await unsuspendSellerWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
+      additional_data: req.validatedBody.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/[id]/unterminate/route.ts
+++ b/packages/core/src/api/admin/sellers/[id]/unterminate/route.ts
@@ -5,15 +5,17 @@ import {
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { HttpTypes } from "@mercurjs/types"
 
+import { AdminUnterminateSellerType } from "../../validators"
 import { unterminateSellerWorkflow } from "../../../../../workflows/seller"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest,
+  req: AuthenticatedMedusaRequest<AdminUnterminateSellerType>,
   res: MedusaResponse<HttpTypes.AdminSellerResponse>
 ) => {
   await unterminateSellerWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
+      additional_data: req.validatedBody.additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/middlewares.ts
+++ b/packages/core/src/api/admin/sellers/middlewares.ts
@@ -18,6 +18,9 @@ import {
   AdminUpdateSeller,
   AdminSuspendSeller,
   AdminTerminateSeller,
+  AdminApproveSeller,
+  AdminUnsuspendSeller,
+  AdminUnterminateSeller,
   AdminAddSellerMember,
   AdminInviteSellerMember,
   AdminUpsertSellerAddress,
@@ -83,6 +86,7 @@ export const adminSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/admin/sellers/:id/unsuspend",
     middlewares: [
+      validateAndTransformBody(AdminUnsuspendSeller),
       validateAndTransformQuery(
         AdminGetSellerParams,
         adminSellerQueryConfig.retrieve
@@ -93,6 +97,7 @@ export const adminSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/admin/sellers/:id/approve",
     middlewares: [
+      validateAndTransformBody(AdminApproveSeller),
       validateAndTransformQuery(
         AdminGetSellerParams,
         adminSellerQueryConfig.retrieve
@@ -114,6 +119,7 @@ export const adminSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/admin/sellers/:id/unterminate",
     middlewares: [
+      validateAndTransformBody(AdminUnterminateSeller),
       validateAndTransformQuery(
         AdminGetSellerParams,
         adminSellerQueryConfig.retrieve

--- a/packages/core/src/api/admin/sellers/route.ts
+++ b/packages/core/src/api/admin/sellers/route.ts
@@ -35,9 +35,12 @@ export const POST = async (
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  const { additional_data, ...sellerData } = req.validatedBody
+
   const { result } = await createSellersWorkflow(req.scope).run({
     input: {
-      sellers: [req.validatedBody],
+      sellers: [sellerData],
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/admin/sellers/validators.ts
+++ b/packages/core/src/api/admin/sellers/validators.ts
@@ -95,15 +95,30 @@ export const UpdateSeller = z.object({
 })
 export const AdminUpdateSeller = WithAdditionalData(UpdateSeller)
 
-export type AdminSuspendSellerType = z.infer<typeof AdminSuspendSeller>
-export const AdminSuspendSeller = z.object({
+const SuspendSeller = z.object({
   reason: z.string().optional(),
 })
+export type AdminSuspendSellerType = z.infer<typeof SuspendSeller> &
+  AdditionalData
+export const AdminSuspendSeller = WithAdditionalData(SuspendSeller)
 
-export type AdminTerminateSellerType = z.infer<typeof AdminTerminateSeller>
-export const AdminTerminateSeller = z.object({
+const TerminateSeller = z.object({
   reason: z.string().optional(),
 })
+export type AdminTerminateSellerType = z.infer<typeof TerminateSeller> &
+  AdditionalData
+export const AdminTerminateSeller = WithAdditionalData(TerminateSeller)
+
+const SellerLifecycleAction = z.object({})
+export type AdminApproveSellerType = z.infer<typeof SellerLifecycleAction> &
+  AdditionalData
+export const AdminApproveSeller = WithAdditionalData(SellerLifecycleAction)
+export type AdminUnsuspendSellerType = z.infer<typeof SellerLifecycleAction> &
+  AdditionalData
+export const AdminUnsuspendSeller = WithAdditionalData(SellerLifecycleAction)
+export type AdminUnterminateSellerType = z.infer<typeof SellerLifecycleAction> &
+  AdditionalData
+export const AdminUnterminateSeller = WithAdditionalData(SellerLifecycleAction)
 
 export type AdminAddSellerMemberType = z.infer<typeof AdminAddSellerMember>
 export const AdminAddSellerMember = z.object({

--- a/packages/core/src/api/vendor/offers/[id]/route.ts
+++ b/packages/core/src/api/vendor/offers/[id]/route.ts
@@ -38,9 +38,12 @@ export const POST = async (
   const { id } = req.params
   await validateSellerOffer(req.scope, req.seller_context!.seller_id, id)
 
+  const { additional_data, ...update } = req.validatedBody
+
   await updateOffersWorkflow(req.scope).run({
     input: {
-      offers: [{ id, ...req.validatedBody }],
+      offers: [{ id, ...update }],
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/offers/batch/route.ts
+++ b/packages/core/src/api/vendor/offers/batch/route.ts
@@ -15,6 +15,8 @@ export const POST = async (
   const sellerId = req.seller_context!.seller_id
   const memberId = req.auth_context.actor_id
 
+  const { additional_data } = req.validatedBody
+
   const offers: CreateOfferDTO[] = req.validatedBody.offers.map((o) => ({
     seller_id: sellerId,
     created_by: memberId,
@@ -29,7 +31,7 @@ export const POST = async (
   }))
 
   const { result } = await createOffersWorkflow(req.scope).run({
-    input: { offers },
+    input: { offers, additional_data },
   })
 
   const offerIds = result.map((o) => o.id)

--- a/packages/core/src/api/vendor/offers/route.ts
+++ b/packages/core/src/api/vendor/offers/route.ts
@@ -38,15 +38,18 @@ export const POST = async (
   const sellerId = req.seller_context!.seller_id
   const memberId = req.auth_context.actor_id
 
+  const { additional_data, ...offerData } = req.validatedBody
+
   const { result } = await createOffersWorkflow(req.scope).run({
     input: {
       offers: [
         {
-          ...req.validatedBody,
+          ...offerData,
           seller_id: sellerId,
           created_by: memberId,
         },
       ],
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/offers/validators.ts
+++ b/packages/core/src/api/vendor/offers/validators.ts
@@ -3,7 +3,9 @@ import {
   createFindParams,
   createOperatorMap,
   createSelectParams,
+  WithAdditionalData,
 } from "@medusajs/medusa/api/utils/validators"
+import { AdditionalData } from "@medusajs/framework/types"
 
 export type VendorGetOfferParamsType = z.infer<typeof VendorGetOfferParams>
 export const VendorGetOfferParams = createSelectParams()
@@ -67,8 +69,7 @@ const VendorOfferUpsertPrice = z
   })
   .strict()
 
-export type VendorCreateOfferType = z.infer<typeof VendorCreateOffer>
-export const VendorCreateOffer = z
+const CreateOffer = z
   .object({
     sku: z.string().min(1),
     variant_id: z.string(),
@@ -81,8 +82,10 @@ export const VendorCreateOffer = z
   })
   .strict()
 
-export type VendorUpdateOfferType = z.infer<typeof VendorUpdateOffer>
-export const VendorUpdateOffer = z
+export type VendorCreateOfferType = z.infer<typeof CreateOffer> & AdditionalData
+export const VendorCreateOffer = WithAdditionalData(CreateOffer)
+
+const UpdateOffer = z
   .object({
     sku: z.string().min(1).optional(),
     shipping_profile_id: z.string().min(1).optional(),
@@ -90,6 +93,9 @@ export const VendorUpdateOffer = z
     prices: z.array(VendorOfferUpsertPrice).optional(),
   })
   .strict()
+
+export type VendorUpdateOfferType = z.infer<typeof UpdateOffer> & AdditionalData
+export const VendorUpdateOffer = WithAdditionalData(UpdateOffer)
 
 const VendorBatchInventoryItemCreate = z
   .object({
@@ -105,16 +111,21 @@ const VendorBatchInventoryItemUpdate = z
   })
   .strict()
 
-export type VendorBatchOfferInventoryItemsType = z.infer<
-  typeof VendorBatchOfferInventoryItems
->
-export const VendorBatchOfferInventoryItems = z
+const BatchOfferInventoryItems = z
   .object({
     create: z.array(VendorBatchInventoryItemCreate).optional(),
     update: z.array(VendorBatchInventoryItemUpdate).optional(),
     delete: z.array(z.string()).optional(),
   })
   .strict()
+
+export type VendorBatchOfferInventoryItemsType = z.infer<
+  typeof BatchOfferInventoryItems
+> &
+  AdditionalData
+export const VendorBatchOfferInventoryItems = WithAdditionalData(
+  BatchOfferInventoryItems
+)
 
 const VendorCreateOffersBatchItem = z
   .object({
@@ -129,11 +140,14 @@ const VendorCreateOffersBatchItem = z
   })
   .strict()
 
-export type VendorCreateOffersBatchType = z.infer<
-  typeof VendorCreateOffersBatch
->
-export const VendorCreateOffersBatch = z
+const CreateOffersBatch = z
   .object({
     offers: z.array(VendorCreateOffersBatchItem).min(1).max(100),
   })
   .strict()
+
+export type VendorCreateOffersBatchType = z.infer<
+  typeof CreateOffersBatch
+> &
+  AdditionalData
+export const VendorCreateOffersBatch = WithAdditionalData(CreateOffersBatch)

--- a/packages/core/src/api/vendor/orders/[id]/fulfillments/[fulfillment_id]/cancel/route.ts
+++ b/packages/core/src/api/vendor/orders/[id]/fulfillments/[fulfillment_id]/cancel/route.ts
@@ -7,9 +7,10 @@ import { HttpTypes } from "@mercurjs/types"
 
 import { cancelOrderFulfillmentWorkflow } from "../../../../../../../workflows/order/workflows/cancel-order-fulfillment"
 import { validateSellerOrder } from "../../../../helpers"
+import { VendorCancelFulfillmentType } from "../../../../validators"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest,
+  req: AuthenticatedMedusaRequest<VendorCancelFulfillmentType>,
   res: MedusaResponse<HttpTypes.VendorOrderResponse>
 ) => {
   const { id, fulfillment_id } = req.params
@@ -17,11 +18,15 @@ export const POST = async (
 
   await validateSellerOrder(req.scope, sellerId, id)
 
+  const { additional_data, no_notification } = req.validatedBody
+
   await cancelOrderFulfillmentWorkflow(req.scope).run({
     input: {
       order_id: id,
       fulfillment_id,
       canceled_by: sellerId,
+      no_notification,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/orders/middlewares.ts
+++ b/packages/core/src/api/vendor/orders/middlewares.ts
@@ -15,6 +15,7 @@ import {
   vendorOrderQueryConfig,
 } from "./query-config"
 import {
+  VendorCancelFulfillment,
   VendorCreateFulfillment,
   VendorCreateShipment,
   VendorGetOrderChangesParams,
@@ -104,6 +105,7 @@ export const vendorOrdersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/vendor/orders/:id/fulfillments/:fulfillment_id/cancel",
     middlewares: [
+      validateAndTransformBody(VendorCancelFulfillment),
       validateAndTransformQuery(
         VendorGetOrderParams,
         vendorOrderQueryConfig.retrieve

--- a/packages/core/src/api/vendor/orders/validators.ts
+++ b/packages/core/src/api/vendor/orders/validators.ts
@@ -3,7 +3,9 @@ import {
   createFindParams,
   createOperatorMap,
   createSelectParams,
+  WithAdditionalData,
 } from "@medusajs/medusa/api/utils/validators"
+import { AdditionalData } from "@medusajs/framework/types"
 
 export type VendorGetOrderParamsType = z.infer<typeof VendorGetOrderParams>
 export const VendorGetOrderParams = createSelectParams()
@@ -33,8 +35,7 @@ export type VendorGetOrderChangesParamsType = z.infer<
 >
 export const VendorGetOrderChangesParams = createSelectParams()
 
-export type VendorCreateFulfillmentType = z.infer<typeof VendorCreateFulfillment>
-export const VendorCreateFulfillment = z.object({
+const CreateFulfillment = z.object({
   items: z.array(
     z.object({
       id: z.string(),
@@ -44,6 +45,20 @@ export const VendorCreateFulfillment = z.object({
   requires_shipping: z.boolean(),
   location_id: z.string(),
 })
+
+export type VendorCreateFulfillmentType = z.infer<typeof CreateFulfillment> &
+  AdditionalData
+export const VendorCreateFulfillment = WithAdditionalData(CreateFulfillment)
+
+const CancelFulfillment = z
+  .object({
+    no_notification: z.boolean().optional(),
+  })
+  .strict()
+
+export type VendorCancelFulfillmentType = z.infer<typeof CancelFulfillment> &
+  AdditionalData
+export const VendorCancelFulfillment = WithAdditionalData(CancelFulfillment)
 
 export type VendorCreateShipmentType = z.infer<typeof VendorCreateShipment>
 export const VendorCreateShipment = z.object({

--- a/packages/core/src/api/vendor/products/[id]/cancel/route.ts
+++ b/packages/core/src/api/vendor/products/[id]/cancel/route.ts
@@ -9,9 +9,10 @@ import {
 import { ProductChangeDTO, ProductChangeStatus } from "@mercurjs/types"
 
 import { cancelProductChangeWorkflow } from "../../../../../workflows/product-edit/workflows/cancel-product-change"
+import { VendorCancelProductChangeType } from "../../validators"
 
 export const POST = async (
-  req: AuthenticatedMedusaRequest,
+  req: AuthenticatedMedusaRequest<VendorCancelProductChangeType>,
   res: MedusaResponse<{ product_change: ProductChangeDTO }>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
@@ -39,6 +40,7 @@ export const POST = async (
     input: {
       id: changes[0].id,
       canceled_by: sellerId,
+      additional_data: req.validatedBody.additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/products/[id]/route.ts
+++ b/packages/core/src/api/vendor/products/[id]/route.ts
@@ -67,13 +67,14 @@ export const POST = async (
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const sellerId = req.seller_context!.seller_id
 
-  const { additional_data: _ad, ...update } = req.validatedBody
+  const { additional_data, ...update } = req.validatedBody
 
   const { result } = await productEditUpdateProductWorkflow(req.scope).run({
     input: {
       product_id: req.params.id,
       created_by: sellerId,
       update: update as Record<string, unknown>,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/products/validators.ts
+++ b/packages/core/src/api/vendor/products/validators.ts
@@ -323,14 +323,17 @@ export const VendorUpdateProductVariant = z
   })
   .strict()
 
-export type VendorCancelProductChangeType = z.infer<
-  typeof VendorCancelProductChange
->
-export const VendorCancelProductChange = z
+const CancelProductChange = z
   .object({
     internal_note: z.string().optional(),
   })
   .strict()
+
+export type VendorCancelProductChangeType = z.infer<
+  typeof CancelProductChange
+> &
+  AdditionalData
+export const VendorCancelProductChange = WithAdditionalData(CancelProductChange)
 
 const VendorBatchAttributeScalar = z.union([
   z.string(),

--- a/packages/core/src/api/vendor/sellers/[id]/address/route.ts
+++ b/packages/core/src/api/vendor/sellers/[id]/address/route.ts
@@ -12,10 +12,13 @@ export const POST = async (
   req: AuthenticatedMedusaRequest<VendorUpsertSellerAddressType>,
   res: MedusaResponse<HttpTypes.VendorSellerResponse>
 ) => {
+  const { additional_data, ...data } = req.validatedBody
+
   await updateSellerAddressWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
-      data: req.validatedBody,
+      data,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/sellers/[id]/payment-details/route.ts
+++ b/packages/core/src/api/vendor/sellers/[id]/payment-details/route.ts
@@ -12,10 +12,13 @@ export const POST = async (
   req: AuthenticatedMedusaRequest<VendorUpsertSellerPaymentDetailsType>,
   res: MedusaResponse<HttpTypes.VendorSellerResponse>
 ) => {
+  const { additional_data, ...data } = req.validatedBody
+
   await updateSellerPaymentDetailsWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
-      data: req.validatedBody,
+      data,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/sellers/[id]/professional-details/route.ts
+++ b/packages/core/src/api/vendor/sellers/[id]/professional-details/route.ts
@@ -17,10 +17,13 @@ export const POST = async (
   req: AuthenticatedMedusaRequest<VendorUpsertSellerProfessionalDetailsType>,
   res: MedusaResponse<HttpTypes.VendorSellerResponse>
 ) => {
+  const { additional_data, ...data } = req.validatedBody
+
   await updateSellerProfessionalDetailsWorkflow(req.scope).run({
     input: {
       seller_id: req.params.id,
-      data: req.validatedBody,
+      data,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/sellers/[id]/route.ts
+++ b/packages/core/src/api/vendor/sellers/[id]/route.ts
@@ -41,10 +41,13 @@ export const POST = async (
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
+  const { additional_data, ...update } = req.validatedBody
+
   await updateSellersWorkflow(req.scope).run({
     input: {
       selector: { id: req.params.id },
-      update: req.validatedBody,
+      update,
+      additional_data,
     },
   })
 

--- a/packages/core/src/api/vendor/sellers/me/route.ts
+++ b/packages/core/src/api/vendor/sellers/me/route.ts
@@ -6,6 +6,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { HttpTypes } from "@mercurjs/types"
 
 import { VendorUpdateSellerType } from "../validators"
+import { updateSellersWorkflow } from "../../../../workflows/seller"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -30,7 +31,17 @@ export const POST = async (
   res: MedusaResponse<HttpTypes.VendorSellerResponse>
 ) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-  const sellerId =  req.seller_context!.seller_id
+  const sellerId = req.seller_context!.seller_id
+
+  const { additional_data, ...update } = req.validatedBody
+
+  await updateSellersWorkflow(req.scope).run({
+    input: {
+      selector: { id: sellerId },
+      update,
+      additional_data,
+    },
+  })
 
   const {
     data: [seller],

--- a/packages/core/src/api/vendor/sellers/route.ts
+++ b/packages/core/src/api/vendor/sellers/route.ts
@@ -55,6 +55,7 @@ export const POST = async (
     member_email,
     first_name,
     last_name,
+    additional_data,
     ...sellerData
   } = req.validatedBody
 
@@ -78,6 +79,7 @@ export const POST = async (
       address,
       professional_details,
       payment_details,
+      additional_data,
     },
   })
 

--- a/packages/core/src/workflows/product-attribute/workflows/create-and-link-product-attributes.ts
+++ b/packages/core/src/workflows/product-attribute/workflows/create-and-link-product-attributes.ts
@@ -22,7 +22,14 @@ export type CreateAndLinkProductAttributesWorkflowHooks = [
     { input: CreateAndLinkProductAttributesWorkflowInput },
     unknown
   >,
-  Hook<"productAttributesLinked", { product_id: string }, unknown>,
+  Hook<
+    "productAttributesLinked",
+    {
+      product_id: string
+      additional_data: Record<string, unknown> | undefined
+    },
+    unknown
+  >,
 ]
 
 export const createAndLinkProductAttributesToProductWorkflowId =
@@ -57,6 +64,7 @@ export const createAndLinkProductAttributesToProductWorkflow: ReturnWorkflow<
 
     const productAttributesLinked = createHook("productAttributesLinked", {
       product_id: input.product_id,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, {

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-product.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-product.ts
@@ -1,10 +1,12 @@
 import { AdditionalData } from "@medusajs/framework/types"
 import { deepEqualObj } from "@medusajs/framework/utils"
 import {
+  createHook,
   createWorkflow,
+  type Hook,
+  type ReturnWorkflow,
   transform,
   WorkflowResponse,
-  type ReturnWorkflow,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep } from "@medusajs/medusa/core-flows"
 import {
@@ -21,6 +23,17 @@ export type ProductEditUpdateProductWorkflowInput = {
   created_by?: string
   update: Record<string, unknown>
 } & AdditionalData
+
+export type ProductEditUpdateProductWorkflowHooks = [
+  Hook<
+    "productChangeCreated",
+    {
+      product_change: ProductChangeDTO
+      additional_data: Record<string, unknown> | undefined
+    },
+    unknown
+  >,
+]
 
 const DIFFABLE_FIELDS = [
   "title",
@@ -52,7 +65,7 @@ export const productEditUpdateProductWorkflowId = "product-edit-update-product"
 export const productEditUpdateProductWorkflow: ReturnWorkflow<
   ProductEditUpdateProductWorkflowInput,
   ProductChangeDTO,
-  []
+  ProductEditUpdateProductWorkflowHooks
 > = createWorkflow(
   productEditUpdateProductWorkflowId,
   function (input: ProductEditUpdateProductWorkflowInput) {
@@ -168,6 +181,13 @@ export const productEditUpdateProductWorkflow: ReturnWorkflow<
       })),
     })
 
-    return new WorkflowResponse(change)
+    const productChangeCreated = createHook("productChangeCreated", {
+      product_change: change,
+      additional_data: input.additional_data,
+    })
+
+    return new WorkflowResponse(change, {
+      hooks: [productChangeCreated],
+    })
   },
 )

--- a/packages/core/src/workflows/product/workflows/confirm-products.ts
+++ b/packages/core/src/workflows/product/workflows/confirm-products.ts
@@ -11,6 +11,7 @@ import {
   useQueryGraphStep,
 } from "@medusajs/medusa/core-flows"
 import { ProductChangeActionType } from "@mercurjs/types"
+import { AdditionalData } from "@medusajs/framework/types"
 
 import { ProductWorkflowEvents } from "../events"
 import { validateProductsStatusStep } from "../steps/validate-products-status"
@@ -22,7 +23,7 @@ type ConfirmProductsWorkflowInput = {
   product_ids: string[]
   actor_id?: string
   internal_note?: string
-}
+} & AdditionalData
 
 export const confirmProductsWorkflow = createWorkflow(
   confirmProductsWorkflowId,
@@ -76,6 +77,7 @@ export const confirmProductsWorkflow = createWorkflow(
     const productsConfirmed = createHook("productsConfirmed", {
       product_ids: input.product_ids,
       internal_note: input.internal_note,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, { hooks: [productsConfirmed] })

--- a/packages/core/src/workflows/product/workflows/reject-product.ts
+++ b/packages/core/src/workflows/product/workflows/reject-product.ts
@@ -11,6 +11,7 @@ import {
   useQueryGraphStep,
 } from "@medusajs/medusa/core-flows"
 import { ProductChangeActionType } from "@mercurjs/types"
+import { AdditionalData } from "@medusajs/framework/types"
 
 import { ProductWorkflowEvents } from "../events"
 import { validateProductsStatusStep } from "../steps/validate-products-status"
@@ -22,7 +23,7 @@ type RejectProductWorkflowInput = {
   product_id: string
   message?: string
   actor_id?: string
-}
+} & AdditionalData
 
 export const rejectProductWorkflow = createWorkflow(
   rejectProductWorkflowId,
@@ -76,6 +77,7 @@ export const rejectProductWorkflow = createWorkflow(
     const productRejected = createHook("productRejected", {
       product_id: input.product_id,
       message: input.message,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, { hooks: [productRejected] })

--- a/packages/core/src/workflows/product/workflows/request-product-change.ts
+++ b/packages/core/src/workflows/product/workflows/request-product-change.ts
@@ -10,6 +10,7 @@ import {
   useQueryGraphStep,
 } from "@medusajs/medusa/core-flows"
 import { ProductChangeActionType } from "@mercurjs/types"
+import { AdditionalData } from "@medusajs/framework/types"
 
 import { ProductWorkflowEvents } from "../events"
 import { validateProductsStatusStep } from "../steps/validate-products-status"
@@ -21,7 +22,7 @@ type RequestProductChangeWorkflowInput = {
   product_id: string
   message?: string
   actor_id?: string
-}
+} & AdditionalData
 
 export const requestProductChangeWorkflow = createWorkflow(
   requestProductChangeWorkflowId,
@@ -69,6 +70,7 @@ export const requestProductChangeWorkflow = createWorkflow(
     const productChangeRequested = createHook("productChangeRequested", {
       product_id: input.product_id,
       message: input.message,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, { hooks: [productChangeRequested] })

--- a/packages/core/src/workflows/seller/workflows/approve-seller.ts
+++ b/packages/core/src/workflows/seller/workflows/approve-seller.ts
@@ -5,6 +5,7 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep, emitEventStep } from "@medusajs/medusa/core-flows"
+import { AdditionalData } from "@medusajs/framework/types"
 import { SellerStatus } from "@mercurjs/types"
 
 import { validateApproveSellerStep, updateSellersStep } from "../steps"
@@ -14,7 +15,7 @@ export const approveSellerWorkflowId = "approve-seller"
 
 type ApproveSellerWorkflowInput = {
   seller_id: string
-}
+} & AdditionalData
 
 export const approveSellerWorkflow = createWorkflow(
   approveSellerWorkflowId,
@@ -48,6 +49,7 @@ export const approveSellerWorkflow = createWorkflow(
 
     const sellerApproved = createHook("sellerApproved", {
       seller_id: input.seller_id,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, { hooks: [sellerApproved] })

--- a/packages/core/src/workflows/seller/workflows/suspend-seller.ts
+++ b/packages/core/src/workflows/seller/workflows/suspend-seller.ts
@@ -5,6 +5,7 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep, emitEventStep } from "@medusajs/medusa/core-flows"
+import { AdditionalData } from "@medusajs/framework/types"
 import { SellerStatus } from "@mercurjs/types"
 
 import { validateSuspendSellerStep, updateSellersStep } from "../steps"
@@ -15,7 +16,7 @@ export const suspendSellerWorkflowId = "suspend-seller"
 type SuspendSellerWorkflowInput = {
   seller_id: string
   reason?: string
-}
+} & AdditionalData
 
 export const suspendSellerWorkflow = createWorkflow(
   suspendSellerWorkflowId,
@@ -49,6 +50,7 @@ export const suspendSellerWorkflow = createWorkflow(
 
     const sellerSuspended = createHook("sellerSuspended", {
       seller_id: input.seller_id,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, { hooks: [sellerSuspended] })

--- a/packages/core/src/workflows/seller/workflows/terminate-seller.ts
+++ b/packages/core/src/workflows/seller/workflows/terminate-seller.ts
@@ -5,6 +5,7 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep, emitEventStep } from "@medusajs/medusa/core-flows"
+import { AdditionalData } from "@medusajs/framework/types"
 import { SellerStatus } from "@mercurjs/types"
 
 import { validateTerminateSellerStep, updateSellersStep } from "../steps"
@@ -15,7 +16,7 @@ export const terminateSellerWorkflowId = "terminate-seller"
 type TerminateSellerWorkflowInput = {
   seller_id: string
   reason?: string
-}
+} & AdditionalData
 
 export const terminateSellerWorkflow = createWorkflow(
   terminateSellerWorkflowId,
@@ -48,6 +49,7 @@ export const terminateSellerWorkflow = createWorkflow(
 
     const sellerTerminated = createHook("sellerTerminated", {
       seller_id: input.seller_id,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, { hooks: [sellerTerminated] })

--- a/packages/core/src/workflows/seller/workflows/unsuspend-seller.ts
+++ b/packages/core/src/workflows/seller/workflows/unsuspend-seller.ts
@@ -5,6 +5,7 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep, emitEventStep } from "@medusajs/medusa/core-flows"
+import { AdditionalData } from "@medusajs/framework/types"
 import { SellerStatus } from "@mercurjs/types"
 
 import { validateUnsuspendSellerStep, updateSellersStep } from "../steps"
@@ -14,7 +15,7 @@ export const unsuspendSellerWorkflowId = "unsuspend-seller"
 
 type UnsuspendSellerWorkflowInput = {
   seller_id: string
-}
+} & AdditionalData
 
 export const unsuspendSellerWorkflow = createWorkflow(
   unsuspendSellerWorkflowId,
@@ -47,6 +48,7 @@ export const unsuspendSellerWorkflow = createWorkflow(
 
     const sellerUnsuspended = createHook("sellerUnsuspended", {
       seller_id: input.seller_id,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, { hooks: [sellerUnsuspended] })

--- a/packages/core/src/workflows/seller/workflows/unterminate-seller.ts
+++ b/packages/core/src/workflows/seller/workflows/unterminate-seller.ts
@@ -5,6 +5,7 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep, emitEventStep } from "@medusajs/medusa/core-flows"
+import { AdditionalData } from "@medusajs/framework/types"
 import { SellerStatus } from "@mercurjs/types"
 
 import { validateUnterminateSellerStep, updateSellersStep } from "../steps"
@@ -14,7 +15,7 @@ export const unterminateSellerWorkflowId = "unterminate-seller"
 
 type UnterminateSellerWorkflowInput = {
   seller_id: string
-}
+} & AdditionalData
 
 export const unterminateSellerWorkflow = createWorkflow(
   unterminateSellerWorkflowId,
@@ -47,6 +48,7 @@ export const unterminateSellerWorkflow = createWorkflow(
 
     const sellerUnterminated = createHook("sellerUnterminated", {
       seller_id: input.seller_id,
+      additional_data: input.additional_data,
     })
 
     return new WorkflowResponse(void 0, { hooks: [sellerUnterminated] })


### PR DESCRIPTION
## Summary

Wires Medusa's `additional_data` extension pattern end-to-end across **vendor** and **admin** `POST`/`PATCH` endpoints in `@mercurjs/core` that previously accepted the field at the validator (or not at all) but dropped/nested it before the workflow — so extension hooks now actually receive it.

`POST /admin/products` and `POST /vendor/products` were already the fully-wired references; this brings the rest of the surface to parity.

The three legs of the pattern: **(1)** validator wrapped with `WithAdditionalData`, **(2)** handler forwards `additional_data` at the top level of the workflow input, **(3)** workflow defines a `createHook(..., { additional_data })` and types input `& AdditionalData`.

## Vendor side (commit 1)
- **Products**: update (`products/[id]`) — added `productChangeCreated` hook + forward.
- **Sellers**: create/update, address, payment-details, professional-details — un-nested/forwarded; `sellers/me` (was a no-op) now runs `updateSellersWorkflow`.
- **Offers**: create, update, batch, inventory-items batch — wrapped validators + forward.
- **Product change cancel**; **order fulfillment create** + **cancel** (added a `VendorCancelFulfillment` body validator).

## Admin side (commit 2)
- **Sellers**: create/update, address, payment-details, professional-details — forward. Lifecycle `approve` / `suspend` / `terminate` / `unsuspend` / `unterminate` — threaded `additional_data` into the existing named hooks, wrapped/added validators (+ wired new body validators into middleware), forward.
- **Products moderation**: `confirm` / `reject` / `request-changes` — threaded `additional_data` into the hooks + wrapped validators + forward.
- **Product-changes** `cancel` / `confirm` — wrapped validators + forward (hooks already existed).
- **Offers batch create** — wrapped validator + forward (hook exists).
- **Product attributes batch** — wrapped validator + forward + threaded `additional_data` into the `productAttributesLinked` hook.

## Implementation notes
- New hooks use the snake_case `additional_data` key, matching Mercur's convention.
- Wrapped validators infer their request type from the **base** schema `& AdditionalData` (not the `WithAdditionalData(...)` result, which trips a Zod/TS constraint error) — consistent with the existing seller validators.

## Verification
- `tsc --noEmit` on `packages/core`: **0 errors**
- `bun run --filter @mercurjs/core build`: **passes**

## Out of scope / follow-ups
- **Admin commission-rates** (create/update/batch-rules) and **seller-member** (add/invite/resend) routes: their workflows take positional/array inputs, so threading `additional_data` needs a workflow-input contract change — deferred.
- Remaining vendor **Tier 3** endpoints (pricing/promotions/campaigns, inventory/shipping/stock, customers, payments/payouts, returns/claims/exchanges/order-edits).
- Integration specs asserting `additional_data` reaches a registered hook (fresh worktrees can't run the integration suite reliably here).