### PR TITLE
feat(dashboard): widget extension zones across admin & vendor pages

### DIFF
--- a/packages/admin/src/extension-targets.d.ts
+++ b/packages/admin/src/extension-targets.d.ts
@@ -4,6 +4,14 @@ import "@mercurjs/dashboard-sdk"
 
 declare module "@mercurjs/dashboard-sdk" {
   interface WidgetZoneRegistry {
+    "api-keys.detail.main.after": true
+    "api-keys.detail.main.before": true
+    "api-keys.list.after": true
+    "api-keys.list.before": true
+    "attributes.detail.main.after": true
+    "attributes.detail.main.before": true
+    "attributes.list.after": true
+    "attributes.list.before": true
     "campaigns.detail.main.after": true
     "campaigns.detail.main.before": true
     "campaigns.detail.side.after": true
@@ -20,6 +28,10 @@ declare module "@mercurjs/dashboard-sdk" {
     "collections.detail.main.before": true
     "collections.list.after": true
     "collections.list.before": true
+    "commissions.detail.main.after": true
+    "commissions.detail.main.before": true
+    "commissions.list.after": true
+    "commissions.list.before": true
     "customer-groups.detail.main.after": true
     "customer-groups.detail.main.before": true
     "customer-groups.list.after": true
@@ -36,6 +48,18 @@ declare module "@mercurjs/dashboard-sdk" {
     "inventory.detail.side.before": true
     "inventory.list.after": true
     "inventory.list.before": true
+    "locations.detail.main.after": true
+    "locations.detail.main.before": true
+    "locations.detail.side.after": true
+    "locations.detail.side.before": true
+    "locations.list.after": true
+    "locations.list.before": true
+    "marketplace.detail.main.after": true
+    "marketplace.detail.main.before": true
+    "offer-variants.detail.main.after": true
+    "offer-variants.detail.main.before": true
+    "offer-variants.detail.side.after": true
+    "offer-variants.detail.side.before": true
     "offers.detail.main.after": true
     "offers.detail.main.before": true
     "offers.detail.side.after": true
@@ -48,34 +72,84 @@ declare module "@mercurjs/dashboard-sdk" {
     "orders.detail.side.before": true
     "orders.list.after": true
     "orders.list.before": true
+    "payouts.detail.main.after": true
+    "payouts.detail.main.before": true
+    "payouts.list.after": true
+    "payouts.list.before": true
     "price-lists.detail.main.after": true
     "price-lists.detail.main.before": true
     "price-lists.detail.side.after": true
     "price-lists.detail.side.before": true
     "price-lists.list.after": true
     "price-lists.list.before": true
+    "product-tags.detail.main.after": true
+    "product-tags.detail.main.before": true
+    "product-tags.list.after": true
+    "product-tags.list.before": true
+    "product-types.detail.main.after": true
+    "product-types.detail.main.before": true
+    "product-types.list.after": true
+    "product-types.list.before": true
+    "product-variants.detail.main.after": true
+    "product-variants.detail.main.before": true
+    "product-variants.detail.side.after": true
+    "product-variants.detail.side.before": true
     "product.detail.main.after": true
     "product.detail.main.before": true
     "product.detail.side.after": true
     "product.detail.side.before": true
+    "products.list.after": true
+    "products.list.before": true
+    "profile.detail.main.after": true
+    "profile.detail.main.before": true
     "promotions.detail.main.after": true
     "promotions.detail.main.before": true
     "promotions.detail.side.after": true
     "promotions.detail.side.before": true
     "promotions.list.after": true
     "promotions.list.before": true
+    "refund-reasons.list.after": true
+    "refund-reasons.list.before": true
+    "regions.detail.main.after": true
+    "regions.detail.main.before": true
+    "regions.list.after": true
+    "regions.list.before": true
     "reservation.detail.main.after": true
     "reservation.detail.main.before": true
     "reservation.detail.side.after": true
     "reservation.detail.side.before": true
     "reservation.list.after": true
     "reservation.list.before": true
+    "return-reasons.list.after": true
+    "return-reasons.list.before": true
+    "sales-channels.detail.main.after": true
+    "sales-channels.detail.main.before": true
+    "sales-channels.list.after": true
+    "sales-channels.list.before": true
+    "shipping-option-types.detail.main.after": true
+    "shipping-option-types.detail.main.before": true
+    "shipping-option-types.list.after": true
+    "shipping-option-types.list.before": true
+    "shipping-profiles.detail.main.after": true
+    "shipping-profiles.detail.main.before": true
+    "shipping-profiles.list.after": true
+    "shipping-profiles.list.before": true
     "stores.detail.main.after": true
     "stores.detail.main.before": true
     "stores.detail.side.after": true
     "stores.detail.side.before": true
     "stores.list.after": true
     "stores.list.before": true
+    "tax-regions.detail.main.after": true
+    "tax-regions.detail.main.before": true
+    "tax-regions.list.after": true
+    "tax-regions.list.before": true
+    "tax-regions.province.detail.main.after": true
+    "tax-regions.province.detail.main.before": true
+    "users.detail.main.after": true
+    "users.detail.main.before": true
+    "users.list.after": true
+    "users.list.before": true
   }
 
   interface NavItemRegistry {

--- a/packages/admin/src/pages/api-key-management/api-key-management-detail/api-key-management-detail.tsx
+++ b/packages/admin/src/pages/api-key-management/api-key-management-detail/api-key-management-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useApiKey } from "../../../hooks/api/api-keys"
@@ -46,8 +47,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
       data={api_key}
       data-testid={`${api_key.type}-api-key-detail-page`}
     >
-      <ApiKeyGeneralSection apiKey={api_key} />
-      {isPublishable && <ApiKeySalesChannelSection apiKey={api_key} />}
+      <WidgetZone id="api-keys.detail.main" data={api_key}>
+        <ApiKeyGeneralSection apiKey={api_key} />
+        {isPublishable && <ApiKeySalesChannelSection apiKey={api_key} />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/api-key-management/api-key-management-list/api-key-management-list.tsx
+++ b/packages/admin/src/pages/api-key-management/api-key-management-list/api-key-management-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   ApiKeyManagementListView,
@@ -15,7 +17,9 @@ const Root = ({ children }: { children?: ReactNode }) => {
       hasOutlet
       data-testid="publishable-api-keys-list-page"
     >
-      {Children.count(children) > 0 ? children : <ApiKeyManagementListView />}
+      <WidgetZone id="api-keys.list">
+        {Children.count(children) > 0 ? children : <ApiKeyManagementListView />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/attributes/attribute-detail/attribute-detail.tsx
+++ b/packages/admin/src/pages/attributes/attribute-detail/attribute-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react";
 import { useLoaderData, useParams } from "react-router-dom";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton";
 import { SingleColumnPage } from "../../../components/layout/pages";
 import { useProductAttribute } from "../../../hooks/api";
@@ -43,8 +44,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage hasOutlet showJSON data={attribute}>
-      <AttributeGeneralSection attribute={attribute} />
-      <AttributePossibleValuesSection attribute={attribute} />
+      <WidgetZone id="attributes.detail.main" data={attribute}>
+        <AttributeGeneralSection attribute={attribute} />
+        <AttributePossibleValuesSection attribute={attribute} />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/admin/src/pages/attributes/attribute-list/attribute-list.tsx
+++ b/packages/admin/src/pages/attributes/attribute-list/attribute-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "../../../components/layout/pages";
 import {
   AttributeListView,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage showMetadata={false} showJSON={false} hasOutlet>
-      {Children.count(children) > 0 ? children : <AttributeListView />}
+      <WidgetZone id="attributes.list">
+        {Children.count(children) > 0 ? children : <AttributeListView />}
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/admin/src/pages/commissions/commission-rule-detail/commission-rule-detail.tsx
+++ b/packages/admin/src/pages/commissions/commission-rule-detail/commission-rule-detail.tsx
@@ -3,6 +3,7 @@ import { Container, Heading, StatusBadge } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { ActionMenu } from "../../../components/common/action-menu";
 import { SectionRow } from "../../../components/common/section";
 import { SingleColumnPage } from "../../../components/layout/pages";
@@ -173,8 +174,10 @@ export const CommissionRuleDetail = () => {
 
   return (
     <SingleColumnPage hasOutlet data={commission_rate}>
-      <ScopeSection rule={commission_rate} />
-      <CommissionSection rule={commission_rate} />
+      <WidgetZone id="commissions.detail.main" data={commission_rate}>
+        <ScopeSection rule={commission_rate} />
+        <CommissionSection rule={commission_rate} />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/admin/src/pages/commissions/commissions-list/commissions-page.tsx
+++ b/packages/admin/src/pages/commissions/commissions-list/commissions-page.tsx
@@ -1,5 +1,7 @@
 import { Children, ReactNode } from "react";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "../../../components/layout/pages";
 import { GlobalCommissionSection } from "./components/global-commission-section/global-commission-section";
 import { CommissionRulesTable } from "./components/commission-rules-table/commission-rules-table";
@@ -7,14 +9,16 @@ import { CommissionRulesTable } from "./components/commission-rules-table/commis
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage hasOutlet data-testid="commissions-page">
-      {Children.count(children) > 0 ? (
-        children
-      ) : (
-        <>
-          <GlobalCommissionSection />
-          <CommissionRulesTable />
-        </>
-      )}
+      <WidgetZone id="commissions.list">
+        {Children.count(children) > 0 ? (
+          children
+        ) : (
+          <>
+            <GlobalCommissionSection />
+            <CommissionRulesTable />
+          </>
+        )}
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/admin/src/pages/locations/location-detail/location-detail.tsx
+++ b/packages/admin/src/pages/locations/location-detail/location-detail.tsx
@@ -6,6 +6,7 @@ import { LocationGeneralSection } from "./components/location-general-section";
 import LocationsSalesChannelsSection from "./components/location-sales-channels-section/locations-sales-channels-section";
 import { locationLoader } from "./loader";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton";
 import { TwoColumnPage } from "../../../components/layout/pages";
 import LocationsFulfillmentProvidersSection from "./components/location-fulfillment-providers-section/location-fulfillment-providers-section";
@@ -55,11 +56,15 @@ const Root = ({ children }: { children?: ReactNode }) => {
       data-testid="location-detail-page"
     >
       <TwoColumnPage.Main data-testid="location-detail-main">
-        <LocationGeneralSection location={location} />
+        <WidgetZone id="locations.detail.main" data={location}>
+          <LocationGeneralSection location={location} />
+        </WidgetZone>
       </TwoColumnPage.Main>
       <TwoColumnPage.Sidebar data-testid="location-detail-sidebar">
-        <LocationsSalesChannelsSection location={location} />
-        <LocationsFulfillmentProvidersSection location={location} />
+        <WidgetZone id="locations.detail.side" data={location}>
+          <LocationsSalesChannelsSection location={location} />
+          <LocationsFulfillmentProvidersSection location={location} />
+        </WidgetZone>
       </TwoColumnPage.Sidebar>
     </TwoColumnPage>
   );

--- a/packages/admin/src/pages/locations/location-list/location-list.tsx
+++ b/packages/admin/src/pages/locations/location-list/location-list.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react";
 import { ShoppingBag, TruckFast } from "@medusajs/icons";
 import { Container, Heading } from "@medusajs/ui";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { useTranslation } from "react-i18next";
 
 import { useStockLocations } from "../../../hooks/api/stock-locations";
@@ -128,7 +129,9 @@ const Root = ({ children }: { children?: ReactNode }) => {
   ) : (
     <TwoColumnPage showJSON>
       <TwoColumnPage.Main>
-        <LocationListContent />
+        <WidgetZone id="locations.list">
+          <LocationListContent />
+        </WidgetZone>
       </TwoColumnPage.Main>
       <TwoColumnPage.Sidebar>
         <LinksSection />

--- a/packages/admin/src/pages/marketplace/marketplace-detail/marketplace-detail.tsx
+++ b/packages/admin/src/pages/marketplace/marketplace-detail/marketplace-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useStore } from "../../../hooks/api/store"
@@ -29,8 +30,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage data={store} hasOutlet showMetadata showJSON>
-      <MarketplaceGeneralSection store={store} />
-      <MarketplaceCurrencySection store={store} />
+      <WidgetZone id="marketplace.detail.main" data={store}>
+        <MarketplaceGeneralSection store={store} />
+        <MarketplaceCurrencySection store={store} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/offers/[id]/variants/[offer_id]/offer-variant-detail-page.tsx
+++ b/packages/admin/src/pages/offers/[id]/variants/[offer_id]/offer-variant-detail-page.tsx
@@ -1,6 +1,7 @@
 import { Children, ReactNode } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { TwoColumnPageSkeleton } from "../../../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../../../components/layout/pages"
 import { useOffer } from "../../../../../hooks/api/offers"
@@ -51,13 +52,17 @@ const Root = ({ children }: { children?: ReactNode }) => {
       ) : (
         <TwoColumnPage data={typed} hasOutlet>
           <TwoColumnPage.Main>
-            <OfferVariantGeneralSection offer={typed} />
-            <OfferInventorySection offer={typed} />
+            <WidgetZone id="offer-variants.detail.main" data={typed}>
+              <OfferVariantGeneralSection offer={typed} />
+              <OfferInventorySection offer={typed} />
+            </WidgetZone>
           </TwoColumnPage.Main>
           <TwoColumnPage.Sidebar>
-            <OfferVariantShippingSection offer={typed} />
-            <OfferPricingSection offer={typed} />
-            <OfferStoreSidebar seller={typed.seller} />
+            <WidgetZone id="offer-variants.detail.side" data={typed}>
+              <OfferVariantShippingSection offer={typed} />
+              <OfferPricingSection offer={typed} />
+              <OfferStoreSidebar seller={typed.seller} />
+            </WidgetZone>
           </TwoColumnPage.Sidebar>
         </TwoColumnPage>
       )}

--- a/packages/admin/src/pages/payouts/payout-detail/payout-detail.tsx
+++ b/packages/admin/src/pages/payouts/payout-detail/payout-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { usePayout } from "../../../hooks/api/payouts"
@@ -25,7 +26,9 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage data={payout} showJSON showMetadata>
-      <PayoutGeneralSection payout={payout} />
+      <WidgetZone id="payouts.detail.main" data={payout}>
+        <PayoutGeneralSection payout={payout} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/payouts/payout-list/payout-list.tsx
+++ b/packages/admin/src/pages/payouts/payout-list/payout-list.tsx
@@ -3,6 +3,8 @@ import { Container, Heading } from "@medusajs/ui"
 import { keepPreviousData } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { _DataTable } from "../../../components/table/data-table"
 import { usePayouts } from "../../../hooks/api/payouts"
@@ -112,7 +114,9 @@ export const PayoutListTable = ({ children }: { children?: ReactNode }) => {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage>
-      {Children.count(children) > 0 ? children : <PayoutListTable />}
+      <WidgetZone id="payouts.list">
+        {Children.count(children) > 0 ? children : <PayoutListTable />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/product-tags/product-tag-detail/product-tag-detail.tsx
+++ b/packages/admin/src/pages/product-tags/product-tag-detail/product-tag-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useProductTag } from "../../../hooks/api"
@@ -38,8 +39,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage showJSON showMetadata data={product_tag}>
-      <ProductTagGeneralSection productTag={product_tag} />
-      <ProductTagProductSection productTag={product_tag} />
+      <WidgetZone id="product-tags.detail.main" data={product_tag}>
+        <ProductTagGeneralSection productTag={product_tag} />
+        <ProductTagProductSection productTag={product_tag} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/product-tags/product-tag-list/product-tag-list.tsx
+++ b/packages/admin/src/pages/product-tags/product-tag-list/product-tag-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   ProductTagListView,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage showMetadata={false} showJSON={false} hasOutlet>
-      {Children.count(children) > 0 ? children : <ProductTagListView />}
+      <WidgetZone id="product-tags.list">
+        {Children.count(children) > 0 ? children : <ProductTagListView />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/product-types/product-type-detail/product-type-detail.tsx
+++ b/packages/admin/src/pages/product-types/product-type-detail/product-type-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useProductType } from "../../../hooks/api/product-types"
@@ -37,8 +38,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage showJSON showMetadata data={product_type}>
-      <ProductTypeGeneralSection productType={product_type} />
-      <ProductTypeProductSection productType={product_type} />
+      <WidgetZone id="product-types.detail.main" data={product_type}>
+        <ProductTypeGeneralSection productType={product_type} />
+        <ProductTypeProductSection productType={product_type} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/product-types/product-type-list/product-type-list.tsx
+++ b/packages/admin/src/pages/product-types/product-type-list/product-type-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   ProductTypeListView,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage>
-      {Children.count(children) > 0 ? children : <ProductTypeListView />}
+      <WidgetZone id="product-types.list">
+        {Children.count(children) > 0 ? children : <ProductTypeListView />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/product-variants/product-variant-detail/product-variant-detail.tsx
+++ b/packages/admin/src/pages/product-variants/product-variant-detail/product-variant-detail.tsx
@@ -4,6 +4,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 import { HttpTypes } from "@medusajs/types";
 import { useProductVariant } from "../../../hooks/api/products";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton";
 import { TwoColumnPage } from "../../../components/layout/pages";
 import { VariantGeneralSection } from "./components/variant-general-section";
@@ -47,9 +48,15 @@ const Root = ({ children }: { children?: ReactNode }) => {
   ) : (
     <TwoColumnPage data={variant} showJSON showMetadata hasOutlet>
       <TwoColumnPage.Main>
-        <VariantGeneralSection variant={variant} />
+        <WidgetZone id="product-variants.detail.main" data={variant}>
+          <VariantGeneralSection variant={variant} />
+        </WidgetZone>
       </TwoColumnPage.Main>
-      <TwoColumnPage.Sidebar>{null}</TwoColumnPage.Sidebar>
+      <TwoColumnPage.Sidebar>
+        <WidgetZone id="product-variants.detail.side" data={variant}>
+          {null}
+        </WidgetZone>
+      </TwoColumnPage.Sidebar>
     </TwoColumnPage>
   );
 };

--- a/packages/admin/src/pages/products/product-list/product-list.tsx
+++ b/packages/admin/src/pages/products/product-list/product-list.tsx
@@ -1,4 +1,7 @@
 import { ReactNode, Children } from "react";
+
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "../../../components/layout/pages";
 import {
   ProductListTable,
@@ -13,7 +16,9 @@ const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <div data-testid="products-page">
       <SingleColumnPage>
-        {Children.count(children) > 0 ? children : <ProductListTable />}
+        <WidgetZone id="products.list">
+          {Children.count(children) > 0 ? children : <ProductListTable />}
+        </WidgetZone>
       </SingleColumnPage>
     </div>
   );

--- a/packages/admin/src/pages/profile/profile-detail/profile-detail.tsx
+++ b/packages/admin/src/pages/profile/profile-detail/profile-detail.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { useMe } from "../../../hooks/api/users"
 import { ProfileGeneralSection } from "./components/profile-general-section"
 
@@ -22,7 +24,9 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage data-testid="profile-detail-page">
-      <ProfileGeneralSection user={user} />
+      <WidgetZone id="profile.detail.main" data={user}>
+        <ProfileGeneralSection user={user} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/refund-reasons/refund-reason-list/refund-reason-list.tsx
+++ b/packages/admin/src/pages/refund-reasons/refund-reason-list/refund-reason-list.tsx
@@ -1,5 +1,7 @@
 import { Children, ReactNode } from "react";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "../../../components/layout/pages";
 import { RefundReasonListTable } from "./components/refund-reason-list-table";
 import {
@@ -12,7 +14,9 @@ import { RefundReasonListDataTable } from "./components/refund-reason-list-table
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage showMetadata={false} showJSON={false} hasOutlet>
-      {Children.count(children) > 0 ? children : <RefundReasonListTable />}
+      <WidgetZone id="refund-reasons.list">
+        {Children.count(children) > 0 ? children : <RefundReasonListTable />}
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/admin/src/pages/regions/region-detail/region-detail.tsx
+++ b/packages/admin/src/pages/regions/region-detail/region-detail.tsx
@@ -6,6 +6,7 @@ import { RegionCountrySection } from "./components/region-country-section";
 import { RegionGeneralSection } from "./components/region-general-section";
 import { regionLoader } from "./loader";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton";
 import { SingleColumnPage } from "../../../components/layout/pages";
 import { usePricePreferences } from "../../../hooks/api/price-preferences";
@@ -61,11 +62,13 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage data={region} showMetadata showJSON>
-      <RegionGeneralSection
-        region={region}
-        pricePreferences={pricePreferences ?? []}
-      />
-      <RegionCountrySection region={region} />
+      <WidgetZone id="regions.detail.main" data={region}>
+        <RegionGeneralSection
+          region={region}
+          pricePreferences={pricePreferences ?? []}
+        />
+        <RegionCountrySection region={region} />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/admin/src/pages/regions/region-list/region-list.tsx
+++ b/packages/admin/src/pages/regions/region-list/region-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   RegionListView,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage>
-      {Children.count(children) > 0 ? children : <RegionListView />}
+      <WidgetZone id="regions.list">
+        {Children.count(children) > 0 ? children : <RegionListView />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/return-reasons/return-reason-list/return-reason-list.tsx
+++ b/packages/admin/src/pages/return-reasons/return-reason-list/return-reason-list.tsx
@@ -1,12 +1,16 @@
 import { Children, ReactNode } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { ReturnReasonListTable } from "./components/return-reason-list-table"
 
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage showMetadata={false} showJSON={false} hasOutlet>
-      {Children.count(children) > 0 ? children : <ReturnReasonListTable />}
+      <WidgetZone id="return-reasons.list">
+        {Children.count(children) > 0 ? children : <ReturnReasonListTable />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/sales-channels/sales-channel-detail/sales-channel-detail.tsx
+++ b/packages/admin/src/pages/sales-channels/sales-channel-detail/sales-channel-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useSalesChannel } from "../../../hooks/api/sales-channels"
@@ -28,8 +29,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage showJSON showMetadata data={sales_channel}>
-      <SalesChannelGeneralSection salesChannel={sales_channel} />
-      <SalesChannelProductSection salesChannel={sales_channel} />
+      <WidgetZone id="sales-channels.detail.main" data={sales_channel}>
+        <SalesChannelGeneralSection salesChannel={sales_channel} />
+        <SalesChannelProductSection salesChannel={sales_channel} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/sales-channels/sales-channel-list/sales-channel-list.tsx
+++ b/packages/admin/src/pages/sales-channels/sales-channel-list/sales-channel-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   SalesChannelListView,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage hasOutlet>
-      {Children.count(children) > 0 ? children : <SalesChannelListView />}
+      <WidgetZone id="sales-channels.list">
+        {Children.count(children) > 0 ? children : <SalesChannelListView />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/shipping-option-types/shipping-option-type-detail/shipping-option-type-detail.tsx
+++ b/packages/admin/src/pages/shipping-option-types/shipping-option-type-detail/shipping-option-type-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useShippingOptionType } from "../../../hooks/api"
@@ -32,9 +33,11 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage showJSON showMetadata data={shipping_option_type}>
-      <ShippingOptionTypeGeneralSection
-        shippingOptionType={shipping_option_type}
-      />
+      <WidgetZone id="shipping-option-types.detail.main" data={shipping_option_type}>
+        <ShippingOptionTypeGeneralSection
+          shippingOptionType={shipping_option_type}
+        />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/shipping-option-types/shipping-option-type-list/shipping-option-type-list.tsx
+++ b/packages/admin/src/pages/shipping-option-types/shipping-option-type-list/shipping-option-type-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   ShippingOptionTypeListView,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage>
-      {Children.count(children) > 0 ? children : <ShippingOptionTypeListView />}
+      <WidgetZone id="shipping-option-types.list">
+        {Children.count(children) > 0 ? children : <ShippingOptionTypeListView />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/shipping-profiles/shipping-profile-detail/shipping-profile-detail.tsx
+++ b/packages/admin/src/pages/shipping-profiles/shipping-profile-detail/shipping-profile-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { useShippingProfile } from "../../../hooks/api/shipping-profiles"
 import { ShippingProfileGeneralSection } from "./components/shipping-profile-general-section"
@@ -35,7 +36,9 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage showMetadata showJSON data={shipping_profile}>
-      <ShippingProfileGeneralSection profile={shipping_profile} />
+      <WidgetZone id="shipping-profiles.detail.main" data={shipping_profile}>
+        <ShippingProfileGeneralSection profile={shipping_profile} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/shipping-profiles/shipping-profiles-list/shipping-profile-list.tsx
+++ b/packages/admin/src/pages/shipping-profiles/shipping-profiles-list/shipping-profile-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   ShippingProfileListView,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage>
-      {Children.count(children) > 0 ? children : <ShippingProfileListView />}
+      <WidgetZone id="shipping-profiles.list">
+        {Children.count(children) > 0 ? children : <ShippingProfileListView />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/tax-regions/tax-region-detail/tax-region-detail.tsx
+++ b/packages/admin/src/pages/tax-regions/tax-region-detail/tax-region-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState, Children } from "react";
 import { useLoaderData, useParams } from "react-router-dom";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { SingleColumnPage } from "../../../components/layout/pages";
 import { useTaxRegion } from "../../../hooks/api/tax-regions";
 import { TaxRegionDetailSection } from "./components/tax-region-detail-section";
@@ -41,18 +42,20 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage data={taxRegion} showJSON showMetadata>
-      <TaxRegionSublevelAlert
-        taxRegion={taxRegion}
-        showSublevelRegions={showSublevelRegions}
-        setShowSublevelRegions={setShowSublevelRegions}
-      />
-      <TaxRegionDetailSection taxRegion={taxRegion} />
-      <TaxRegionProvinceSection
-        taxRegion={taxRegion}
-        showSublevelRegions={showSublevelRegions}
-      />
-      <TaxRegionOverrideSection taxRegion={taxRegion} />
-      <TaxRegionProviderSection taxRegion={taxRegion} />
+      <WidgetZone id="tax-regions.detail.main" data={taxRegion}>
+        <TaxRegionSublevelAlert
+          taxRegion={taxRegion}
+          showSublevelRegions={showSublevelRegions}
+          setShowSublevelRegions={setShowSublevelRegions}
+        />
+        <TaxRegionDetailSection taxRegion={taxRegion} />
+        <TaxRegionProvinceSection
+          taxRegion={taxRegion}
+          showSublevelRegions={showSublevelRegions}
+        />
+        <TaxRegionOverrideSection taxRegion={taxRegion} />
+        <TaxRegionProviderSection taxRegion={taxRegion} />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/admin/src/pages/tax-regions/tax-region-list/tax-region-list.tsx
+++ b/packages/admin/src/pages/tax-regions/tax-region-list/tax-region-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   TaxRegionListView,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage hasOutlet>
-      {Children.count(children) > 0 ? children : <TaxRegionListView />}
+      <WidgetZone id="tax-regions.list">
+        {Children.count(children) > 0 ? children : <TaxRegionListView />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/tax-regions/tax-region-province-detail/tax-region-detail.tsx
+++ b/packages/admin/src/pages/tax-regions/tax-region-province-detail/tax-region-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useTaxRegion } from "../../../hooks/api/tax-regions"
 import { TaxRegionProvinceDetailSection } from "./components/tax-region-province-detail-section"
@@ -37,8 +38,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage data={taxRegion} showJSON>
-      <TaxRegionProvinceDetailSection taxRegion={taxRegion} />
-      <TaxRegionProvinceOverrideSection taxRegion={taxRegion} />
+      <WidgetZone id="tax-regions.province.detail.main" data={taxRegion}>
+        <TaxRegionProvinceDetailSection taxRegion={taxRegion} />
+        <TaxRegionProvinceOverrideSection taxRegion={taxRegion} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/users/user-detail/user-detail.tsx
+++ b/packages/admin/src/pages/users/user-detail/user-detail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useUser } from "../../../hooks/api/users"
@@ -34,7 +35,9 @@ const Root = ({ children }: { children?: ReactNode }) => {
     </SingleColumnPage>
   ) : (
     <SingleColumnPage data={user} showJSON showMetadata>
-      <UserGeneralSection user={user} />
+      <WidgetZone id="users.detail.main" data={user}>
+        <UserGeneralSection user={user} />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/admin/src/pages/users/user-list/user-list.tsx
+++ b/packages/admin/src/pages/users/user-list/user-list.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { SingleColumnPage } from "../../../components/layout/pages"
 import {
   UserListTable,
@@ -12,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage>
-      {Children.count(children) > 0 ? children : <UserListTable />}
+      <WidgetZone id="users.list">
+        {Children.count(children) > 0 ? children : <UserListTable />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/vendor/src/components/layout/shell/shell.tsx
+++ b/packages/vendor/src/components/layout/shell/shell.tsx
@@ -278,5 +278,5 @@ const StoreSetupWidget = () => {
     return null
   }
 
-  return <WidgetZone id="store.setup" data={seller} />
+  return <WidgetZone id="seller.setup" data={seller} />
 }

--- a/packages/vendor/src/extension-targets.d.ts
+++ b/packages/vendor/src/extension-targets.d.ts
@@ -36,12 +36,22 @@ declare module "@mercurjs/dashboard-sdk" {
     "inventory.detail.side.before": true
     "inventory.list.after": true
     "inventory.list.before": true
+    "locations.detail.main.after": true
+    "locations.detail.main.before": true
+    "locations.detail.side.after": true
+    "locations.detail.side.before": true
+    "locations.list.after": true
+    "locations.list.before": true
     "login.after.after": true
     "login.after.before": true
     "login.before.after": true
     "login.before.before": true
     "login.logo.after": true
     "login.logo.before": true
+    "offer-variants.detail.main.after": true
+    "offer-variants.detail.main.before": true
+    "offer-variants.detail.side.after": true
+    "offer-variants.detail.side.before": true
     "offers.detail.main.after": true
     "offers.detail.main.before": true
     "offers.detail.side.after": true
@@ -64,26 +74,56 @@ declare module "@mercurjs/dashboard-sdk" {
     "price-lists.detail.side.before": true
     "price-lists.list.after": true
     "price-lists.list.before": true
+    "product-tags.detail.main.after": true
+    "product-tags.detail.main.before": true
+    "product-tags.list.after": true
+    "product-tags.list.before": true
+    "product-types.detail.main.after": true
+    "product-types.detail.main.before": true
+    "product-types.list.after": true
+    "product-types.list.before": true
+    "product-variants.detail.main.after": true
+    "product-variants.detail.main.before": true
     "product.detail.main.after": true
     "product.detail.main.before": true
     "product.detail.side.after": true
     "product.detail.side.before": true
     "product.list.after": true
     "product.list.before": true
+    "profile.detail.main.after": true
+    "profile.detail.main.before": true
     "promotions.detail.main.after": true
     "promotions.detail.main.before": true
     "promotions.detail.side.after": true
     "promotions.detail.side.before": true
     "promotions.list.after": true
     "promotions.list.before": true
+    "regions.detail.main.after": true
+    "regions.detail.main.before": true
+    "regions.list.after": true
+    "regions.list.before": true
     "reservations.detail.main.after": true
     "reservations.detail.main.before": true
     "reservations.detail.side.after": true
     "reservations.detail.side.before": true
     "reservations.list.after": true
     "reservations.list.before": true
-    "store.setup.after": true
-    "store.setup.before": true
+    "return-reasons.list.after": true
+    "return-reasons.list.before": true
+    "seller.setup.after": true
+    "seller.setup.before": true
+    "shipping-profiles.detail.main.after": true
+    "shipping-profiles.detail.main.before": true
+    "shipping-profiles.list.after": true
+    "shipping-profiles.list.before": true
+    "tax-regions.detail.main.after": true
+    "tax-regions.detail.main.before": true
+    "tax-regions.list.after": true
+    "tax-regions.list.before": true
+    "tax-regions.province.detail.main.after": true
+    "tax-regions.province.detail.main.before": true
+    "team.list.after": true
+    "team.list.before": true
   }
 
   interface NavItemRegistry {

--- a/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/offer-variant-detail-page.tsx
+++ b/packages/vendor/src/pages/offers/[id]/variants/[offer_id]/offer-variant-detail-page.tsx
@@ -2,6 +2,8 @@ import { Children, ReactNode } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
 import { TwoColumnPageSkeleton } from "../../../../../components/common/skeleton"
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { TwoColumnPage } from "../../../../../components/layout/pages"
 import { useOffer } from "../../../../../hooks/api/offers"
 import { OFFER_VARIANT_DETAIL_FIELDS } from "../../../common/constants"
@@ -47,12 +49,16 @@ const Root = ({ children }: { children?: ReactNode }) => {
       ) : (
         <TwoColumnPage data={typed} hasOutlet>
           <TwoColumnPage.Main>
-            <OfferVariantGeneralSection offer={typed} />
-            <OfferInventorySection offer={typed} />
+            <WidgetZone id="offer-variants.detail.main" data={typed}>
+              <OfferVariantGeneralSection offer={typed} />
+              <OfferInventorySection offer={typed} />
+            </WidgetZone>
           </TwoColumnPage.Main>
           <TwoColumnPage.Sidebar>
-            <OfferVariantShippingSection offer={typed} />
-            <OfferPricingSection offer={typed} />
+            <WidgetZone id="offer-variants.detail.side" data={typed}>
+              <OfferVariantShippingSection offer={typed} />
+              <OfferPricingSection offer={typed} />
+            </WidgetZone>
           </TwoColumnPage.Sidebar>
         </TwoColumnPage>
       )}

--- a/packages/vendor/src/pages/product-variants/product-variant-detail/product-variant-detail.tsx
+++ b/packages/vendor/src/pages/product-variants/product-variant-detail/product-variant-detail.tsx
@@ -1,6 +1,8 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
 import { useProductVariant } from "@hooks/api/products"
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton"
@@ -38,10 +40,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
       {Children.count(children) > 0 ? (
         children
       ) : (
-        <>
+        <WidgetZone id="product-variants.detail.main" data={variant}>
           <VariantGeneralSection variant={variant} />
           <VariantMediaSection variant={variant} />
-        </>
+        </WidgetZone>
       )}
     </SingleColumnPage>
   )

--- a/packages/vendor/src/pages/settings/locations/[location_id]/location-detail-page.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/location-detail-page.tsx
@@ -3,6 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { useStockLocation } from "@hooks/api/stock-locations";
 
 import { LocationGeneralSection } from "./_components/location-general-section";
@@ -45,10 +46,14 @@ const Root = ({ children }: { children?: ReactNode }) => {
       ) : (
         <TwoColumnPage data={location} hasOutlet>
           <TwoColumnPage.Main>
-            <LocationGeneralSection location={location} />
+            <WidgetZone id="locations.detail.main" data={location}>
+              <LocationGeneralSection location={location} />
+            </WidgetZone>
           </TwoColumnPage.Main>
           <TwoColumnPage.Sidebar>
-            <LocationsFulfillmentProvidersSection location={location} />
+            <WidgetZone id="locations.detail.side" data={location}>
+              <LocationsFulfillmentProvidersSection location={location} />
+            </WidgetZone>
           </TwoColumnPage.Sidebar>
         </TwoColumnPage>
       )}

--- a/packages/vendor/src/pages/settings/locations/location-list-page.tsx
+++ b/packages/vendor/src/pages/settings/locations/location-list-page.tsx
@@ -6,6 +6,7 @@ import { useLoaderData } from "react-router-dom";
 
 import { SidebarLink } from "@components/common/sidebar-link/sidebar-link";
 import { TwoColumnPage } from "@components/layout/pages";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { useStockLocations } from "@hooks/api/stock-locations";
 
 import LocationListItem from "./_components/location-list-item";
@@ -62,12 +63,14 @@ const Root = ({ children }: { children?: ReactNode }) => {
       ) : (
         <TwoColumnPage>
           <TwoColumnPage.Main>
-            <LocationListHeader />
-            <div className="flex flex-col gap-3 lg:col-span-2">
-              {stockLocations.map((location) => (
-                <LocationListItem key={location.id} location={location} />
-              ))}
-            </div>
+            <WidgetZone id="locations.list">
+              <LocationListHeader />
+              <div className="flex flex-col gap-3 lg:col-span-2">
+                {stockLocations.map((location) => (
+                  <LocationListItem key={location.id} location={location} />
+                ))}
+              </div>
+            </WidgetZone>
           </TwoColumnPage.Main>
           <TwoColumnPage.Sidebar>
             <LinksSection />

--- a/packages/vendor/src/pages/settings/product-tags/[id]/product-tag-detail-page.tsx
+++ b/packages/vendor/src/pages/settings/product-tags/[id]/product-tag-detail-page.tsx
@@ -3,6 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { SingleColumnPageSkeleton } from "@components/common/skeleton";
 import { SingleColumnPage } from "@components/layout/pages";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { useProductTag } from "@hooks/api";
 
 import { ProductTagGeneralSection } from "./_components/product-tag-general-section";
@@ -38,10 +39,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
       {Children.count(children) > 0 ? (
         children
       ) : (
-        <>
+        <WidgetZone id="product-tags.detail.main" data={product_tag}>
           <ProductTagGeneralSection productTag={product_tag} />
           <ProductTagProductSection productTag={product_tag} />
-        </>
+        </WidgetZone>
       )}
     </SingleColumnPage>
   );

--- a/packages/vendor/src/pages/settings/product-tags/product-tag-list-page.tsx
+++ b/packages/vendor/src/pages/settings/product-tags/product-tag-list-page.tsx
@@ -1,6 +1,7 @@
 import { Children, ReactNode } from "react";
 
 import { SingleColumnPage } from "@components/layout/pages";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 
 import {
   ProductTagListTable,
@@ -13,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage showMetadata={false} showJSON={false} hasOutlet>
-      {Children.count(children) > 0 ? children : <ProductTagListTable />}
+      <WidgetZone id="product-tags.list">
+        {Children.count(children) > 0 ? children : <ProductTagListTable />}
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/product-types/[id]/product-type-detail-page.tsx
+++ b/packages/vendor/src/pages/settings/product-types/[id]/product-type-detail-page.tsx
@@ -3,6 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { SingleColumnPageSkeleton } from "@components/common/skeleton";
 import { SingleColumnPage } from "@components/layout/pages";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { useProductType } from "@hooks/api/product-types";
 
 import { ProductTypeGeneralSection } from "./_components/product-type-general-section";
@@ -38,10 +39,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
       {Children.count(children) > 0 ? (
         children
       ) : (
-        <>
+        <WidgetZone id="product-types.detail.main" data={product_type}>
           <ProductTypeGeneralSection productType={product_type} />
           <ProductTypeProductSection productType={product_type} />
-        </>
+        </WidgetZone>
       )}
     </SingleColumnPage>
   );

--- a/packages/vendor/src/pages/settings/product-types/product-type-list-page.tsx
+++ b/packages/vendor/src/pages/settings/product-types/product-type-list-page.tsx
@@ -1,6 +1,7 @@
 import { Children, ReactNode } from "react";
 
 import { SingleColumnPage } from "@components/layout/pages";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 
 import {
   ProductTypeListTable,
@@ -13,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage hasOutlet>
-      {Children.count(children) > 0 ? children : <ProductTypeListTable />}
+      <WidgetZone id="product-types.list">
+        {Children.count(children) > 0 ? children : <ProductTypeListTable />}
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/profile/profile-detail/profile-detail.tsx
+++ b/packages/vendor/src/pages/settings/profile/profile-detail/profile-detail.tsx
@@ -1,16 +1,24 @@
 import { ReactNode, Children } from "react"
 
+import { WidgetZone } from "@mercurjs/dashboard-shared"
+
+import { useMe } from "../../../../hooks/api"
 import { SingleColumnPage } from "../../../../components/layout/pages"
 import { ProfileGeneralSection } from "./components/profile-general-section"
 
 const Root = ({ children }: { children?: ReactNode }) => {
+  const { seller_member } = useMe()
+  const member = seller_member?.member
+
   return Children.count(children) > 0 ? (
     <SingleColumnPage>
       {children}
     </SingleColumnPage>
   ) : (
     <SingleColumnPage>
-      <ProfileGeneralSection />
+      <WidgetZone id="profile.detail.main" data={member}>
+        <ProfileGeneralSection />
+      </WidgetZone>
     </SingleColumnPage>
   )
 }

--- a/packages/vendor/src/pages/settings/regions/[id]/index.tsx
+++ b/packages/vendor/src/pages/settings/regions/[id]/index.tsx
@@ -1,5 +1,7 @@
 import { useLoaderData, useParams } from "react-router-dom";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { useRegion } from "@hooks/api/regions";
 import { RegionCountrySection } from "./_components/region-country-section";
 import { RegionGeneralSection } from "./_components/region-general-section";
@@ -56,11 +58,13 @@ const RegionDetail = () => {
 
   return (
     <SingleColumnPage data={region} showMetadata showJSON>
-      <RegionGeneralSection
-        region={region}
-        pricePreferences={pricePreferences ?? []}
-      />
-      <RegionCountrySection region={region} />
+      <WidgetZone id="regions.detail.main" data={region}>
+        <RegionGeneralSection
+          region={region}
+          pricePreferences={pricePreferences ?? []}
+        />
+        <RegionCountrySection region={region} />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/regions/index.tsx
+++ b/packages/vendor/src/pages/settings/regions/index.tsx
@@ -1,10 +1,14 @@
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "@components/layout/pages";
 import { RegionListTable } from "./_components/region-list-table";
 
 const RegionList = () => {
   return (
     <SingleColumnPage>
-      <RegionListTable />
+      <WidgetZone id="regions.list">
+        <RegionListTable />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/return-reasons/index.tsx
+++ b/packages/vendor/src/pages/settings/return-reasons/index.tsx
@@ -1,10 +1,14 @@
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "@components/layout/pages";
 import { ReturnReasonListTable } from "./_components/return-reason-list-table";
 
 const ReturnReasonList = () => {
   return (
     <SingleColumnPage showMetadata={false} showJSON={false} hasOutlet>
-      <ReturnReasonListTable />
+      <WidgetZone id="return-reasons.list">
+        <ReturnReasonListTable />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/shipping-profiles/[id]/shipping-profile-detail-page.tsx
+++ b/packages/vendor/src/pages/settings/shipping-profiles/[id]/shipping-profile-detail-page.tsx
@@ -3,6 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { SingleColumnPageSkeleton } from "@components/common/skeleton";
 import { SingleColumnPage } from "@components/layout/pages";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 import { useShippingProfile } from "@hooks/api/shipping-profiles";
 
 import { ShippingProfileGeneralSection } from "./_components/shipping-profile-general-section";
@@ -37,7 +38,9 @@ const Root = ({ children }: { children?: ReactNode }) => {
       {Children.count(children) > 0 ? (
         children
       ) : (
-        <ShippingProfileGeneralSection profile={shipping_profile} />
+        <WidgetZone id="shipping-profiles.detail.main" data={shipping_profile}>
+          <ShippingProfileGeneralSection profile={shipping_profile} />
+        </WidgetZone>
       )}
     </SingleColumnPage>
   );

--- a/packages/vendor/src/pages/settings/shipping-profiles/shipping-profile-list-page.tsx
+++ b/packages/vendor/src/pages/settings/shipping-profiles/shipping-profile-list-page.tsx
@@ -1,6 +1,7 @@
 import { Children, ReactNode } from "react";
 
 import { SingleColumnPage } from "@components/layout/pages";
+import { WidgetZone } from "@mercurjs/dashboard-shared";
 
 import {
   ShippingProfileListTable,
@@ -14,7 +15,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage hasOutlet>
-      {Children.count(children) > 0 ? children : <ShippingProfileListTable />}
+      <WidgetZone id="shipping-profiles.list">
+        {Children.count(children) > 0 ? children : <ShippingProfileListTable />}
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/store/store-detail-page.tsx
+++ b/packages/vendor/src/pages/settings/store/store-detail-page.tsx
@@ -50,7 +50,7 @@ const Root = ({ children }: { children?: ReactNode }) => {
 
   const StatusBanner = () => (
     <>
-      <WidgetZone id="store.setup" data={seller} />
+      <WidgetZone id="seller.setup" data={seller} />
       {statusAlert && (
         <Alert variant={statusAlert.variant} dismissible className="p-5">
           <div className="text-ui-fg-subtle txt-small pb-2 font-medium leading-[20px]">

--- a/packages/vendor/src/pages/settings/tax-regions/[id]/index.tsx
+++ b/packages/vendor/src/pages/settings/tax-regions/[id]/index.tsx
@@ -1,5 +1,7 @@
 import { useLoaderData, useParams } from "react-router-dom";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "@components/layout/pages";
 import { useTaxRegion } from "@hooks/api/tax-regions";
 import { TaxRegionDetailSection } from "./_components/tax-region-detail-section";
@@ -36,17 +38,19 @@ const TaxRegionDetail = () => {
 
   return (
     <SingleColumnPage data={taxRegion}>
-      <TaxRegionSublevelAlert
-        taxRegion={taxRegion}
-        showSublevelRegions={showSublevelRegions}
-        setShowSublevelRegions={setShowSublevelRegions}
-      />
-      <TaxRegionDetailSection taxRegion={taxRegion} />
-      <TaxRegionProvinceSection
-        taxRegion={taxRegion}
-        showSublevelRegions={showSublevelRegions}
-      />
-      <TaxRegionOverrideSection taxRegion={taxRegion} />
+      <WidgetZone id="tax-regions.detail.main" data={taxRegion}>
+        <TaxRegionSublevelAlert
+          taxRegion={taxRegion}
+          showSublevelRegions={showSublevelRegions}
+          setShowSublevelRegions={setShowSublevelRegions}
+        />
+        <TaxRegionDetailSection taxRegion={taxRegion} />
+        <TaxRegionProvinceSection
+          taxRegion={taxRegion}
+          showSublevelRegions={showSublevelRegions}
+        />
+        <TaxRegionOverrideSection taxRegion={taxRegion} />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/tax-regions/[id]/provinces/[province_id]/index.tsx
+++ b/packages/vendor/src/pages/settings/tax-regions/[id]/provinces/[province_id]/index.tsx
@@ -1,5 +1,7 @@
 import { useLoaderData, useParams } from "react-router-dom";
 
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "@components/layout/pages";
 import { useTaxRegion } from "@hooks/api/tax-regions";
 import { TaxRegionProvinceDetailSection } from "./_components/tax-region-detail-section";
@@ -34,8 +36,10 @@ const TaxRegionProvinceDetail = () => {
 
   return (
     <SingleColumnPage data={taxRegion}>
-      <TaxRegionProvinceDetailSection taxRegion={taxRegion} />
-      <TaxRegionProvinceOverrideSection taxRegion={taxRegion} />
+      <WidgetZone id="tax-regions.province.detail.main" data={taxRegion}>
+        <TaxRegionProvinceDetailSection taxRegion={taxRegion} />
+        <TaxRegionProvinceOverrideSection taxRegion={taxRegion} />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/tax-regions/index.tsx
+++ b/packages/vendor/src/pages/settings/tax-regions/index.tsx
@@ -1,10 +1,14 @@
+import { WidgetZone } from "@mercurjs/dashboard-shared";
+
 import { SingleColumnPage } from "@components/layout/pages";
 import { TaxRegionListView } from "./_components/tax-region-list-view";
 
 const TaxRegionsList = () => {
   return (
     <SingleColumnPage hasOutlet>
-      <TaxRegionListView />
+      <WidgetZone id="tax-regions.list">
+        <TaxRegionListView />
+      </WidgetZone>
     </SingleColumnPage>
   );
 };

--- a/packages/vendor/src/pages/settings/team/team-list-page.tsx
+++ b/packages/vendor/src/pages/settings/team/team-list-page.tsx
@@ -1,6 +1,7 @@
 import { Children, ReactNode } from "react"
 
 import { SingleColumnPage } from "@components/layout/pages"
+import { WidgetZone } from "@mercurjs/dashboard-shared"
 
 import {
   TeamListTable,
@@ -13,7 +14,9 @@ import {
 const Root = ({ children }: { children?: ReactNode }) => {
   return (
     <SingleColumnPage hasOutlet>
-      {Children.count(children) > 0 ? children : <TeamListTable />}
+      <WidgetZone id="team.list">
+        {Children.count(children) > 0 ? children : <TeamListTable />}
+      </WidgetZone>
     </SingleColumnPage>
   )
 }


### PR DESCRIPTION
## Summary

Adds `WidgetZone` extension points to every admin and vendor dashboard page that previously lacked them, so downstream projects can inject UI into any list or detail page without forking.

## Changes

- **List pages** wrap their table content in `<WidgetZone id="<domain>.list">`.
- **Detail pages** wrap section content in `<WidgetZone id="<domain>.detail.main">` (and `.detail.side` for `TwoColumnPage` sidebars).
- Existing compound-component `Children.count(...)` guards are preserved — only the default branches are wrapped.
- Renames the vendor onboarding widget zone `store.setup` → `seller.setup`.
- Regenerates `extension-targets.d.ts` for both packages (admin: 146 zones, vendor: 120 zones).

## Coverage

- **Admin**: api-keys, attributes, commissions, locations, marketplace, payouts, product-tags, product-types, products, product-variants, profile, refund-reasons, regions, return-reasons, sales-channels, shipping-option-types, shipping-profiles, tax-regions (+ provinces), users, offer-variants.
- **Vendor**: locations, product-tags, product-types, profile, regions, return-reasons, shipping-profiles, tax-regions (+ provinces), team, offer-variants, product-variants, store.

## Verification

- Regenerated extension-target registries; no page-level file remains without a zone.
- `tsc` introduces no new type errors (remaining errors are pre-existing and unrelated).