### PR TITLE
fix(vendor): wire seller status & general zone through display extension fields

### DIFF
--- a/packages/vendor/src/pages/settings/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
+++ b/packages/vendor/src/pages/settings/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
@@ -68,7 +68,12 @@ export const ProfileGeneralSection = () => {
           </Text>
         </div>
       </DisplayField>
-      <DisplayExtensionZone model="member" zone="general" data={member} />
+      <DisplayExtensionZone
+        model="member"
+        zone="general"
+        data={member}
+        builtInFieldIds={["first_name", "last_name", "language"]}
+      />
     </Container>
   )
 }

--- a/packages/vendor/src/pages/settings/store/_components/store-detail-header.tsx
+++ b/packages/vendor/src/pages/settings/store/_components/store-detail-header.tsx
@@ -3,6 +3,8 @@ import { CheckCircleSolid, PencilSquare } from "@medusajs/icons";
 import { Avatar, Heading, StatusBadge, Tooltip } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
+import { DisplayField } from "@mercurjs/dashboard-shared";
+
 import { ActionMenu } from "@components/common/action-menu";
 import { HttpTypes } from "@mercurjs/types";
 import { SellerStatus } from "@mercurjs/types";
@@ -95,9 +97,16 @@ export const StoreDetailActions = ({
         children
       ) : (
         <>
-          <StatusBadge color={getStatusColor(seller.status)}>
-            {getStatusLabel(seller.status, t)}
-          </StatusBadge>
+          <DisplayField
+            model="seller"
+            zone="general"
+            id="status"
+            data={seller}
+          >
+            <StatusBadge color={getStatusColor(seller.status)}>
+              {getStatusLabel(seller.status, t)}
+            </StatusBadge>
+          </DisplayField>
           <StoreDetailEditButton />
         </>
       )}

--- a/packages/vendor/src/pages/settings/store/_components/store-general-section.tsx
+++ b/packages/vendor/src/pages/settings/store/_components/store-general-section.tsx
@@ -2,7 +2,10 @@ import { Children, ReactNode } from "react";
 import { Badge, Container, Text } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 
-import { DisplayField } from "@mercurjs/dashboard-shared";
+import {
+  DisplayExtensionZone,
+  DisplayField,
+} from "@mercurjs/dashboard-shared";
 import { HttpTypes } from "@mercurjs/types";
 
 import { StoreDetailHeader } from "./store-detail-header";
@@ -128,6 +131,20 @@ export const StoreGeneralSection = ({
               </div>
             </div>
           </DisplayField>
+          <DisplayExtensionZone
+            model="seller"
+            zone="general"
+            data={seller}
+            builtInFieldIds={[
+              "status",
+              "description",
+              "handle",
+              "email",
+              "phone",
+              "website_url",
+              "currency_code",
+            ]}
+          />
         </>
       )}
     </Container>

--- a/packages/vendor/src/pages/store-select/store-select.tsx
+++ b/packages/vendor/src/pages/store-select/store-select.tsx
@@ -113,6 +113,7 @@ const StoreSelectList = ({
                 model="seller"
                 zone="seller-select"
                 data={seller}
+                builtInFieldIds={["status"]}
               />
               <ChevronRight className="text-ui-fg-muted" />
             </button>


### PR DESCRIPTION
## Summary

Fixes seller detail extension zones in the vendor dashboard so custom fields honor built-in overrides and expose the missing status/action extension points.

## Problem

- On **store-select** and the **profile general section**, an override for a built-in field (e.g. `status`) rendered **twice** — once from the `<DisplayField>` replacement and again from the sibling `<DisplayExtensionZone>`, which treated the override as a newly *added* field because `builtInFieldIds` was never passed.
- The **store detail header** rendered the seller status badge hardcoded, so a `DisplayField id="status"` override had no effect (no status change).
- The **store general section** had no `<DisplayExtensionZone>`, so added custom fields / section actions could not be injected.

## Changes

- `store-detail-header.tsx` — wrap the status `StatusBadge` in `<DisplayField model="seller" zone="general" id="status">` so overrides/removals apply.
- `store-general-section.tsx` — add `<DisplayExtensionZone model="seller" zone="general">` with `builtInFieldIds` covering every inline field (`status`, `description`, `handle`, `email`, `phone`, `website_url`, `currency_code`).
- `store-select.tsx` — pass `builtInFieldIds={["status"]}` to the zone.
- `profile-general-section.tsx` — pass `builtInFieldIds={["first_name", "last_name", "language"]}`.

## Notes

Audited every `DisplayField` / `DisplayExtensionZone` usage across admin and vendor — these were the only sites missing `builtInFieldIds`; all `*-general-section` components already pass it (inline or via a named constant).