### PR TITLE
feat(dashboard): seller form extension zones across admin & vendor

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -76,6 +76,7 @@
                       "rc/resources/tutorials/custom-panel-page",
                       "rc/resources/tutorials/add-a-widget",
                       "rc/resources/tutorials/extend-forms-and-tables",
+                      "rc/resources/tutorials/extend-onboarding",
                       "rc/resources/tutorials/customize-navigation",
                       "rc/resources/tutorials/custom-api-route"
                     ]

--- a/apps/docs/rc/references/workflows/product/confirm-products.mdx
+++ b/apps/docs/rc/references/workflows/product/confirm-products.mdx
@@ -33,6 +33,8 @@ await confirmProductsWorkflow(container).run({
   Operator-only note stored on the audit change and included in the emitted event.
 </ParamField>
 
+<ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
+
 ## Result
 
 <ResponseField name="result" type="void">

--- a/apps/docs/rc/references/workflows/product/reject-product.mdx
+++ b/apps/docs/rc/references/workflows/product/reject-product.mdx
@@ -33,6 +33,8 @@ await rejectProductWorkflow(container).run({
   Actor id recorded on the audit trail entry.
 </ParamField>
 
+<ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
+
 ## Result
 
 <ResponseField name="result" type="void">

--- a/apps/docs/rc/references/workflows/product/request-product-change.mdx
+++ b/apps/docs/rc/references/workflows/product/request-product-change.mdx
@@ -33,6 +33,8 @@ await requestProductChangeWorkflow(container).run({
   Actor id recorded on the audit trail entry.
 </ParamField>
 
+<ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
+
 ## Result
 
 <ResponseField name="result" type="void">

--- a/apps/docs/rc/references/workflows/seller/approve-seller.mdx
+++ b/apps/docs/rc/references/workflows/seller/approve-seller.mdx
@@ -19,6 +19,8 @@ await approveSellerWorkflow(container).run({
 
 <ParamField body="seller_id" type="string" required>Id of the seller to approve.</ParamField>
 
+<ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
+
 ## Result
 
 <ResponseField name="result" type="void">Nothing is returned.</ResponseField>

--- a/apps/docs/rc/references/workflows/seller/suspend-seller.mdx
+++ b/apps/docs/rc/references/workflows/seller/suspend-seller.mdx
@@ -20,6 +20,8 @@ await suspendSellerWorkflow(container).run({
 <ParamField body="seller_id" type="string" required>Id of the seller to suspend.</ParamField>
 <ParamField body="reason" type="string">Reason stored in `status_reason`.</ParamField>
 
+<ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
+
 ## Result
 
 <ResponseField name="result" type="void">Nothing is returned.</ResponseField>

--- a/apps/docs/rc/references/workflows/seller/terminate-seller.mdx
+++ b/apps/docs/rc/references/workflows/seller/terminate-seller.mdx
@@ -20,6 +20,8 @@ await terminateSellerWorkflow(container).run({
 <ParamField body="seller_id" type="string" required>Id of the seller to terminate.</ParamField>
 <ParamField body="reason" type="string">Reason stored in `status_reason`.</ParamField>
 
+<ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
+
 ## Result
 
 <ResponseField name="result" type="void">Nothing is returned.</ResponseField>

--- a/apps/docs/rc/references/workflows/seller/unsuspend-seller.mdx
+++ b/apps/docs/rc/references/workflows/seller/unsuspend-seller.mdx
@@ -19,6 +19,8 @@ await unsuspendSellerWorkflow(container).run({
 
 <ParamField body="seller_id" type="string" required>Id of the suspended seller.</ParamField>
 
+<ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
+
 ## Result
 
 <ResponseField name="result" type="void">Nothing is returned.</ResponseField>

--- a/apps/docs/rc/references/workflows/seller/unterminate-seller.mdx
+++ b/apps/docs/rc/references/workflows/seller/unterminate-seller.mdx
@@ -19,6 +19,8 @@ await unterminateSellerWorkflow(container).run({
 
 <ParamField body="seller_id" type="string" required>Id of the terminated seller.</ParamField>
 
+<ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
+
 ## Result
 
 <ResponseField name="result" type="void">Nothing is returned.</ResponseField>

--- a/apps/docs/rc/resources/tutorials/add-a-widget.mdx
+++ b/apps/docs/rc/resources/tutorials/add-a-widget.mdx
@@ -70,6 +70,7 @@ Zones mounted today in the **vendor portal**:
 | Zone | Where it renders |
 |------|------------------|
 | `product.list.before` / `.after` | Vendor product list page |
+| `store.setup.before` / `.after` | The store-setup / onboarding surface (dashboard home + store settings), passed the `seller` as `data` |
 | `login.logo.*` | The logo slot on the public login screen |
 | `login.before.*` / `login.after.*` | Around the login form (rendered before authentication) |
 
@@ -103,8 +104,8 @@ The full, valid set is typed as `WidgetZoneId` and generated into `@mercurjs/ven
   <Card title="Extend forms and tables" href="/rc/resources/tutorials/extend-forms-and-tables">
     Add validated fields and columns with defineCustomFieldsConfig.
   </Card>
-  <Card title="Customize navigation" href="/rc/resources/tutorials/customize-navigation">
-    Reorder, hide, and re-parent sidebar items.
+  <Card title="Extend the onboarding flow" href="/rc/resources/tutorials/extend-onboarding">
+    Add a store-setup field and persist it through a workflow hook.
   </Card>
 </CardGroup>
 </content>

--- a/apps/docs/rc/resources/tutorials/extend-onboarding.mdx
+++ b/apps/docs/rc/resources/tutorials/extend-onboarding.mdx
@@ -1,0 +1,254 @@
+---
+title: "Extend the onboarding flow"
+description: "Add a field to the vendor store-setup surface, submit it through additional_data, and persist it durably from a workflow hook — end to end, without forking."
+---
+
+The vendor **store-setup / onboarding** surface is a widget zone (`store.setup`) that renders the full `seller` object as its `data`. That makes onboarding a full extension seam: drop a widget to add UI, carry the new value to the API on the built-in seller routes through `additional_data`, and persist it from a workflow hook — the same three layers you'd wire in plain Medusa, kept intact by Mercur.
+
+<Info>
+  **Three layers, one flow.** The panel (a `store.setup` widget) *renders and collects*. The vendor seller route *carries* the value through `additional_data` — no core schema change. A `sellersUpdated` workflow hook *persists* it. Each layer is additive: nothing built-in is replaced.
+</Info>
+
+## What you'll build
+
+A "Tax ID" prompt on the vendor store-setup surface. The vendor types a VAT number; it rides `additional_data` to `POST /vendor/sellers/:id`, and a workflow hook stores it durably through the [Custom Fields module](/rc/resources/customization/custom-fields).
+
+## Register the typed targets (once)
+
+Widget zones are typed ids the vendor panel generates from its own pages and ships as `@mercurjs/vendor/extension-targets`. Register them once (shipped by `create-mercur-app`):
+
+```typescript apps/vendor/src/extension-targets.d.ts
+/// <reference types="@mercurjs/vendor/extension-targets" />
+```
+
+With it present, `store.setup` autocompletes and an invalid zone fails `tsc` instead of silently doing nothing.
+
+## 1 — Render on the onboarding surface
+
+<Steps>
+  <Step title="Add the store-setup widget">
+    Drop a file under `src/widgets/`. Export the component as the **default** and a `config` with `zone: "store.setup.before"`. The zone hands your component the `seller` as `data`:
+
+    ```tsx apps/vendor/src/widgets/tax-id-setup.tsx
+    import "@mercurjs/vendor/extension-targets"
+    import { defineWidgetConfig } from "@mercurjs/dashboard-sdk"
+    import { SellerDTO } from "@mercurjs/types"
+    import { Container, Heading, Input, Button, Text, toast } from "@medusajs/ui"
+    import { useMutation } from "@tanstack/react-query"
+    import { useState } from "react"
+
+    import { client } from "../lib/client"
+
+    export const config = defineWidgetConfig({
+      zone: "store.setup.before",
+    })
+
+    const TaxIdSetup = ({ data: seller }: { data?: SellerDTO }) => {
+      const [taxId, setTaxId] = useState("")
+
+      const { mutate, isPending } = useMutation({
+        mutationFn: () =>
+          client.vendor.sellers.$id.mutate({
+            $id: seller!.id,
+            // additional_data is accepted on every vendor seller route —
+            // it never touches the built-in seller columns.
+            additional_data: { tax_id: taxId },
+          }),
+        onSuccess: () => toast.success("Tax ID saved"),
+        onError: () => toast.error("Could not save Tax ID"),
+      })
+
+      if (!seller) {
+        return null
+      }
+
+      return (
+        <Container className="mb-2 flex items-end gap-x-3">
+          <div className="flex-1">
+            <Heading level="h2">Complete your tax details</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              Add your VAT / Tax ID to finish store setup.
+            </Text>
+            <Input
+              className="mt-3"
+              placeholder="VAT-000000"
+              value={taxId}
+              onChange={(e) => setTaxId(e.target.value)}
+              data-testid="tax-id-setup-input"
+            />
+          </div>
+          <Button
+            size="small"
+            isLoading={isPending}
+            disabled={!taxId}
+            onClick={() => mutate()}
+            data-testid="tax-id-setup-save"
+          >
+            Save
+          </Button>
+        </Container>
+      )
+    }
+
+    export default TaxIdSetup
+    ```
+  </Step>
+  <Step title="Understand where it renders">
+    `store.setup` is hosted in two places, both passing the same `seller` as `data`:
+
+    | Host | When it shows |
+    |------|---------------|
+    | The vendor shell (above the page outlet) | On top-level routes — the dashboard "home" onboarding banner |
+    | The store settings detail page | Always, above the store status banner |
+
+    A single widget file covers both. Multiple `store.setup.before` / `.after` widgets stack in registration order.
+  </Step>
+</Steps>
+
+<Note>
+  **`client` is your app's typed SDK.** `create-mercur-app` ships `apps/vendor/src/lib/client.ts` — a `createClient<Routes>()` instance. `client.vendor.sellers.$id.mutate(...)` is the typed `POST /vendor/sellers/:id`, so the request and response types match the backend route.
+</Note>
+
+## 2 — Carry the value through `additional_data`
+
+You don't touch the seller route or its validator. Every vendor and admin seller route already wraps its body with `WithAdditionalData`, so an unknown `additional_data` object is accepted and forwarded into the workflow untouched:
+
+```ts packages/core/src/api/vendor/sellers/[id]/route.ts (built-in — for reference)
+const { additional_data, ...update } = req.validatedBody
+
+await updateSellersWorkflow(req.scope).run({
+  input: {
+    selector: { id: req.params.id },
+    update,
+    additional_data, // ← forwarded to the workflow's hooks
+  },
+})
+```
+
+That is the whole "wiring" step: your `{ tax_id }` payload arrives in the workflow as `additional_data` without a schema change.
+
+## 3 — Persist it from a workflow hook
+
+`updateSellersWorkflow` exposes a `sellersUpdated` hook that runs after the update with `{ sellers, additional_data }`. Subscribe to it in your Medusa app and persist the value.
+
+<Steps>
+  <Step title="Declare a durable field">
+    Register a `Seller` custom field so the value gets a real, queryable column (no migration to hand-write):
+
+    ```ts apps/api/medusa-config.ts
+    module.exports = defineConfig({
+      // ...
+      modules: [
+        {
+          resolve: "@mercurjs/core/modules/custom-fields",
+          options: {
+            customFields: {
+              Seller: {
+                tax_id: { type: "string", nullable: true },
+              },
+            },
+          },
+        },
+      ],
+    })
+    ```
+
+    ```bash
+    bunx medusa db:migrate
+    ```
+  </Step>
+  <Step title="Subscribe to the hook">
+    Drop a file under `src/workflows/` in your Medusa app. Medusa imports everything under `src/workflows` at boot, so registering the hook is just defining it. Read `additional_data`, upsert through the Custom Fields service:
+
+    ```ts apps/api/src/workflows/hooks/seller-tax-id.ts
+    import { updateSellersWorkflow } from "@mercurjs/core/workflows"
+    import { MercurModules } from "@mercurjs/types"
+
+    updateSellersWorkflow.hooks.sellersUpdated(
+      async ({ sellers, additional_data }, { container }) => {
+        const taxId = additional_data?.tax_id
+        if (typeof taxId !== "string") {
+          return
+        }
+
+        const customFields = container.resolve(MercurModules.CUSTOM_FIELDS)
+
+        await customFields.upsert(
+          "seller",
+          sellers.map((seller) => ({ id: seller.id, tax_id: taxId })),
+        )
+      },
+    )
+    ```
+
+    <Tip>
+      The hook fires for **every** seller update, not only your widget's — always guard on the field being present (`typeof taxId !== "string"`) so unrelated edits (name, address, status) pass through untouched.
+    </Tip>
+  </Step>
+  <Step title="Read it back">
+    The value is now linked to the seller and queryable through Medusa's remote query:
+
+    ```ts
+    const { data: [seller] } = await query.graph({
+      entity: "seller",
+      fields: ["id", "name", "custom_fields.tax_id"],
+      filters: { id: sellerId },
+    })
+    ```
+
+    Add `custom_fields.*` to the `/vendor/sellers/me` query config if you want the widget to reflect the saved value on reload.
+  </Step>
+</Steps>
+
+## How the layers connect
+
+```
+store.setup widget  →  client.vendor.sellers.$id.mutate({ additional_data })
+        │
+        ▼
+POST /vendor/sellers/:id  →  updateSellersWorkflow({ update, additional_data })
+        │
+        ▼
+hook: sellersUpdated({ sellers, additional_data })  →  customFields.upsert("seller", …)
+        │
+        ▼
+seller.custom_fields.tax_id  (durable, queryable)
+```
+
+## Verify
+
+1. Open the vendor portal — the Tax ID prompt renders on the dashboard home and on **Settings → Store**.
+2. Enter a value and save — the mutation succeeds (`toast.success`) and hits `POST /vendor/sellers/:id`.
+3. `query.graph({ entity: "seller", fields: ["custom_fields.tax_id"] })` returns the saved value.
+4. Edit an unrelated field (store name) — the seller update still works and the guard skips the upsert.
+5. Set `zone: "not.a.zone"` on the widget — `bun run lint` (tsc) fails against `WidgetZoneId`.
+6. Delete the widget file — the prompt disappears; the seller route and hook are unaffected.
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Why additional_data instead of adding a body field?">
+    The seller routes' validators are core-owned. `additional_data` is the sanctioned escape hatch — every vendor and admin route wraps its body with `WithAdditionalData`, so you carry extra context to the workflow hooks without patching the request schema or forking the route.
+  </Accordion>
+  <Accordion title="Which seller workflows expose hooks?">
+    `updateSellersWorkflow` exposes `sellersUpdated`, and `createSellerAccountWorkflow` (the `POST /vendor/sellers` onboarding submit) exposes `sellerAccountCreated` — both carry `{ additional_data }`. Use `sellerAccountCreated` to capture data at first registration and `sellersUpdated` for later edits. See the [workflow references](/rc/references/workflows/seller/update-sellers).
+  </Accordion>
+  <Accordion title="Can I store it on the seller's metadata instead?">
+    Yes — for a quick, non-queryable value, resolve the seller module in the hook and write to `seller.metadata`. Reach for the [Custom Fields module](/rc/resources/customization/custom-fields) when you want a typed, queryable column, which is what most onboarding data (tax IDs, compliance flags) needs.
+  </Accordion>
+  <Accordion title="Does the hook run inside the request?">
+    Yes — workflow hooks run as steps of the workflow the route invokes, with the same compensation/rollback semantics. If your hook throws, the seller update rolls back. Keep slow or best-effort work (external syncs) in a subscriber on the emitted `seller.updated` event instead.
+  </Accordion>
+</AccordionGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Extend a workflow" href="/rc/resources/customization/extend-a-workflow">
+    The full hook + compensation model for Mercur workflows.
+  </Card>
+  <Card title="Custom Fields module" href="/rc/resources/customization/custom-fields">
+    Durable, queryable storage for the data your hook writes.
+  </Card>
+</CardGroup>
+</content>

--- a/packages/admin/src/extension-targets.d.ts
+++ b/packages/admin/src/extension-targets.d.ts
@@ -185,7 +185,7 @@ declare module "@mercurjs/dashboard-sdk" {
       displayZones: "general"
       displayFieldIds: "available_quantity" | "description" | "header" | "line_item_id" | "location" | "reserved_quantity" | "stocked_quantity"
     }
-    "store": {
+    "seller": {
       formZones: "create" | "edit"
       formTabs: { "create": "details" | "users" }
       displayZones: "address" | "company-details" | "configuration" | "general" | "members" | "offers" | "orders" | "payment-details" | "requests"

--- a/packages/admin/src/pages/stores/store-create/components/store-create-form.tsx
+++ b/packages/admin/src/pages/stores/store-create/components/store-create-form.tsx
@@ -67,7 +67,7 @@ export const StoreCreateForm = ({ children }: StoreCreateFormProps) => {
   );
 
   return (
-    <TabbedForm model="store" zone="create" form={form} onSubmit={handleSubmit} isLoading={isPending}>
+    <TabbedForm model="seller" zone="create" form={form} onSubmit={handleSubmit} isLoading={isPending}>
       {Children.count(children) > 0 ? children : defaultTabs}
     </TabbedForm>
   );

--- a/packages/admin/src/pages/stores/store-details/components/store-address-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-address-section.tsx
@@ -82,7 +82,7 @@ export const StoreAddressSection = ({ seller }: StoreAddressSectionProps) => {
           </Text>
         </div>
       )}
-      <DisplayExtensionZone model="store" zone="address" data={seller} />
+      <DisplayExtensionZone model="seller" zone="address" data={seller} />
     </Container>
   );
 };

--- a/packages/admin/src/pages/stores/store-details/components/store-company-details-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-company-details-section.tsx
@@ -76,7 +76,7 @@ export const StoreCompanyDetailsSection = ({
           </Text>
         </div>
       )}
-      <DisplayExtensionZone model="store" zone="company-details" data={seller} />
+      <DisplayExtensionZone model="seller" zone="company-details" data={seller} />
     </Container>
   );
 };

--- a/packages/admin/src/pages/stores/store-details/components/store-configuration-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-configuration-section.tsx
@@ -57,7 +57,7 @@ export const StoreConfigurationSection = ({
           message={t("store.timeOff.empty.message")}
         />
       )}
-      <DisplayExtensionZone model="store" zone="configuration" data={seller} />
+      <DisplayExtensionZone model="seller" zone="configuration" data={seller} />
     </Container>
   );
 };

--- a/packages/admin/src/pages/stores/store-details/components/store-general-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-general-section.tsx
@@ -54,7 +54,7 @@ export const StoreGeneralSection = ({
             )}
           </div>
           <StoreDetailHeader seller={seller} />
-          <DisplayField model="store" zone="general" id="description" data={seller}>
+          <DisplayField model="seller" zone="general" id="description" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.description")}
@@ -64,7 +64,7 @@ export const StoreGeneralSection = ({
               </Text>
             </div>
           </DisplayField>
-          <DisplayField model="store" zone="general" id="handle" data={seller}>
+          <DisplayField model="seller" zone="general" id="handle" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.handle")}
@@ -74,7 +74,7 @@ export const StoreGeneralSection = ({
               </Text>
             </div>
           </DisplayField>
-          <DisplayField model="store" zone="general" id="email" data={seller}>
+          <DisplayField model="seller" zone="general" id="email" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.email")}
@@ -84,7 +84,7 @@ export const StoreGeneralSection = ({
               </Text>
             </div>
           </DisplayField>
-          <DisplayField model="store" zone="general" id="phone" data={seller}>
+          <DisplayField model="seller" zone="general" id="phone" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.phone")}
@@ -94,7 +94,7 @@ export const StoreGeneralSection = ({
               </Text>
             </div>
           </DisplayField>
-          <DisplayField model="store" zone="general" id="website_url" data={seller}>
+          <DisplayField model="seller" zone="general" id="website_url" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.website")}
@@ -104,7 +104,7 @@ export const StoreGeneralSection = ({
               </Text>
             </div>
           </DisplayField>
-          <DisplayField model="store" zone="general" id="currency_code" data={seller}>
+          <DisplayField model="seller" zone="general" id="currency_code" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.currency")}
@@ -120,7 +120,7 @@ export const StoreGeneralSection = ({
             </div>
           </DisplayField>
           <DisplayExtensionZone
-            model="store"
+            model="seller"
             zone="general"
             data={seller}
             builtInFieldIds={[

--- a/packages/admin/src/pages/stores/store-details/components/store-members-section/store-members-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-members-section/store-members-section.tsx
@@ -24,7 +24,7 @@ export const StoreMembersSection = ({ sellerId }: StoreMembersSectionProps) => {
         </Link>
       </div>
       <StoreMembersDataTable sellerId={sellerId} />
-      <DisplayExtensionZone model="store" zone="members" data={sellerId} />
+      <DisplayExtensionZone model="seller" zone="members" data={sellerId} />
     </Container>
   );
 };

--- a/packages/admin/src/pages/stores/store-details/components/store-offers-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-offers-section.tsx
@@ -100,7 +100,7 @@ export const StoreOffersSection = ({ sellerId }: StoreOffersSectionProps) => {
         }}
         commands={commands}
       />
-      <DisplayExtensionZone model="store" zone="offers" data={sellerId} />
+      <DisplayExtensionZone model="seller" zone="offers" data={sellerId} />
     </Container>
   );
 };

--- a/packages/admin/src/pages/stores/store-details/components/store-orders-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-orders-section.tsx
@@ -94,7 +94,7 @@ export const StoreOrdersSection = ({ sellerId }: StoreOrdersSectionProps) => {
           icon: <ShoppingCart className="text-ui-fg-subtle" />,
         }}
       />
-      <DisplayExtensionZone model="store" zone="orders" data={sellerId} />
+      <DisplayExtensionZone model="seller" zone="orders" data={sellerId} />
     </Container>
   );
 };

--- a/packages/admin/src/pages/stores/store-details/components/store-payment-details-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-payment-details-section.tsx
@@ -81,7 +81,7 @@ export const StorePaymentDetailsSection = ({
           </Text>
         </div>
       )}
-      <DisplayExtensionZone model="store" zone="payment-details" data={seller} />
+      <DisplayExtensionZone model="seller" zone="payment-details" data={seller} />
     </Container>
   );
 };

--- a/packages/admin/src/pages/stores/store-details/components/store-request-section.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-request-section.tsx
@@ -121,7 +121,7 @@ export const StoreRequestSection = ({ seller }: StoreRequestSectionProps) => {
           }}
         />
       </div>
-      <DisplayExtensionZone model="store" zone="requests" data={seller} />
+      <DisplayExtensionZone model="seller" zone="requests" data={seller} />
     </Container>
   );
 };

--- a/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
+++ b/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
@@ -101,7 +101,7 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
 
   const form = useExtendableForm({
     schema: EditStoreSchema,
-    model: "store",
+    model: "seller",
     data: seller,
     defaultValues: {
       status: (seller.status as SellerStatus) ?? SellerStatus.OPEN,
@@ -179,6 +179,7 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
         is_premium: values.is_premium,
         logo: logoUrl,
         banner: bannerUrl,
+        additional_data: values.additional_data,
       },
       {
         onSuccess: () => {
@@ -454,7 +455,7 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
             </div>
           </div>
           <FormExtensionZone
-            model="store"
+            model="seller"
             zone="edit"
             control={form.control}
             data={seller}

--- a/packages/admin/src/pages/stores/store-list/components/store-list-table/store-list-data-table.tsx
+++ b/packages/admin/src/pages/stores/store-list/components/store-list-table/store-list-data-table.tsx
@@ -156,7 +156,7 @@ const useColumns = () => {
   )
 
   const { columns: extended, filters } = useExtendableTable<SellerDTO>({
-    model: "store",
+    model: "seller",
     columns: [selectColumn, ...base] as unknown as ColumnDef<
       SellerDTO,
       unknown

--- a/packages/core/src/api/vendor/members/me/route.ts
+++ b/packages/core/src/api/vendor/members/me/route.ts
@@ -55,8 +55,10 @@ export const POST = async (
     )
   }
 
+  const { additional_data, ...update } = req.validatedBody
+
   await updateMemberWorkflow(req.scope).run({
-    input: { selector: { id: memberId }, update: req.validatedBody },
+    input: { selector: { id: memberId }, update, additional_data },
   })
 
   const { data: sellerMembers } = await query.graph({

--- a/packages/core/src/api/vendor/members/validators.ts
+++ b/packages/core/src/api/vendor/members/validators.ts
@@ -1,5 +1,8 @@
 import { z } from "zod"
 
+import { WithAdditionalData } from "@medusajs/medusa/api/utils/validators"
+import { AdditionalData } from "@medusajs/framework/types"
+
 export type VendorAcceptMemberInviteType = z.infer<typeof VendorAcceptMemberInvite>
 export const VendorAcceptMemberInvite = z.object({
   invite_token: z.string(),
@@ -7,9 +10,11 @@ export const VendorAcceptMemberInvite = z.object({
   last_name: z.string().nullable().optional(),
 })
 
-export type VendorUpdateMemberType = z.infer<typeof VendorUpdateMember>
-export const VendorUpdateMember = z.object({
+export const UpdateMember = z.object({
   first_name: z.string().nullable().optional(),
   last_name: z.string().nullable().optional(),
   locale: z.string().nullable().optional(),
 })
+
+export type VendorUpdateMemberType = z.infer<typeof UpdateMember> & AdditionalData
+export const VendorUpdateMember = WithAdditionalData(UpdateMember)

--- a/packages/core/src/workflows/seller/workflows/update-member.ts
+++ b/packages/core/src/workflows/seller/workflows/update-member.ts
@@ -1,26 +1,51 @@
 import {
+  createHook,
   createWorkflow,
   WorkflowResponse,
+  type Hook,
+  type ReturnWorkflow,
 } from "@medusajs/framework/workflows-sdk"
+import { AdditionalData } from "@medusajs/framework/types"
+import { MemberDTO } from "@mercurjs/types"
 
 import { updateMembersStep } from "../steps"
 
 export const updateMemberWorkflowId = "update-member"
 
-type UpdateMemberWorkflowInput = {
+export type UpdateMemberWorkflowInput = {
   selector: Record<string, unknown>
   update: {
     first_name?: string | null
     last_name?: string | null
     locale?: string | null
   }
-}
+} & AdditionalData
 
-export const updateMemberWorkflow = createWorkflow(
+export type UpdateMemberWorkflowHooks = [
+  Hook<
+    "membersUpdated",
+    {
+      members: MemberDTO[]
+      additional_data: Record<string, unknown> | undefined
+    },
+    unknown
+  >,
+]
+
+export const updateMemberWorkflow: ReturnWorkflow<
+  UpdateMemberWorkflowInput,
+  MemberDTO[],
+  UpdateMemberWorkflowHooks
+> = createWorkflow(
   updateMemberWorkflowId,
   function (input: UpdateMemberWorkflowInput) {
     const members = updateMembersStep(input)
 
-    return new WorkflowResponse(members)
+    const membersUpdated = createHook("membersUpdated", {
+      members,
+      additional_data: input.additional_data,
+    })
+
+    return new WorkflowResponse(members, { hooks: [membersUpdated] })
   }
 )

--- a/packages/vendor/src/extension-targets.d.ts
+++ b/packages/vendor/src/extension-targets.d.ts
@@ -148,6 +148,12 @@ declare module "@mercurjs/dashboard-sdk" {
       displayZones: "attributes" | "general" | "locations" | "variants"
       displayFieldIds: "available" | "in_stock" | "reserved" | "sku" | "title"
     }
+    "member": {
+      formZones: "edit"
+      formTabs: Record<string, string>
+      displayZones: "general"
+      displayFieldIds: "first_name" | "language" | "last_name"
+    }
     "offer": {
       formZones: "create" | "edit"
       formTabs: { "create": "catalogue" | "stockLevelsAndPrices" }
@@ -191,16 +197,10 @@ declare module "@mercurjs/dashboard-sdk" {
       displayFieldIds: "available_quantity" | "description" | "line_item_id" | "location" | "reserved_quantity" | "stocked_quantity" | "title"
     }
     "seller": {
-      formZones: "onboarding"
+      formZones: "address" | "edit" | "onboarding" | "payment-details" | "professional-details"
       formTabs: Record<string, string>
-      displayZones: "store-select"
-      displayFieldIds: "status"
-    }
-    "store": {
-      formZones: never
-      formTabs: Record<string, string>
-      displayZones: "general"
-      displayFieldIds: "currency_code" | "description" | "email" | "handle" | "phone" | "website_url"
+      displayZones: "general" | "seller-select"
+      displayFieldIds: "currency_code" | "description" | "email" | "handle" | "phone" | "status" | "website_url"
     }
   }
 }

--- a/packages/vendor/src/pages/settings/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
+++ b/packages/vendor/src/pages/settings/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
@@ -1,6 +1,10 @@
 import { PencilSquare } from "@medusajs/icons"
 import { Container, Heading, Text } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
+import {
+  DisplayExtensionZone,
+  DisplayField,
+} from "@mercurjs/dashboard-shared"
 import { ActionMenu } from "../../../../../../components/common/action-menu"
 import { useMe } from "../../../../../../hooks/api"
 import { languages } from "../../../../../../i18n/languages"
@@ -33,31 +37,38 @@ export const ProfileGeneralSection = () => {
           ]}
         />
       </div>
-      <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
-        <Text size="small" leading="compact" weight="plus">
-          {t("profile.fields.firstName", "First name")}
-        </Text>
-        <Text size="small" leading="compact">
-          {member?.first_name || "-"}
-        </Text>
-      </div>
-      <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
-        <Text size="small" leading="compact" weight="plus">
-          {t("profile.fields.lastName", "Last name")}
-        </Text>
-        <Text size="small" leading="compact">
-          {member?.last_name || "-"}
-        </Text>
-      </div>
-      <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
-        <Text size="small" leading="compact" weight="plus">
-          {t("profile.fields.languageLabel")}
-        </Text>
-        <Text size="small" leading="compact">
-          {languages.find((lang) => lang.code === i18n.language)
-            ?.display_name || "-"}
-        </Text>
-      </div>
+      <DisplayField model="member" zone="general" id="first_name" data={member}>
+        <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+          <Text size="small" leading="compact" weight="plus">
+            {t("profile.fields.firstName", "First name")}
+          </Text>
+          <Text size="small" leading="compact">
+            {member?.first_name || "-"}
+          </Text>
+        </div>
+      </DisplayField>
+      <DisplayField model="member" zone="general" id="last_name" data={member}>
+        <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+          <Text size="small" leading="compact" weight="plus">
+            {t("profile.fields.lastName", "Last name")}
+          </Text>
+          <Text size="small" leading="compact">
+            {member?.last_name || "-"}
+          </Text>
+        </div>
+      </DisplayField>
+      <DisplayField model="member" zone="general" id="language" data={member}>
+        <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+          <Text size="small" leading="compact" weight="plus">
+            {t("profile.fields.languageLabel")}
+          </Text>
+          <Text size="small" leading="compact">
+            {languages.find((lang) => lang.code === i18n.language)
+              ?.display_name || "-"}
+          </Text>
+        </div>
+      </DisplayField>
+      <DisplayExtensionZone model="member" zone="general" data={member} />
     </Container>
   )
 }

--- a/packages/vendor/src/pages/settings/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
+++ b/packages/vendor/src/pages/settings/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
@@ -1,8 +1,8 @@
-import { zodResolver } from "@hookform/resolvers/zod"
 import { Button, Input, Select, toast } from "@medusajs/ui"
-import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
+
+import { FormExtensionZone, useExtendableForm } from "@mercurjs/dashboard-shared"
 
 import { Form } from "../../../../../../components/common/form"
 import { RouteDrawer, useRouteModal } from "../../../../../../components/modals"
@@ -25,13 +25,15 @@ export const EditProfileForm = () => {
   const { seller_member } = useMe()
   const member = seller_member?.member
 
-  const form = useForm<zod.infer<typeof EditProfileSchema>>({
+  const form = useExtendableForm({
+    schema: EditProfileSchema,
+    model: "member",
+    data: member,
     defaultValues: {
       first_name: member?.first_name ?? "",
       last_name: member?.last_name ?? "",
       language: i18n.language,
     },
-    resolver: zodResolver(EditProfileSchema),
   })
 
   const sortedLanguages = languages.sort((a, b) =>
@@ -45,6 +47,7 @@ export const EditProfileForm = () => {
       {
         first_name: values.first_name || null,
         last_name: values.last_name || null,
+        additional_data: values.additional_data,
       },
       {
         onSuccess: async () => {
@@ -139,6 +142,12 @@ export const EditProfileForm = () => {
                   </div>
                 </Form.Item>
               )}
+            />
+            <FormExtensionZone
+              model="member"
+              zone="edit"
+              control={form.control}
+              data={member}
             />
           </div>
         </RouteDrawer.Body>

--- a/packages/vendor/src/pages/settings/store/_components/store-general-section.tsx
+++ b/packages/vendor/src/pages/settings/store/_components/store-general-section.tsx
@@ -49,7 +49,7 @@ export const StoreGeneralSection = ({
           </div>
           <StoreDetailHeader seller={seller} />
           <DisplayField
-            model="store"
+            model="seller"
             zone="general"
             id="description"
             data={seller}
@@ -63,7 +63,7 @@ export const StoreGeneralSection = ({
               </Text>
             </div>
           </DisplayField>
-          <DisplayField model="store" zone="general" id="handle" data={seller}>
+          <DisplayField model="seller" zone="general" id="handle" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.handle")}
@@ -73,7 +73,7 @@ export const StoreGeneralSection = ({
               </Text>
             </div>
           </DisplayField>
-          <DisplayField model="store" zone="general" id="email" data={seller}>
+          <DisplayField model="seller" zone="general" id="email" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.email")}
@@ -83,7 +83,7 @@ export const StoreGeneralSection = ({
               </Text>
             </div>
           </DisplayField>
-          <DisplayField model="store" zone="general" id="phone" data={seller}>
+          <DisplayField model="seller" zone="general" id="phone" data={seller}>
             <div className="text-ui-fg-subtle grid grid-cols-2 px-6 py-4">
               <Text size="small" leading="compact" weight="plus">
                 {t("fields.phone")}
@@ -94,7 +94,7 @@ export const StoreGeneralSection = ({
             </div>
           </DisplayField>
           <DisplayField
-            model="store"
+            model="seller"
             zone="general"
             id="website_url"
             data={seller}
@@ -109,7 +109,7 @@ export const StoreGeneralSection = ({
             </div>
           </DisplayField>
           <DisplayField
-            model="store"
+            model="seller"
             zone="general"
             id="currency_code"
             data={seller}

--- a/packages/vendor/src/pages/settings/store/address/store-address-form.tsx
+++ b/packages/vendor/src/pages/settings/store/address/store-address-form.tsx
@@ -1,9 +1,9 @@
-import { zodResolver } from "@hookform/resolvers/zod";
 import i18n from "i18next";
 import { Button, Input, toast } from "@medusajs/ui";
-import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
+
+import { FormExtensionZone, useExtendableForm } from "@mercurjs/dashboard-shared";
 
 import { Form } from "@components/common/form";
 import { CountrySelect } from "@components/inputs/country-select";
@@ -36,7 +36,10 @@ export const StoreAddressForm = ({ seller }: StoreAddressFormProps) => {
   const { handleSuccess } = useRouteModal();
   const address = seller.address;
 
-  const form = useForm<zod.infer<typeof StoreAddressSchema>>({
+  const form = useExtendableForm({
+    schema: StoreAddressSchema,
+    model: "seller",
+    data: seller,
     defaultValues: {
       name: address?.name ?? "",
       address_1: address?.address_1 ?? "",
@@ -46,7 +49,6 @@ export const StoreAddressForm = ({ seller }: StoreAddressFormProps) => {
       postal_code: address?.postal_code ?? "",
       country_code: address?.country_code ?? "",
     },
-    resolver: zodResolver(StoreAddressSchema),
   });
 
   const { mutateAsync, isPending } = useUpdateSellerAddress(seller.id);
@@ -61,6 +63,7 @@ export const StoreAddressForm = ({ seller }: StoreAddressFormProps) => {
         province: values.province || null,
         postal_code: values.postal_code || null,
         country_code: values.country_code,
+        additional_data: values.additional_data,
       },
       {
         onSuccess: () => {
@@ -173,6 +176,12 @@ export const StoreAddressForm = ({ seller }: StoreAddressFormProps) => {
                 <Form.ErrorMessage />
               </Form.Item>
             )}
+          />
+          <FormExtensionZone
+            model="seller"
+            zone="address"
+            control={form.control}
+            data={seller}
           />
         </RouteDrawer.Body>
         <RouteDrawer.Footer>

--- a/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
+++ b/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
@@ -1,4 +1,3 @@
-import { zodResolver } from "@hookform/resolvers/zod";
 import i18n from "i18next";
 import { InformationCircleSolid } from "@medusajs/icons";
 import {
@@ -10,10 +9,12 @@ import {
   Textarea,
   toast,
 } from "@medusajs/ui";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useFieldArray } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
 import { useCallback } from "react";
+
+import { FormExtensionZone, useExtendableForm } from "@mercurjs/dashboard-shared";
 
 import { FileType, FileUpload } from "@components/common/file-upload";
 import { Form } from "@components/common/form";
@@ -90,7 +91,10 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
   const { t } = useTranslation();
   const { handleSuccess } = useRouteModal();
 
-  const form = useForm<zod.infer<typeof EditStoreSchema>>({
+  const form = useExtendableForm({
+    schema: EditStoreSchema,
+    model: "seller",
+    data: seller,
     defaultValues: {
       name: seller.name ?? "",
       handle: seller.handle ?? "",
@@ -105,7 +109,6 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
         ? [{ id: "existing-banner", url: seller.banner, isThumbnail: false, file: null }]
         : [],
     },
-    resolver: zodResolver(EditStoreSchema),
   });
 
   const { fields: logoFields } = useFieldArray({
@@ -164,6 +167,7 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
         website_url: ensureWebsiteProtocol(values.website_url),
         logo: logoUrl,
         banner: bannerUrl,
+        additional_data: values.additional_data,
       },
       {
         onSuccess: () => {
@@ -402,6 +406,12 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
               </div>
             </div>
           </div>
+          <FormExtensionZone
+            model="seller"
+            zone="edit"
+            control={form.control}
+            data={seller}
+          />
         </RouteDrawer.Body>
         <RouteDrawer.Footer>
           <div className="flex items-center justify-end gap-x-2">

--- a/packages/vendor/src/pages/settings/store/payment-details/store-payment-details-form.tsx
+++ b/packages/vendor/src/pages/settings/store/payment-details/store-payment-details-form.tsx
@@ -1,9 +1,9 @@
-import { zodResolver } from "@hookform/resolvers/zod";
 import i18n from "i18next";
 import { Button, Input, toast } from "@medusajs/ui";
-import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
+
+import { FormExtensionZone, useExtendableForm } from "@mercurjs/dashboard-shared";
 
 import { Form } from "@components/common/form";
 import { CountrySelect } from "@components/inputs/country-select/country-select";
@@ -40,7 +40,10 @@ export const StorePaymentDetailsForm = ({
   const { handleSuccess } = useRouteModal();
   const details = seller.payment_details;
 
-  const form = useForm<zod.infer<typeof StorePaymentDetailsSchema>>({
+  const form = useExtendableForm({
+    schema: StorePaymentDetailsSchema,
+    model: "seller",
+    data: seller,
     defaultValues: {
       country_code: details?.country_code ?? "",
       holder_name: details?.holder_name ?? "",
@@ -49,7 +52,6 @@ export const StorePaymentDetailsForm = ({
       routing_number: details?.routing_number ?? "",
       account_number: details?.account_number ?? "",
     },
-    resolver: zodResolver(StorePaymentDetailsSchema),
   });
 
   const selectedCountry = form.watch("country_code");
@@ -66,6 +68,7 @@ export const StorePaymentDetailsForm = ({
         bic: isABA ? null : values.bic || null,
         routing_number: isABA ? values.routing_number || null : null,
         account_number: values.account_number || null,
+        additional_data: values.additional_data,
       },
       {
         onSuccess: () => {
@@ -200,6 +203,12 @@ export const StorePaymentDetailsForm = ({
               />
             </>
           )}
+          <FormExtensionZone
+            model="seller"
+            zone="payment-details"
+            control={form.control}
+            data={seller}
+          />
         </RouteDrawer.Body>
         <RouteDrawer.Footer>
           <div className="flex items-center justify-end gap-x-2">

--- a/packages/vendor/src/pages/settings/store/professional-details/store-professional-details-form.tsx
+++ b/packages/vendor/src/pages/settings/store/professional-details/store-professional-details-form.tsx
@@ -1,8 +1,8 @@
-import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Input, toast } from "@medusajs/ui";
-import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as zod from "zod";
+
+import { FormExtensionZone, useExtendableForm } from "@mercurjs/dashboard-shared";
 
 import { Form } from "@components/common/form";
 import { RouteDrawer, useRouteModal } from "@components/modals";
@@ -27,13 +27,15 @@ export const StoreProfessionalDetailsForm = ({
   const { handleSuccess } = useRouteModal();
   const details = seller.professional_details;
 
-  const form = useForm<zod.infer<typeof StoreProfessionalDetailsSchema>>({
+  const form = useExtendableForm({
+    schema: StoreProfessionalDetailsSchema,
+    model: "seller",
+    data: seller,
     defaultValues: {
       corporate_name: details?.corporate_name ?? "",
       registration_number: details?.registration_number ?? "",
       tax_id: details?.tax_id ?? "",
     },
-    resolver: zodResolver(StoreProfessionalDetailsSchema),
   });
 
   const { mutateAsync, isPending } = useUpdateSellerProfessionalDetails(
@@ -46,6 +48,7 @@ export const StoreProfessionalDetailsForm = ({
         corporate_name: values.corporate_name || null,
         registration_number: values.registration_number || null,
         tax_id: values.tax_id || null,
+        additional_data: values.additional_data,
       },
       {
         onSuccess: () => {
@@ -112,6 +115,12 @@ export const StoreProfessionalDetailsForm = ({
                 <Form.ErrorMessage />
               </Form.Item>
             )}
+          />
+          <FormExtensionZone
+            model="seller"
+            zone="professional-details"
+            control={form.control}
+            data={seller}
           />
         </RouteDrawer.Body>
         <RouteDrawer.Footer>

--- a/packages/vendor/src/pages/store-select/store-select.tsx
+++ b/packages/vendor/src/pages/store-select/store-select.tsx
@@ -101,7 +101,7 @@ const StoreSelectList = ({
               </div>
               <DisplayField
                 model="seller"
-                zone="store-select"
+                zone="seller-select"
                 id="status"
                 data={seller}
               >
@@ -111,7 +111,7 @@ const StoreSelectList = ({
               </DisplayField>
               <DisplayExtensionZone
                 model="seller"
-                zone="store-select"
+                zone="seller-select"
                 data={seller}
               />
               <ChevronRight className="text-ui-fg-muted" />


### PR DESCRIPTION
## Summary

Adds custom-field form extension zones for the `seller` model across the admin and vendor store-settings surfaces, mirroring the existing panel-extension pattern.

- **Admin** — `store-edit` form uses `useExtendableForm({ model: "seller" })` + `FormExtensionZone`, and threads `additional_data` into the seller update payload. `store-create` wizard anchors its tabs to the seller `create` zone.
- **Vendor** — store settings forms (edit, professional-details, address, payment-details) convert to `useExtendableForm({ model: "seller" })`, render `FormExtensionZone`, and thread `additional_data` into the vendor seller routes.
- Regenerated `extension-targets.d.ts` for both admin and vendor so the `seller` model exposes the new `formZones` / `formTabs` / `displayZones`.
- Docs updates for the panel-extension references.

No template changes.

## Testing
- `bunx tsc --noEmit` on `@mercurjs/admin` — no new errors in the touched files (remaining errors are pre-existing and unrelated).