### PR TITLE
fix(dashboard): consistent spacing for form extension zone fields

### DIFF
--- a/apps/docs/rc/references/workflows/cart/add-seller-shipping-method-to-cart.mdx
+++ b/apps/docs/rc/references/workflows/cart/add-seller-shipping-method-to-cart.mdx
@@ -21,12 +21,16 @@ await addSellerShippingMethodToCartWorkflow(container).run({
 ## Input
 
 <ParamField body="cart_id" type="string" required>The cart to add shipping methods to.</ParamField>
-<ParamField body="options" type="object[]" required>Shipping options to add as methods.
+
+<ParamField body="options" type="object[]" required>
+  Shipping options to add as methods.
+
   <Expandable title="properties">
     <ParamField body="id" type="string" required>The shipping option ID; must have a calculated price for the cart.</ParamField>
     <ParamField body="data" type="object">Custom method data validated by the fulfillment provider.</ParamField>
   </Expandable>
 </ParamField>
+
 <ParamField body="additional_data" type="object">Custom data passed through to the workflow hooks.</ParamField>
 
 ## Result

--- a/apps/docs/rc/references/workflows/commission/batch-commission-rules.mdx
+++ b/apps/docs/rc/references/workflows/commission/batch-commission-rules.mdx
@@ -23,13 +23,17 @@ const { result } = await batchCommissionRulesWorkflow(container).run({
 ## Input
 
 <ParamField body="commission_rate_id" type="string" required>The commission rate the rules belong to.</ParamField>
-<ParamField body="create" type="object[]">Rules to create.
+<ParamField body="create" type="object[]">
+  Rules to create.
+
   <Expandable title="properties">
     <ParamField body="reference" type="string" required>Entity type the rule targets (e.g. `seller`, `product_category`, `product_type`).</ParamField>
     <ParamField body="reference_id" type="string" required>ID of the referenced entity.</ParamField>
   </Expandable>
 </ParamField>
-<ParamField body="update" type="object[]">Rules to update.
+<ParamField body="update" type="object[]">
+  Rules to update.
+
   <Expandable title="properties">
     <ParamField body="id" type="string" required>The rule to update.</ParamField>
     <ParamField body="reference" type="string">New reference type.</ParamField>

--- a/apps/docs/rc/references/workflows/offer/batch-offer-inventory-items.mdx
+++ b/apps/docs/rc/references/workflows/offer/batch-offer-inventory-items.mdx
@@ -23,13 +23,17 @@ const { result } = await batchOfferInventoryItemsWorkflow(container).run({
 ## Input
 
 <ParamField body="offer_id" type="string" required>The offer whose inventory links are managed; fails if not found.</ParamField>
-<ParamField body="create" type="object[]">Links to create; the inventory items must exist and not appear in `update`/`delete`.
+<ParamField body="create" type="object[]">
+  Links to create; the inventory items must exist and not appear in `update`/`delete`.
+
   <Expandable title="properties">
     <ParamField body="inventory_item_id" type="string" required>The inventory item to link.</ParamField>
     <ParamField body="required_quantity" type="number">Units consumed per offer unit; defaults to `1`.</ParamField>
   </Expandable>
 </ParamField>
-<ParamField body="update" type="object[]">Existing links to update.
+<ParamField body="update" type="object[]">
+  Existing links to update.
+
   <Expandable title="properties">
     <ParamField body="inventory_item_id" type="string" required>The linked inventory item.</ParamField>
     <ParamField body="required_quantity" type="number" required>New units consumed per offer unit.</ParamField>

--- a/apps/docs/rc/references/workflows/offer/create-offers.mdx
+++ b/apps/docs/rc/references/workflows/offer/create-offers.mdx
@@ -31,7 +31,9 @@ const { result } = await createOffersWorkflow(container).run({
 
 ## Input
 
-<ParamField body="offers" type="object[]" required>Offers to create.
+<ParamField body="offers" type="object[]" required>
+  Offers to create.
+
   <Expandable title="properties">
     <ParamField body="seller_id" type="string" required>The seller that owns the offer.</ParamField>
     <ParamField body="created_by" type="string" required>ID of the member creating the offer.</ParamField>

--- a/apps/docs/rc/references/workflows/offer/update-offers.mdx
+++ b/apps/docs/rc/references/workflows/offer/update-offers.mdx
@@ -24,7 +24,9 @@ const { result } = await updateOffersWorkflow(container).run({
 
 ## Input
 
-<ParamField body="offers" type="object[]" required>Offer updates, keyed by ID.
+<ParamField body="offers" type="object[]" required>
+  Offer updates, keyed by ID.
+
   <Expandable title="properties">
     <ParamField body="id" type="string" required>The offer to update; fails if not found.</ParamField>
     <ParamField body="sku" type="string">New SKU.</ParamField>

--- a/apps/docs/rc/references/workflows/order-group/get-order-groups-list.mdx
+++ b/apps/docs/rc/references/workflows/order-group/get-order-groups-list.mdx
@@ -21,7 +21,9 @@ const { result } = await getOrderGroupsListWorkflow(container).run({
 ## Input
 
 <ParamField body="fields" type="string[]" required>Fields to retrieve; merged with the defaults needed for status aggregation.</ParamField>
-<ParamField body="variables" type="object">Query filters plus pagination.
+<ParamField body="variables" type="object">
+  Query filters plus pagination.
+
   <Expandable title="properties">
     <ParamField body="skip" type="number">Number of groups to skip.</ParamField>
     <ParamField body="take" type="number">Number of groups to return.</ParamField>

--- a/apps/docs/rc/references/workflows/payout/process-payout-for-webhook.mdx
+++ b/apps/docs/rc/references/workflows/payout/process-payout-for-webhook.mdx
@@ -21,7 +21,9 @@ await processPayoutForWebhookWorkflow(container).run({
 ## Input
 
 <ParamField body="action" type="string" required>One of `account.activated`, `account.restricted`, `account.rejected`, `payout.processing`, `payout.paid`, `payout.failed`, `payout.canceled`, `not_supported`.</ParamField>
-<ParamField body="data" type="object">Event target; nothing happens when omitted.
+<ParamField body="data" type="object">
+  Event target; nothing happens when omitted.
+
   <Expandable title="properties">
     <ParamField body="id" type="string" required>The ID of the payout account (for `account.*` actions) or the payout (for `payout.*` actions).</ParamField>
   </Expandable>

--- a/apps/docs/rc/resources/tutorials/add-a-widget.mdx
+++ b/apps/docs/rc/resources/tutorials/add-a-widget.mdx
@@ -108,4 +108,3 @@ The full, valid set is typed as `WidgetZoneId` and generated into `@mercurjs/ven
     Add a store-setup field and persist it through a workflow hook.
   </Card>
 </CardGroup>
-</content>

--- a/apps/docs/rc/resources/tutorials/customize-navigation.mdx
+++ b/apps/docs/rc/resources/tutorials/customize-navigation.mdx
@@ -108,4 +108,3 @@ export default defineNavigationConfig({
     Inject a component into a built-in page.
   </Card>
 </CardGroup>
-</content>

--- a/apps/docs/rc/resources/tutorials/extend-forms-and-tables.mdx
+++ b/apps/docs/rc/resources/tutorials/extend-forms-and-tables.mdx
@@ -186,4 +186,3 @@ The SDK derives the fetch query from `link` and merges it into the built-in quer
     Inject a component at a built-in zone.
   </Card>
 </CardGroup>
-</content>

--- a/apps/docs/rc/resources/tutorials/extend-onboarding.mdx
+++ b/apps/docs/rc/resources/tutorials/extend-onboarding.mdx
@@ -251,4 +251,3 @@ seller.custom_fields.tax_id  (durable, queryable)
     Durable, queryable storage for the data your hook writes.
   </Card>
 </CardGroup>
-</content>

--- a/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
+++ b/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
@@ -76,7 +76,9 @@ const SUPPORTED_FORMATS_FILE_EXTENSIONS = [
 const stripWebsiteProtocol = (url: string | null | undefined): string =>
   url ? url.replace(/^https?:\/\//i, "") : "";
 
-const getFileNameFromUrl = (url: string | null | undefined): string | undefined => {
+const getFileNameFromUrl = (
+  url: string | null | undefined,
+): string | undefined => {
   if (!url || url.startsWith("blob:")) return undefined;
   try {
     const pathname = new URL(url).pathname;
@@ -113,10 +115,24 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
       website_url: stripWebsiteProtocol(seller.website_url),
       is_premium: seller.is_premium ?? false,
       media: seller.logo
-        ? [{ id: "existing-logo", url: seller.logo, isThumbnail: false, file: null }]
+        ? [
+            {
+              id: "existing-logo",
+              url: seller.logo,
+              isThumbnail: false,
+              file: null,
+            },
+          ]
         : [],
       bannerMedia: seller.banner
-        ? [{ id: "existing-banner", url: seller.banner, isThumbnail: false, file: null }]
+        ? [
+            {
+              id: "existing-banner",
+              url: seller.banner,
+              isThumbnail: false,
+              file: null,
+            },
+          ]
         : [],
     },
   });
@@ -184,7 +200,9 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
       {
         onSuccess: () => {
           toast.success(
-            t("stores.edit.successToast", { name: values.name ?? values.email }),
+            t("stores.edit.successToast", {
+              name: values.name ?? values.email,
+            }),
           );
           handleSuccess();
         },

--- a/packages/dashboard-shared/src/extensions/form-extension-zone.tsx
+++ b/packages/dashboard-shared/src/extensions/form-extension-zone.tsx
@@ -88,7 +88,7 @@ export const FormExtensionZone = ({
   if (fields.length === 0) return null
 
   return (
-    <>
+    <div className="flex flex-col gap-y-4">
       {fields.map(({ name, field }) => (
         <ExtensionField
           key={name}
@@ -98,6 +98,6 @@ export const FormExtensionZone = ({
           data={data}
         />
       ))}
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## What

Custom form fields rendered through `FormExtensionZone` were collapsing together with no vertical spacing, because the component emitted them inside a bare fragment. They now render inside a `flex flex-col gap-y-4` wrapper so they match the surrounding native field-group spacing.

## Changes

- `packages/dashboard-shared/src/extensions/form-extension-zone.tsx` — wrap mapped extension fields in a `flex flex-col gap-y-4` container (single source of the fix; applies to all ~24 admin + vendor consumers).
- `packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx` — drop the now-redundant manual wrapper around `FormExtensionZone`.
- `apps/docs/rc/**` — pending Mintlify docs formatting tweaks.

## Why centralized

Every admin/vendor edit form renders `<FormExtensionZone>` as a single child of a `flex flex-col gap-y-*` form body, so fixing the fragment→div at the source corrects the gap everywhere at once rather than patching each consumer.