### PR TITLE
fix(admin): correct customer address validation and success toasts

### DIFF
--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -4828,6 +4828,38 @@
                 "successToast"
               ],
               "additionalProperties": false
+            },
+            "delete": {
+              "type": "object",
+              "properties": {
+                "successToast": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "successToast"
+              ],
+              "additionalProperties": false
+            },
+            "validation": {
+              "type": "object",
+              "properties": {
+                "addressNameRequired": {
+                  "type": "string"
+                },
+                "addressRequired": {
+                  "type": "string"
+                },
+                "countryRequired": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "addressNameRequired",
+                "addressRequired",
+                "countryRequired"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -4836,7 +4868,9 @@
             "emptyMessage",
             "fields",
             "create",
-            "edit"
+            "edit",
+            "delete",
+            "validation"
           ],
           "additionalProperties": false
         }

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -1234,6 +1234,14 @@
         "header": "Edit Address",
         "hint": "Edit the customer's address.",
         "successToast": "Address was successfully updated."
+      },
+      "delete": {
+        "successToast": "Address was successfully deleted."
+      },
+      "validation": {
+        "addressNameRequired": "Please enter an address name",
+        "addressRequired": "Please enter an address",
+        "countryRequired": "Please select a country"
       }
     }
   },

--- a/packages/admin/src/pages/customers/customer-create-address/components/create-customer-address-form/create-customer-address-form.tsx
+++ b/packages/admin/src/pages/customers/customer-create-address/components/create-customer-address-form/create-customer-address-form.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Button, Heading, Input, Text, toast } from "@medusajs/ui"
+import i18n from "i18next"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
@@ -14,10 +15,17 @@ import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
 import { useCreateCustomerAddress } from "../../../../../hooks/api/customers"
 
 const CreateCustomerAddressSchema = zod.object({
-  address_name: zod.string().min(1),
-  address_1: zod.string().min(1),
+  address_name: zod.string().min(1, {
+    message: i18n.t("customers.addresses.validation.addressNameRequired"),
+  }),
+  address_1: zod.string().min(1, {
+    message: i18n.t("customers.addresses.validation.addressRequired"),
+  }),
   address_2: zod.string().optional(),
-  country_code: zod.string().min(2).max(2),
+  country_code: zod
+    .string()
+    .min(2, { message: i18n.t("customers.addresses.validation.countryRequired") })
+    .max(2),
   city: zod.string().optional(),
   postal_code: zod.string().optional(),
   province: zod.string().optional(),

--- a/packages/admin/src/pages/customers/customer-detail/components/customer-address-section/customer-address-section.tsx
+++ b/packages/admin/src/pages/customers/customer-detail/components/customer-address-section/customer-address-section.tsx
@@ -41,9 +41,7 @@ export const CustomerAddressSection = ({
 
     await deleteAddress(address.id, {
       onSuccess: () => {
-        toast.success(
-          t("general.success", { name: address.address_name ?? "address" })
-        )
+        toast.success(t("customers.addresses.delete.successToast"))
 
         navigate(`/customers/${customer.id}`, { replace: true })
       },

--- a/packages/admin/src/pages/customers/customer-edit-address/components/edit-customer-address-form/edit-customer-address-form.tsx
+++ b/packages/admin/src/pages/customers/customer-edit-address/components/edit-customer-address-form/edit-customer-address-form.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { HttpTypes } from "@medusajs/types"
-import { Button, Input } from "@medusajs/ui"
+import { Button, Input, toast } from "@medusajs/ui"
+import i18n from "i18next"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
@@ -12,10 +13,17 @@ import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
 import { useUpdateCustomerAddress } from "../../../../../hooks/api/customers"
 
 const EditCustomerAddressSchema = zod.object({
-  address_name: zod.string().min(1),
-  address_1: zod.string().min(1),
+  address_name: zod.string().min(1, {
+    message: i18n.t("customers.addresses.validation.addressNameRequired"),
+  }),
+  address_1: zod.string().min(1, {
+    message: i18n.t("customers.addresses.validation.addressRequired"),
+  }),
   address_2: zod.string().optional(),
-  country_code: zod.string().min(2).max(2),
+  country_code: zod
+    .string()
+    .min(2, { message: i18n.t("customers.addresses.validation.countryRequired") })
+    .max(2),
   city: zod.string().optional(),
   postal_code: zod.string().optional(),
   province: zod.string().optional(),
@@ -56,7 +64,12 @@ export const EditCustomerAddressForm = ({
   const handleSubmit = form.handleSubmit(async (values) => {
     await mutateAsync(values, {
       onSuccess: () => {
+        toast.success(t("customers.addresses.edit.successToast"))
+
         handleSuccess(`/customers/${customerId}`)
+      },
+      onError: (e) => {
+        toast.error(e.message)
       },
     })
   })


### PR DESCRIPTION
## Summary
- Customer address **create** and **edit** forms now show the designed validation copy instead of raw zod defaults: "Please enter an address name", "Please enter an address", "Please select a country".
- Address **update** now shows a success toast ("Address was successfully updated.") — previously the drawer closed silently.
- Address **delete** now shows "Address was successfully deleted." instead of the generic "Success" toast.
- Added the new `customers.addresses.delete` / `customers.addresses.validation` keys to `en.json` and `$schema.json` (kept in sync so the translation schema test stays consistent).

The create success toast already read "Address was successfully created." and is unchanged.

> Note: the ticket text for item 2 said the *create* toast should read "…deleted"; that's a copy/paste slip — the delete toast is the one showing generic "Success" in the attached screenshot. Fixed each action to its semantically correct message (create → created, update → updated, delete → deleted).

## Linear
[MER-268](https://linear.app/rigbyjs/issue/MER-268)

## Test plan
- [ ] Admin → Customer detail → Addresses → **Create**: submit empty form → field errors read "Please enter an address name", "Please enter an address", "Please select a country". Valid submit → "Address was successfully created."
- [ ] Edit an address → save → "Address was successfully updated." (same validation copy)
- [ ] Delete an address → confirm → "Address was successfully deleted."
- [x] `bun run build` (admin package builds, DTS/type-check passes)
- [x] i18n schema/en.json key consistency verified (no new drift vs `main`)