### PR TITLE
docs: PRs target main instead of canary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ When the user asks to test a worktree (e.g. "test this worktree", "run this work
 - DO NOT COMMIT unless the user explicitly asks
 - Conventional Commits: `feat(scope):`, `fix(scope):`, `docs:`, `chore:`. Use `!` for breaking changes (e.g. `feat(auth)!:`)
 - Create branches following the convention `<type>/<feature>`, where `<type>` matches the Conventional Commit types (`feat`, `fix`, `docs`, `chore`, etc.) and `<feature>` is a short kebab-case description of the work (e.g. `feat/vendor-payouts`, `fix/order-split-rounding`)
-- PRs target `canary`
+- PRs target `main`
 - NEVER mention AI coding assistants (Claude, Claude Code, Codex, Copilot, Cursor, etc.) in commit messages, PR titles, or PR descriptions. No `Co-Authored-By: Claude` trailers, no "Generated with Claude Code" footers, no "🤖" markers. Commits and PRs must read as human-authored.
 
 ## Startup Workflow


### PR DESCRIPTION
Updates the contributing guidance in CLAUDE.md to reflect that pull requests now target `main` rather than `canary`.