### PR TITLE
feat(admin): add title validation to create collection form

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -3356,6 +3356,18 @@
         "updateSuccess": {
           "type": "string"
         },
+        "validation": {
+          "type": "object",
+          "properties": {
+            "titleRequired": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "titleRequired"
+          ],
+          "additionalProperties": false
+        },
         "editCollection": {
           "type": "string"
         },
@@ -3651,6 +3663,7 @@
         "createSuccess",
         "deleteSuccess",
         "updateSuccess",
+        "validation",
         "editCollection",
         "handleTooltip",
         "deleteWarning",

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -879,6 +879,9 @@
     "createSuccess": "Collection was successfully created.",
     "deleteSuccess": "Collection was successfully deleted.",
     "updateSuccess": "Collection was successfully updated.",
+    "validation": {
+      "titleRequired": "Please enter a title"
+    },
     "editCollection": "Edit Collection",
     "handleTooltip": "The handle is used to reference the collection in your storefront. If not specified, the handle will be generated from the collection title.",
     "deleteWarning": "You are about to delete the collection {{title}}. This action cannot be undone.",

--- a/packages/admin/src/pages/collections/collection-create/components/create-collection-form/create-collection-form.tsx
+++ b/packages/admin/src/pages/collections/collection-create/components/create-collection-form/create-collection-form.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Button, Heading, Input, Text, toast } from "@medusajs/ui"
+import i18n from "i18next"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
@@ -33,7 +34,9 @@ const CollectionIconSchema = zod.object({
 })
 
 const CreateCollectionSchema = zod.object({
-  title: zod.string().min(1),
+  title: zod
+    .string()
+    .min(1, { message: i18n.t("collections.validation.titleRequired") }),
   handle: zod.string().optional(),
   media: zod.array(CollectionMediaSchema).optional(),
   icon: CollectionIconSchema.nullable().optional(),


### PR DESCRIPTION
## Summary
- Add a required-title validation message to the admin **Create Collection** form: submitting with an empty title now shows "Please enter a title" instead of the default zod message.
- Reuse the established validation pattern (`.min(1, { message: i18n.t(...) })`) already used by categories, commission rules, and attributes.
- Add the `collections.validation.titleRequired` key to `en.json` and `$schema.json`.

## Linear
[MER-262](https://linear.app/rigbyjs/issue/MER-262)

## Test plan
- [ ] Open Collections → Create, leave Title empty, submit → inline error "Please enter a title".
- [ ] `bun run build`
- [ ] Translation schema test (`validate-translations.spec.ts`) — the new key pairs correctly between `en.json` and `$schema.json`.