### PR TITLE
fix(panels): merge custom-field link relations into entity fetches

### DIFF
--- a/packages/admin/src/hooks/api/campaigns.tsx
+++ b/packages/admin/src/hooks/api/campaigns.tsx
@@ -35,7 +35,7 @@ export const useCampaign = (
   >
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: campaignsQueryKeys.detail(id),
+    queryKey: campaignsQueryKeys.detail(id, query),
     queryFn: () => sdk.admin.campaigns.$id.query({ $id: id, ...query }),
     ...options,
   })

--- a/packages/admin/src/hooks/api/collections.tsx
+++ b/packages/admin/src/hooks/api/collections.tsx
@@ -32,7 +32,7 @@ export const useCollection = (
   >,
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: collectionsQueryKeys.detail(id),
+    queryKey: collectionsQueryKeys.detail(id, query),
     queryFn: () => sdk.admin.collections.$id.query({ $id: id, ...query }),
     ...options,
   });

--- a/packages/admin/src/hooks/api/customer-groups.tsx
+++ b/packages/admin/src/hooks/api/customer-groups.tsx
@@ -39,7 +39,7 @@ export const useCustomerGroup = (
 ) => {
   const { data, ...rest } = useQuery({
     queryFn: () => sdk.admin.customerGroups.$id.query({ $id: id, ...query }),
-    queryKey: customerGroupsQueryKeys.detail(id),
+    queryKey: customerGroupsQueryKeys.detail(id, query),
     ...options,
   })
 

--- a/packages/admin/src/hooks/api/customers.tsx
+++ b/packages/admin/src/hooks/api/customers.tsx
@@ -38,7 +38,7 @@ export const useCustomer = (
   >
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: customersQueryKeys.detail(id),
+    queryKey: customersQueryKeys.detail(id, query),
     queryFn: () => sdk.admin.customers.$id.query({ $id: id, ...query }),
     ...options,
   })

--- a/packages/admin/src/hooks/api/inventory.tsx
+++ b/packages/admin/src/hooks/api/inventory.tsx
@@ -61,7 +61,7 @@ export const useInventoryItem = (
   const { data, ...rest } = useQuery({
     queryFn: () =>
       sdk.admin.inventoryItems.$id.query({ $id: id, ...query }) as Promise<ExtendedAdminInventoryItemResponse>,
-    queryKey: inventoryItemsQueryKeys.detail(id),
+    queryKey: inventoryItemsQueryKeys.detail(id, query),
     ...options,
   })
 

--- a/packages/admin/src/hooks/api/price-lists.tsx
+++ b/packages/admin/src/hooks/api/price-lists.tsx
@@ -37,7 +37,7 @@ export const usePriceList = (
 ) => {
   const { data, ...rest } = useQuery({
     queryFn: () => sdk.admin.priceLists.$id.query({ $id: id, ...query }),
-    queryKey: priceListsQueryKeys.detail(id),
+    queryKey: priceListsQueryKeys.detail(id, query),
     ...options,
   })
 

--- a/packages/admin/src/hooks/api/promotions.tsx
+++ b/packages/admin/src/hooks/api/promotions.tsx
@@ -40,6 +40,7 @@ export const promotionsQueryKeys = {
 
 export const usePromotion = (
   id: string,
+  query?: HttpTypes.AdminGetPromotionParams,
   options?: Omit<
     UseQueryOptions<
       HttpTypes.AdminPromotionResponse,
@@ -51,8 +52,8 @@ export const usePromotion = (
   >
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: promotionsQueryKeys.detail(id),
-    queryFn: async () => sdk.admin.promotions.$id.query({ $id: id }),
+    queryKey: promotionsQueryKeys.detail(id, query),
+    queryFn: async () => sdk.admin.promotions.$id.query({ $id: id, ...query }),
     ...options,
   })
 

--- a/packages/admin/src/hooks/api/reservations.tsx
+++ b/packages/admin/src/hooks/api/reservations.tsx
@@ -40,7 +40,7 @@ export const useReservationItem = (
   >
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: reservationItemsQueryKeys.detail(id),
+    queryKey: reservationItemsQueryKeys.detail(id, query),
     queryFn: () => sdk.admin.reservations.$id.query({ $id: id, ...query }),
     ...options,
   })

--- a/packages/admin/src/hooks/api/sellers.tsx
+++ b/packages/admin/src/hooks/api/sellers.tsx
@@ -38,7 +38,7 @@ export const useSeller = (
 ) => {
   const { data, ...rest } = useQuery({
     queryFn: () => sdk.admin.sellers.$id.query({ $id: id, ...query }),
-    queryKey: sellersQueryKeys.detail(id),
+    queryKey: sellersQueryKeys.detail(id, query),
     ...options,
   });
 

--- a/packages/admin/src/pages/campaigns/campaign-detail/campaign-detail.tsx
+++ b/packages/admin/src/pages/campaigns/campaign-detail/campaign-detail.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom"
 
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../components/layout/pages"
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { WidgetZone, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { useCampaign } from "../../../hooks/api/campaigns"
 import { CampaignBudget } from "./components/campaign-budget"
 import { CampaignConfigurationSection } from "./components/campaign-configuration-section"
@@ -19,9 +19,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
   >
 
   const { id } = useParams()
+  const query = useLinkQuery("campaign", CAMPAIGN_DETAIL_FIELDS)
   const { campaign, isLoading, isError, error } = useCampaign(
     id!,
-    { fields: CAMPAIGN_DETAIL_FIELDS },
+    query,
     { initialData }
   )
 

--- a/packages/admin/src/pages/campaigns/campaign-detail/loader.ts
+++ b/packages/admin/src/pages/campaigns/campaign-detail/loader.ts
@@ -1,15 +1,18 @@
 import { LoaderFunctionArgs } from "react-router-dom"
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 
 import { campaignsQueryKeys } from "../../../hooks/api/campaigns"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 import { CAMPAIGN_DETAIL_FIELDS } from "./constants"
 
-const campaignDetailQuery = (id: string) => ({
-  queryKey: campaignsQueryKeys.detail(id),
-  queryFn: async () =>
-    sdk.admin.campaigns.$id.query({ $id: id, fields: CAMPAIGN_DETAIL_FIELDS }),
-})
+const campaignDetailQuery = (id: string) => {
+  const query = getLinkQuery("campaign", CAMPAIGN_DETAIL_FIELDS)
+  return {
+    queryKey: campaignsQueryKeys.detail(id, query),
+    queryFn: async () => sdk.admin.campaigns.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const campaignLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/admin/src/pages/campaigns/campaign-edit/campaign-edit.tsx
+++ b/packages/admin/src/pages/campaigns/campaign-edit/campaign-edit.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "../../../components/modals"
 import { VisuallyHidden } from "../../../components/utilities/visually-hidden"
 import { useCampaign } from "../../../hooks/api/campaigns"
@@ -10,7 +11,8 @@ export const CampaignEdit = () => {
   const { t } = useTranslation()
 
   const { id } = useParams()
-  const { campaign, isLoading, isError, error } = useCampaign(id!)
+  const query = useLinkQuery("campaign")
+  const { campaign, isLoading, isError, error } = useCampaign(id!, query)
 
   if (isError) {
     throw error

--- a/packages/admin/src/pages/campaigns/campaign-list/components/campaign-list-table.tsx
+++ b/packages/admin/src/pages/campaigns/campaign-list/components/campaign-list-table.tsx
@@ -3,7 +3,7 @@ import { AdminCampaign } from "@medusajs/types"
 import { Button, Container, Heading, toast, usePrompt } from "@medusajs/ui"
 import { keepPreviousData } from "@tanstack/react-query"
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { Children, ReactNode, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
@@ -68,6 +68,7 @@ export const CampaignListHeader = ({ children }: { children?: ReactNode }) => {
 export const CampaignListDataTable = () => {
   const { t } = useTranslation()
   const { raw, searchParams } = useCampaignTableQuery({ pageSize: PAGE_SIZE })
+  const linkQuery = useLinkQuery("campaign")
 
   const {
     campaigns,
@@ -75,9 +76,12 @@ export const CampaignListDataTable = () => {
     isPending: isLoading,
     isError,
     error,
-  } = useCampaigns(searchParams, {
-    placeholderData: keepPreviousData,
-  })
+  } = useCampaigns(
+    { ...searchParams, ...linkQuery },
+    {
+      placeholderData: keepPreviousData,
+    }
+  )
 
   const columns = useColumns()
 

--- a/packages/admin/src/pages/categories/category-detail/category-detail.tsx
+++ b/packages/admin/src/pages/categories/category-detail/category-detail.tsx
@@ -1,4 +1,4 @@
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared"
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
@@ -19,9 +19,11 @@ const Root = ({ children }: { children?: ReactNode }) => {
     ReturnType<typeof categoryLoader>
   >
 
+  const linkQuery = useLinkQuery("category")
+
   const { product_category, isLoading, isError, error } = useProductCategory(
     id!,
-    undefined,
+    linkQuery,
     {
       initialData,
     }

--- a/packages/admin/src/pages/categories/category-detail/loader.ts
+++ b/packages/admin/src/pages/categories/category-detail/loader.ts
@@ -1,13 +1,19 @@
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 import { LoaderFunctionArgs } from "react-router-dom"
 
 import { categoriesQueryKeys } from "../../../hooks/api/categories"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
-const categoryDetailQuery = (id: string) => ({
-  queryKey: categoriesQueryKeys.detail(id),
-  queryFn: async () => sdk.admin.productCategories.$id.query({ $id: id }),
-})
+const categoryDetailQuery = (id: string) => {
+  const query = getLinkQuery("category")
+
+  return {
+    queryKey: categoriesQueryKeys.detail(id, query),
+    queryFn: async () =>
+      sdk.admin.productCategories.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const categoryLoader = async ({ params }: LoaderFunctionArgs): Promise<any> => {
   const id = params.id

--- a/packages/admin/src/pages/categories/category-edit/category-edit.tsx
+++ b/packages/admin/src/pages/categories/category-edit/category-edit.tsx
@@ -1,4 +1,5 @@
 import { Heading } from "@medusajs/ui"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
@@ -10,8 +11,11 @@ export const CategoryEdit = () => {
   const { id } = useParams()
   const { t } = useTranslation()
 
+  const linkQuery = useLinkQuery("category")
+
   const { product_category, isPending, isError, error } = useProductCategory(
-    id!
+    id!,
+    linkQuery
   )
 
   const ready = !isPending && !!product_category

--- a/packages/admin/src/pages/categories/category-list/components/category-list-table/category-list-data-table.tsx
+++ b/packages/admin/src/pages/categories/category-list/components/category-list-table/category-list-data-table.tsx
@@ -1,6 +1,6 @@
 import { PencilSquare, Trash } from "@medusajs/icons"
 import { AdminProductCategoryResponse } from "@medusajs/types"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { keepPreviousData } from "@tanstack/react-query"
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
 import { useMemo } from "react"
@@ -22,16 +22,25 @@ export const CategoryListDataTable = () => {
   const imageFields =
     "media_images.id,media_images.url,media_images.type,media_images.is_thumbnail,media_images.is_banner"
 
+  const ancestorsLinkQuery = useLinkQuery(
+    "category",
+    `id,name,handle,is_active,is_internal,parent_category,${imageFields}`
+  )
+  const descendantsLinkQuery = useLinkQuery(
+    "category",
+    `id,name,category_children,handle,is_internal,is_active,${imageFields}`
+  )
+
   const query = raw.q
     ? {
         include_ancestors_tree: true,
-        fields: `id,name,handle,is_active,is_internal,parent_category,${imageFields}`,
+        ...ancestorsLinkQuery,
         ...searchParams,
       }
     : {
         include_descendants_tree: true,
         parent_category_id: "null",
-        fields: `id,name,category_children,handle,is_internal,is_active,${imageFields}`,
+        ...descendantsLinkQuery,
         ...searchParams,
       }
 

--- a/packages/admin/src/pages/collections/collection-detail/collection-detail.tsx
+++ b/packages/admin/src/pages/collections/collection-detail/collection-detail.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { WidgetZone, useLinkQuery } from "@mercurjs/dashboard-shared"
 
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
@@ -20,7 +20,7 @@ const Root = ({ children }: { children?: ReactNode }) => {
   const { id } = useParams();
   const { collection, isLoading, isError, error } = useCollection(
     id!,
-    {},
+    useLinkQuery("collection"),
     {
       initialData,
     },

--- a/packages/admin/src/pages/collections/collection-detail/loader.ts
+++ b/packages/admin/src/pages/collections/collection-detail/loader.ts
@@ -1,13 +1,18 @@
 import { LoaderFunctionArgs } from "react-router-dom"
 
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
+
 import { collectionsQueryKeys } from "../../../hooks/api/collections"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
-const collectionDetailQuery = (id: string) => ({
-  queryKey: collectionsQueryKeys.detail(id),
-  queryFn: async () => sdk.admin.collections.$id.query({ $id: id }),
-})
+const collectionDetailQuery = (id: string) => {
+  const query = getLinkQuery("collection")
+  return {
+    queryKey: collectionsQueryKeys.detail(id, query),
+    queryFn: async () => sdk.admin.collections.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const collectionLoader = async ({ params }: LoaderFunctionArgs): Promise<any> => {
   const id = params.id

--- a/packages/admin/src/pages/collections/collection-edit/collection-edit.tsx
+++ b/packages/admin/src/pages/collections/collection-edit/collection-edit.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "../../../components/modals"
 import { useCollection } from "../../../hooks/api/collections"
 import { EditCollectionForm } from "./components/edit-collection-form"
@@ -8,7 +9,10 @@ import { EditCollectionForm } from "./components/edit-collection-form"
 export const CollectionEdit = () => {
   const { id } = useParams()
   const { t } = useTranslation()
-  const { collection, isLoading, isError, error } = useCollection(id!)
+  const { collection, isLoading, isError, error } = useCollection(
+    id!,
+    useLinkQuery("collection"),
+  )
 
   if (isError) {
     throw error

--- a/packages/admin/src/pages/collections/collection-list/components/collection-list-table/collection-list-data-table.tsx
+++ b/packages/admin/src/pages/collections/collection-list/components/collection-list-table/collection-list-data-table.tsx
@@ -1,7 +1,7 @@
 import { HttpTypes } from "@medusajs/types"
 import { keepPreviousData } from "@tanstack/react-query"
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { _DataTable } from "../../../../../components/table/data-table"
@@ -20,7 +20,7 @@ export const CollectionListDataTable = () => {
   const { collections, count, isError, error, isLoading } = useCollections(
     {
       ...searchParams,
-      fields: "+products.id",
+      ...useLinkQuery("collection", "+products.id"),
     },
     {
       placeholderData: keepPreviousData,

--- a/packages/admin/src/pages/customer-groups/customer-group-detail/customer-group-detail.tsx
+++ b/packages/admin/src/pages/customer-groups/customer-group-detail/customer-group-detail.tsx
@@ -1,6 +1,6 @@
 import { Children, ReactNode } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared"
 
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useCustomerGroup } from "../../../hooks/api/customer-groups"
@@ -17,11 +17,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
   >
 
   const { id } = useParams()
+  const query = useLinkQuery("customer_group", CUSTOMER_GROUP_DETAIL_FIELDS)
   const { customer_group, isLoading, isError, error } = useCustomerGroup(
     id!,
-    {
-      fields: CUSTOMER_GROUP_DETAIL_FIELDS,
-    },
+    query,
     { initialData },
   )
 

--- a/packages/admin/src/pages/customer-groups/customer-group-detail/loader.ts
+++ b/packages/admin/src/pages/customer-groups/customer-group-detail/loader.ts
@@ -1,17 +1,21 @@
 import { LoaderFunctionArgs } from "react-router-dom"
-import { productsQueryKeys } from "../../../hooks/api/products"
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
+import { customerGroupsQueryKeys } from "../../../hooks/api/customer-groups"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 import { CUSTOMER_GROUP_DETAIL_FIELDS } from "./constants"
 
-const customerGroupDetailQuery = (id: string) => ({
-  queryKey: productsQueryKeys.detail(id),
-  queryFn: async () =>
-    sdk.admin.customerGroups.$id.query({
-      $id: id,
-      fields: CUSTOMER_GROUP_DETAIL_FIELDS,
-    }),
-})
+const customerGroupDetailQuery = (id: string) => {
+  const query = getLinkQuery("customer_group", CUSTOMER_GROUP_DETAIL_FIELDS)
+  return {
+    queryKey: customerGroupsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      sdk.admin.customerGroups.$id.query({
+        $id: id,
+        ...query,
+      }),
+  }
+}
 
 export const customerGroupLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/admin/src/pages/customer-groups/customer-group-edit/customer-group-edit.tsx
+++ b/packages/admin/src/pages/customer-groups/customer-group-edit/customer-group-edit.tsx
@@ -1,4 +1,5 @@
 import { Heading } from "@medusajs/ui"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 import { RouteDrawer } from "../../../components/modals"
@@ -7,7 +8,11 @@ import { EditCustomerGroupForm } from "./components/edit-customer-group-form"
 
 export const CustomerGroupEdit = () => {
   const { id } = useParams()
-  const { customer_group, isLoading, isError, error } = useCustomerGroup(id!)
+  const query = useLinkQuery("customer_group")
+  const { customer_group, isLoading, isError, error } = useCustomerGroup(
+    id!,
+    query,
+  )
 
   const { t } = useTranslation()
 

--- a/packages/admin/src/pages/customer-groups/customer-group-list/components/customer-group-list-table/customer-group-list-table.tsx
+++ b/packages/admin/src/pages/customer-groups/customer-group-list/components/customer-group-list-table/customer-group-list-table.tsx
@@ -7,7 +7,7 @@ import {
   toast,
   usePrompt,
 } from "@medusajs/ui"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { keepPreviousData } from "@tanstack/react-query"
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
 import { Children, ReactNode, useCallback, useMemo } from "react"
@@ -78,12 +78,16 @@ export const CustomerGroupListDataTable = () => {
 
   const { searchParams, raw } = useCustomerGroupTableQuery({ pageSize: PAGE_SIZE })
 
+  const linkQuery = useLinkQuery(
+    "customer_group",
+    "id,name,created_at,updated_at,customers.id,seller.id,seller.name",
+  )
+
   const { customer_groups, count, isPending, isError, error } =
     useCustomerGroups(
       {
         ...searchParams,
-        fields:
-          "id,name,created_at,updated_at,customers.id,seller.id,seller.name",
+        ...linkQuery,
       },
       {
         placeholderData: keepPreviousData,

--- a/packages/admin/src/pages/customers/customer-detail/customer-detail.tsx
+++ b/packages/admin/src/pages/customers/customer-detail/customer-detail.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { WidgetZone, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../components/layout/pages"
 import { useCustomer } from "../../../hooks/api/customers"
@@ -17,11 +17,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
   const initialData = useLoaderData() as Awaited<
     ReturnType<typeof customerLoader>
   >
-  const { customer, isLoading, isError, error } = useCustomer(
-    id!,
-    { fields: "+*addresses" },
-    { initialData }
-  )
+  const query = useLinkQuery("customer", "+*addresses")
+  const { customer, isLoading, isError, error } = useCustomer(id!, query, {
+    initialData,
+  })
 
   if (isLoading || !customer) {
     return <SingleColumnPageSkeleton sections={2} showJSON showMetadata />

--- a/packages/admin/src/pages/customers/customer-detail/loader.ts
+++ b/packages/admin/src/pages/customers/customer-detail/loader.ts
@@ -1,13 +1,16 @@
 import { LoaderFunctionArgs } from "react-router-dom"
-import { productsQueryKeys } from "../../../hooks/api/products"
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
+import { customersQueryKeys } from "../../../hooks/api/customers"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
-const customerDetailQuery = (id: string) => ({
-  queryKey: productsQueryKeys.detail(id),
-  queryFn: async () =>
-    sdk.admin.customers.$id.query({ $id: id, fields: "+*addresses" }),
-})
+const customerDetailQuery = (id: string) => {
+  const query = getLinkQuery("customer", "+*addresses")
+  return {
+    queryKey: customersQueryKeys.detail(id, query),
+    queryFn: async () => sdk.admin.customers.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const customerLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/admin/src/pages/customers/customer-edit/customer-edit.tsx
+++ b/packages/admin/src/pages/customers/customer-edit/customer-edit.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "../../../components/modals"
 import { useCustomer } from "../../../hooks/api/customers"
 import { EditCustomerForm } from "./components/edit-customer-form"
@@ -9,7 +10,10 @@ export const CustomerEdit = () => {
   const { t } = useTranslation()
 
   const { id } = useParams()
-  const { customer, isLoading, isError, error } = useCustomer(id!)
+  const { customer, isLoading, isError, error } = useCustomer(
+    id!,
+    useLinkQuery("customer")
+  )
 
   if (isError) {
     throw error

--- a/packages/admin/src/pages/customers/customer-list/components/customer-list-table/customer-list-table.tsx
+++ b/packages/admin/src/pages/customers/customer-list/components/customer-list-table/customer-list-table.tsx
@@ -2,7 +2,7 @@ import { PencilSquare } from "@medusajs/icons"
 import { Button, Container, Heading } from "@medusajs/ui"
 import { keepPreviousData } from "@tanstack/react-query"
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { ReactNode, useMemo, Children } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
@@ -71,9 +71,11 @@ export const CustomerListDataTable = () => {
   const { t } = useTranslation()
 
   const { searchParams, raw } = useCustomerTableQuery({ pageSize: PAGE_SIZE })
+  const linkQuery = useLinkQuery("customer")
   const { customers, count, isLoading, isError, error } = useCustomers(
     {
       ...searchParams,
+      ...linkQuery,
     },
     {
       placeholderData: keepPreviousData,

--- a/packages/admin/src/pages/inventory/inventory-detail/components/edit-inventory-item/edit-item-drawer.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/components/edit-inventory-item/edit-item-drawer.tsx
@@ -1,3 +1,4 @@
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "@components/modals"
 import { useInventoryItem } from "@hooks/api"
 import { Heading } from "@medusajs/ui"
@@ -14,7 +15,7 @@ export const InventoryItemEdit = () => {
     isPending: isLoading,
     isError,
     error,
-  } = useInventoryItem(id!)
+  } = useInventoryItem(id!, useLinkQuery("inventory_item"))
 
   const ready = !isLoading && inventoryItem
 

--- a/packages/admin/src/pages/inventory/inventory-detail/inventory-detail.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/inventory-detail.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared"
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton"
 import { TwoColumnPage } from "@components/layout/pages"
@@ -29,9 +29,7 @@ const Root = ({ children }: { children?: ReactNode }) => {
     error,
   } = useInventoryItem(
     id!,
-    {
-      fields: INVENTORY_DETAIL_FIELDS,
-    },
+    useLinkQuery("inventory_item", INVENTORY_DETAIL_FIELDS),
     {
       initialData,
     }

--- a/packages/admin/src/pages/inventory/inventory-detail/loader.ts
+++ b/packages/admin/src/pages/inventory/inventory-detail/loader.ts
@@ -1,18 +1,22 @@
 import type { LoaderFunctionArgs } from "react-router-dom"
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 import { INVENTORY_DETAIL_FIELDS } from "./constants"
 import { inventoryItemsQueryKeys } from "@hooks/api"
 import { sdk } from "@lib/client"
 import { queryClient } from "@lib/query-client"
 import type { ExtendedAdminInventoryItemResponse } from "@custom-types/inventory"
 
-const inventoryDetailQuery = (id: string) => ({
-  queryKey: inventoryItemsQueryKeys.detail(id),
-  queryFn: async () =>
-    sdk.admin.inventoryItems.$id.query({
-      $id: id,
-      fields: INVENTORY_DETAIL_FIELDS,
-    }) as Promise<ExtendedAdminInventoryItemResponse>,
-})
+const inventoryDetailQuery = (id: string) => {
+  const query = getLinkQuery("inventory_item", INVENTORY_DETAIL_FIELDS)
+  return {
+    queryKey: inventoryItemsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      sdk.admin.inventoryItems.$id.query({
+        $id: id,
+        ...query,
+      }) as Promise<ExtendedAdminInventoryItemResponse>,
+  }
+}
 
 export const inventoryItemLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/admin/src/pages/inventory/inventory-list/components/inventory-list-table.tsx
+++ b/packages/admin/src/pages/inventory/inventory-list/components/inventory-list-table.tsx
@@ -2,7 +2,7 @@ import { InventoryTypes, ProductVariantDTO } from "@medusajs/types"
 import { Button, Container, Heading, Text } from "@medusajs/ui"
 
 import { ColumnDef, RowSelectionState } from "@tanstack/react-table"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { Children, ReactNode, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useNavigate } from "react-router-dom"
@@ -91,6 +91,7 @@ export const InventoryListDataTable = () => {
     error,
   } = useInventoryItems({
     ...searchParams,
+    ...useLinkQuery("inventory_item"),
   })
 
   const baseFilters = useInventoryTableFilters()

--- a/packages/admin/src/pages/offers/[id]/loader.ts
+++ b/packages/admin/src/pages/offers/[id]/loader.ts
@@ -1,23 +1,27 @@
 import { LoaderFunctionArgs } from "react-router-dom"
 import { InferClientInput } from "@mercurjs/client"
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 
 import { productsQueryKeys } from "../../../hooks/api/products"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 import { OFFER_PRODUCT_DETAIL_FIELDS } from "../common/constants"
 
-export const offerProductDetailQuery = (id: string, sellerId?: string) => ({
-  queryKey: productsQueryKeys.detail(id, {
-    fields: OFFER_PRODUCT_DETAIL_FIELDS,
+export const offerProductDetailQuery = (id: string, sellerId?: string) => {
+  const query = {
+    ...getLinkQuery("offer", OFFER_PRODUCT_DETAIL_FIELDS),
     seller_id: sellerId,
-  }),
-  queryFn: async () =>
-    sdk.admin.products.$id.query({
-      $id: id,
-      fields: OFFER_PRODUCT_DETAIL_FIELDS,
-      ...(sellerId ? { seller_id: sellerId } : {}),
-    } as InferClientInput<typeof sdk.admin.products.$id.query>),
-})
+  }
+  return {
+    queryKey: productsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      sdk.admin.products.$id.query({
+        $id: id,
+        ...query,
+        ...(sellerId ? { seller_id: sellerId } : {}),
+      } as InferClientInput<typeof sdk.admin.products.$id.query>),
+  }
+}
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/admin/src/pages/offers/[id]/offer-detail-page.tsx
+++ b/packages/admin/src/pages/offers/[id]/offer-detail-page.tsx
@@ -1,7 +1,7 @@
 import { Children, ReactNode } from "react"
 import { useLoaderData, useParams, useSearchParams } from "react-router-dom"
 
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared"
 
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../components/layout/pages"
@@ -22,10 +22,11 @@ const Root = ({ children }: { children?: ReactNode }) => {
   const [searchParams] = useSearchParams()
   const sellerId = searchParams.get("seller_id") ?? undefined
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>
+  const linkQuery = useLinkQuery("offer", OFFER_PRODUCT_DETAIL_FIELDS)
 
   const { product, isLoading, isError, error } = useProduct(
     id!,
-    { fields: OFFER_PRODUCT_DETAIL_FIELDS, seller_id: sellerId },
+    { ...linkQuery, seller_id: sellerId },
     { initialData },
   )
 

--- a/packages/admin/src/pages/offers/_components/use-offer-table-query.tsx
+++ b/packages/admin/src/pages/offers/_components/use-offer-table-query.tsx
@@ -1,3 +1,5 @@
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
+
 import { useQueryParams } from "../../../hooks/use-query-params"
 
 const OFFER_LIST_FIELDS = [
@@ -61,6 +63,8 @@ export const useOfferTableQuery = ({
     q,
   } = raw
 
+  const { fields } = useLinkQuery("offer", OFFER_LIST_FIELDS)
+
   const searchParams: Record<string, unknown> = {
     limit: pageSize,
     offset: offset ? parseInt(offset, 10) : 0,
@@ -75,7 +79,7 @@ export const useOfferTableQuery = ({
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,
     group_by_seller: "true",
-    fields: OFFER_LIST_FIELDS,
+    fields,
   }
 
   return {

--- a/packages/admin/src/pages/orders/order-detail/loader.ts
+++ b/packages/admin/src/pages/orders/order-detail/loader.ts
@@ -1,3 +1,4 @@
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 import { LoaderFunctionArgs } from "react-router-dom"
 
 import { ordersQueryKeys } from "../../../hooks/api/orders"
@@ -5,11 +6,13 @@ import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 import { DEFAULT_FIELDS } from "./constants"
 
-const orderDetailQuery = (id: string) => ({
-  queryKey: ordersQueryKeys.detail(id),
-  queryFn: async () =>
-    sdk.admin.orders.$id.query({ $id: id, fields: DEFAULT_FIELDS }),
-})
+const orderDetailQuery = (id: string) => {
+  const { fields } = getLinkQuery("order", DEFAULT_FIELDS)
+  return {
+    queryKey: ordersQueryKeys.detail(id, { fields }),
+    queryFn: async () => sdk.admin.orders.$id.query({ $id: id, fields }),
+  }
+}
 
 export const orderLoader = async ({ params }: LoaderFunctionArgs): Promise<any> => {
   const id = params.id

--- a/packages/admin/src/pages/orders/order-detail/order-detail.tsx
+++ b/packages/admin/src/pages/orders/order-detail/order-detail.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Children } from "react";
 import { useLoaderData, useParams } from "react-router-dom";
 
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton";
 import { TwoColumnPage } from "../../../components/layout/pages";
 import { useOrder, useOrderPreview } from "../../../hooks/api/orders";
@@ -27,11 +27,11 @@ const Root = ({ children }: { children?: ReactNode }) => {
 
   const { id } = useParams();
 
+  const query = useLinkQuery("order", DEFAULT_FIELDS);
+
   const { order: rawOrder, isLoading, isError, error } = useOrder(
     id!,
-    {
-      fields: DEFAULT_FIELDS,
-    },
+    query,
     {
       initialData,
     },

--- a/packages/admin/src/pages/price-lists/price-list-detail/price-list-detail.tsx
+++ b/packages/admin/src/pages/price-lists/price-list-detail/price-list-detail.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Children } from "react"
 import { useParams } from "react-router-dom"
 
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared"
 
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../components/layout/pages"
@@ -13,7 +13,8 @@ import { PriceListProductSection } from "./components/price-list-product-section
 const Root = ({ children }: { children?: ReactNode }) => {
   const { id } = useParams()
 
-  const { price_list, isLoading, isError, error } = usePriceList(id!)
+  const linkQuery = useLinkQuery("price_list")
+  const { price_list, isLoading, isError, error } = usePriceList(id!, linkQuery)
 
   if (isLoading || !price_list) {
     return (

--- a/packages/admin/src/pages/price-lists/price-list-edit/price-list-edit.tsx
+++ b/packages/admin/src/pages/price-lists/price-list-edit/price-list-edit.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "../../../components/modals"
 import { usePriceList } from "../../../hooks/api/price-lists"
 import { PriceListEditForm } from "./components/price-list-edit-form"
@@ -9,7 +10,8 @@ export const PriceListEdit = () => {
   const { t } = useTranslation()
   const { id } = useParams()
 
-  const { price_list, isLoading, isError, error } = usePriceList(id!)
+  const linkQuery = useLinkQuery("price_list")
+  const { price_list, isLoading, isError, error } = usePriceList(id!, linkQuery)
 
   const ready = !isLoading && price_list
 

--- a/packages/admin/src/pages/price-lists/price-list-list/components/price-list-list-table/price-list-list-data-table.tsx
+++ b/packages/admin/src/pages/price-lists/price-list-list/components/price-list-list-table/price-list-list-data-table.tsx
@@ -1,7 +1,7 @@
 import { HttpTypes } from "@medusajs/types"
 import { keepPreviousData } from "@tanstack/react-query"
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { _DataTable } from "../../../../../components/table/data-table"
@@ -46,8 +46,9 @@ export const PriceListListDataTable = () => {
   const { searchParams, raw } = usePricingTableQuery({
     pageSize: PAGE_SIZE,
   })
+  const linkQuery = useLinkQuery("price_list")
   const { price_lists, count, isLoading, isError, error } = usePriceLists(
-    searchParams,
+    { ...searchParams, ...linkQuery },
     {
       placeholderData: keepPreviousData,
     }

--- a/packages/admin/src/pages/products/product-detail/loader.ts
+++ b/packages/admin/src/pages/products/product-detail/loader.ts
@@ -1,4 +1,5 @@
 import { LoaderFunctionArgs } from "react-router-dom"
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 
 import { productsQueryKeys } from "../../../hooks/api/products"
 import { sdk } from "../../../lib/client"
@@ -6,11 +7,17 @@ import { queryClient } from "../../../lib/query-client"
 import { AdminProductResponse } from "@mercurjs/types"
 import { PRODUCT_DETAIL_QUERY } from "../constants"
 
-const productDetailQuery = (id: string) => ({
-  queryKey: productsQueryKeys.detail(id, PRODUCT_DETAIL_QUERY),
-  queryFn: async () =>
-    sdk.admin.products.$id.query({ $id: id, ...PRODUCT_DETAIL_QUERY }),
-})
+export const productDetailQueryWithLinks = () =>
+  getLinkQuery("product", PRODUCT_DETAIL_QUERY.fields)
+
+const productDetailQuery = (id: string) => {
+  const query = productDetailQueryWithLinks()
+  return {
+    queryKey: productsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      sdk.admin.products.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const productLoader = async ({ params }: LoaderFunctionArgs): Promise<AdminProductResponse> => {
   const id = params.id

--- a/packages/admin/src/pages/products/product-detail/product-detail.tsx
+++ b/packages/admin/src/pages/products/product-detail/product-detail.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { HttpTypes } from "@medusajs/types";
 import { HttpTypes as MercurHttpTypes, SellerDTO } from "@mercurjs/types";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { WidgetZone, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton";
 import { TwoColumnPage } from "../../../components/layout/pages";
 import { useProduct } from "../../../hooks/api/products";
@@ -27,12 +27,13 @@ const Root = ({ children }: { children?: ReactNode }) => {
   >;
 
   const { id } = useParams();
+  const query = useLinkQuery("product", PRODUCT_DETAIL_QUERY.fields);
   const {
     product: rawProduct,
     isLoading,
     isError,
     error,
-  } = useProduct(id!, PRODUCT_DETAIL_QUERY, {
+  } = useProduct(id!, query, {
     initialData: initialData as unknown as MercurHttpTypes.AdminProductResponse,
   });
   const product = rawProduct as AdminProductWithSeller | undefined;

--- a/packages/admin/src/pages/promotions/promotion-detail/breadcrumb.tsx
+++ b/packages/admin/src/pages/promotions/promotion-detail/breadcrumb.tsx
@@ -1,4 +1,5 @@
 import { HttpTypes } from "@medusajs/types"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { UIMatch } from "react-router-dom"
 import { usePromotion } from "../../../hooks/api"
 
@@ -9,7 +10,8 @@ export const PromotionDetailBreadcrumb = (
 ) => {
   const { id } = props.params || {}
 
-  const { promotion } = usePromotion(id!, {
+  const linkQuery = useLinkQuery("promotion")
+  const { promotion } = usePromotion(id!, linkQuery, {
     initialData: props.data,
     enabled: Boolean(id),
   })

--- a/packages/admin/src/pages/promotions/promotion-detail/components/campaign-section/campaign-section.tsx
+++ b/packages/admin/src/pages/promotions/promotion-detail/components/campaign-section/campaign-section.tsx
@@ -4,7 +4,7 @@ import { Container, Heading, Text } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 
-import { DisplayExtensionZone } from "@mercurjs/dashboard-shared"
+import { DisplayExtensionZone, useLinkQuery } from "@mercurjs/dashboard-shared"
 
 import { ActionMenu } from "../../../../../components/common/action-menu"
 import { DateRangeDisplay } from "../../../../../components/common/date-range-display"
@@ -45,7 +45,8 @@ export const CampaignSection = ({
 }) => {
   const { t } = useTranslation()
   const { id } = useParams()
-  const { promotion } = usePromotion(id!, {
+  const linkQuery = useLinkQuery("promotion")
+  const { promotion } = usePromotion(id!, linkQuery, {
     enabled: campaignProp === undefined,
   })
   const campaign = campaignProp !== undefined ? campaignProp : (promotion?.campaign ?? null)

--- a/packages/admin/src/pages/promotions/promotion-detail/components/promotion-conditions-section/promotion-conditions-section.tsx
+++ b/packages/admin/src/pages/promotions/promotion-detail/components/promotion-conditions-section/promotion-conditions-section.tsx
@@ -7,7 +7,7 @@ import { Badge, Container, Heading } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
-import { DisplayExtensionZone } from "@mercurjs/dashboard-shared";
+import { DisplayExtensionZone, useLinkQuery } from "@mercurjs/dashboard-shared";
 
 import { ActionMenu } from "../../../../../components/common/action-menu";
 import { BadgeListSummary } from "../../../../../components/common/badge-list-summary";
@@ -61,7 +61,8 @@ export const PromotionConditionsSection = ({
 }: PromotionConditionsSectionProps) => {
   const { t } = useTranslation();
   const { id } = useParams();
-  const { promotion } = usePromotion(id!, {
+  const linkQuery = useLinkQuery("promotion");
+  const { promotion } = usePromotion(id!, linkQuery, {
     enabled: rulesProp === undefined,
   });
   const query: Record<string, string> = {};

--- a/packages/admin/src/pages/promotions/promotion-detail/components/promotion-general-section/promotion-general-section.tsx
+++ b/packages/admin/src/pages/promotions/promotion-detail/components/promotion-general-section/promotion-general-section.tsx
@@ -14,7 +14,11 @@ import { useNavigate } from "react-router-dom"
 
 import { useParams } from "react-router-dom"
 
-import { DisplayExtensionZone, DisplayField } from "@mercurjs/dashboard-shared"
+import {
+  DisplayExtensionZone,
+  DisplayField,
+  useLinkQuery,
+} from "@mercurjs/dashboard-shared"
 
 import { ActionMenu } from "../../../../../components/common/action-menu"
 import { useDeletePromotion, usePromotion } from "../../../../../hooks/api/promotions"
@@ -66,7 +70,8 @@ export const PromotionGeneralSection = ({
   const prompt = usePrompt()
   const navigate = useNavigate()
   const { id } = useParams()
-  const { promotion: fetched } = usePromotion(id!, {
+  const linkQuery = useLinkQuery("promotion")
+  const { promotion: fetched } = usePromotion(id!, linkQuery, {
     enabled: !promotionProp,
   })
   const promotion = promotionProp ?? fetched

--- a/packages/admin/src/pages/promotions/promotion-detail/loader.ts
+++ b/packages/admin/src/pages/promotions/promotion-detail/loader.ts
@@ -1,12 +1,16 @@
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 import { LoaderFunctionArgs } from "react-router-dom"
 import { promotionsQueryKeys } from "../../../hooks/api/promotions"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
-const promotionDetailQuery = (id: string) => ({
-  queryKey: promotionsQueryKeys.detail(id),
-  queryFn: async () => sdk.admin.promotions.$id.query({ $id: id }),
-})
+const promotionDetailQuery = (id: string) => {
+  const query = getLinkQuery("promotion")
+  return {
+    queryKey: promotionsQueryKeys.detail(id, query),
+    queryFn: async () => sdk.admin.promotions.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const promotionLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/admin/src/pages/promotions/promotion-detail/promotion-detail.tsx
+++ b/packages/admin/src/pages/promotions/promotion-detail/promotion-detail.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Children } from "react";
 import { useLoaderData, useParams } from "react-router-dom";
 
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton";
 import { TwoColumnPage } from "../../../components/layout/pages";
@@ -17,7 +17,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
   >;
 
   const { id } = useParams();
-  const { promotion, isLoading } = usePromotion(id!, { initialData });
+  const linkQuery = useLinkQuery("promotion");
+  const { promotion, isLoading } = usePromotion(id!, linkQuery, {
+    initialData,
+  });
   const query: Record<string, string> = {};
 
   if (promotion?.type === "buyget") {

--- a/packages/admin/src/pages/promotions/promotion-edit-details/promotion-edit-details.tsx
+++ b/packages/admin/src/pages/promotions/promotion-edit-details/promotion-edit-details.tsx
@@ -1,4 +1,5 @@
 import { Heading } from "@medusajs/ui"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 
@@ -10,7 +11,8 @@ export const PromotionEditDetails = () => {
   const { id } = useParams()
   const { t } = useTranslation()
 
-  const { promotion, isLoading, isError, error } = usePromotion(id!)
+  const linkQuery = useLinkQuery("promotion")
+  const { promotion, isLoading, isError, error } = usePromotion(id!, linkQuery)
 
   if (isError) {
     throw error

--- a/packages/admin/src/pages/promotions/promotion-list/components/promotion-list-table/promotion-list-table.tsx
+++ b/packages/admin/src/pages/promotions/promotion-list/components/promotion-list-table/promotion-list-table.tsx
@@ -2,7 +2,7 @@ import { PencilSquare, Trash } from "@medusajs/icons"
 import { HttpTypes } from "@medusajs/types"
 import { Button, Container, Heading, usePrompt } from "@medusajs/ui"
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { Children, ReactNode, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, Outlet, useLoaderData, useNavigate } from "react-router-dom"
@@ -72,8 +72,9 @@ export const PromotionListDataTable = () => {
     useLoaderData() as HttpTypes.AdminPromotionListResponse | undefined
 
   const { searchParams, raw } = usePromotionTableQuery({ pageSize: PAGE_SIZE })
+  const linkQuery = useLinkQuery("promotion")
   const { promotions, count, isLoading, isError, error } = usePromotions(
-    { ...searchParams },
+    { ...searchParams, ...linkQuery },
     {
       initialData,
       placeholderData: keepPreviousData,

--- a/packages/admin/src/pages/reservations/reservation-detail/components/edit-reservation/edit-reservation-modal.tsx
+++ b/packages/admin/src/pages/reservations/reservation-detail/components/edit-reservation/edit-reservation-modal.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "../../../../../components/modals"
 import { useInventoryItem } from "../../../../../hooks/api/inventory"
 import { useReservationItem } from "../../../../../hooks/api/reservations"
@@ -11,7 +12,10 @@ export const ReservationEdit = () => {
   const { id } = useParams()
   const { t } = useTranslation()
 
-  const { reservation, isPending, isError, error } = useReservationItem(id!)
+  const { reservation, isPending, isError, error } = useReservationItem(
+    id!,
+    useLinkQuery("reservation")
+  )
   const { inventory_item: inventoryItem } = useInventoryItem(
     reservation?.inventory_item_id ?? "",
     undefined,

--- a/packages/admin/src/pages/reservations/reservation-detail/loader.ts
+++ b/packages/admin/src/pages/reservations/reservation-detail/loader.ts
@@ -1,12 +1,16 @@
 import { LoaderFunctionArgs } from "react-router-dom"
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 import { reservationItemsQueryKeys } from "../../../hooks/api/reservations"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
-const reservationDetailQuery = (id: string) => ({
-  queryKey: reservationItemsQueryKeys.detail(id),
-  queryFn: async () => sdk.admin.reservations.$id.query({ $id: id }),
-})
+const reservationDetailQuery = (id: string) => {
+  const query = getLinkQuery("reservation")
+  return {
+    queryKey: reservationItemsQueryKeys.detail(id, query),
+    queryFn: async () => sdk.admin.reservations.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const reservationItemLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/admin/src/pages/reservations/reservation-detail/reservation-detail.tsx
+++ b/packages/admin/src/pages/reservations/reservation-detail/reservation-detail.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, Children } from "react";
 import { useLoaderData, useParams } from "react-router-dom";
 
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton";
 import { TwoColumnPage } from "../../../components/layout/pages";
@@ -21,7 +21,7 @@ const Root = ({ children }: { children?: ReactNode }) => {
 
   const { reservation, isLoading, isError, error } = useReservationItem(
     id!,
-    undefined,
+    useLinkQuery("reservation"),
     {
       initialData,
     },
@@ -30,7 +30,7 @@ const Root = ({ children }: { children?: ReactNode }) => {
   // TEMP: fetch directly since the fields are not populated with reservation call
   const { inventory_item } = useInventoryItem(
     reservation?.inventory_item?.id!,
-    undefined,
+    useLinkQuery("inventory_item"),
     { enabled: !!reservation?.inventory_item?.id },
   );
 

--- a/packages/admin/src/pages/reservations/reservation-list/components/reservation-list-table/reservation-list-table.tsx
+++ b/packages/admin/src/pages/reservations/reservation-list/components/reservation-list-table/reservation-list-table.tsx
@@ -1,5 +1,5 @@
 import { Button, Container, Heading, Text } from "@medusajs/ui"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import type { ColumnDef } from "@tanstack/react-table"
 
 import { Children, ReactNode, useMemo } from "react"
@@ -68,6 +68,7 @@ export const ReservationListDataTable = () => {
   const { reservations, count, isPending, isError, error } =
     useReservationItems({
       ...searchParams,
+      ...useLinkQuery("reservation"),
     })
 
   const baseFilters = useReservationTableFilters()

--- a/packages/admin/src/pages/stores/store-edit/store-edit.tsx
+++ b/packages/admin/src/pages/stores/store-edit/store-edit.tsx
@@ -1,4 +1,5 @@
 import { Heading } from "@medusajs/ui";
+import { useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
@@ -10,7 +11,9 @@ export const StoreEdit = () => {
   const { id } = useParams();
   const { t } = useTranslation();
 
-  const { seller, isLoading, isError, error } = useSeller(id!);
+  const query = useLinkQuery("seller");
+
+  const { seller, isLoading, isError, error } = useSeller(id!, query);
 
   if (isError) {
     throw error;

--- a/packages/dashboard-shared/src/extensions/index.ts
+++ b/packages/dashboard-shared/src/extensions/index.ts
@@ -36,7 +36,7 @@ export {
   type UseExtendableTableProps,
   type ExtendableTable,
 } from "./use-extendable-table"
-export { withLinkFields } from "./links"
+export { withLinkFields, linkFields, getLinkQuery, useLinkQuery } from "./links"
 export {
   createFormHelper,
   buildAdditionalDataSchema,

--- a/packages/dashboard-shared/src/extensions/links.ts
+++ b/packages/dashboard-shared/src/extensions/links.ts
@@ -1,3 +1,10 @@
+import { useExtension } from "./context"
+import { getExtensionRegistry } from "./context"
+
+/** Turn a model's `link` relations into `+link.*` merge tokens. */
+export const linkFields = (links: string[]): string =>
+  links.map((l) => `+${l}.*`).join(",")
+
 /**
  * Merge a model's custom-fields `link` relations into a curated fields string
  * using the `+` merge convention (`+link.*`), so linked-module data is fetched
@@ -5,4 +12,32 @@
  * base `fields` unchanged when there are no links.
  */
 export const withLinkFields = (fields: string, links: string[]): string =>
-  links.length ? `${fields},${links.map((l) => `+${l}.*`).join(",")}` : fields
+  links.length ? `${fields},${linkFields(links)}` : fields
+
+/**
+ * Build a spreadable `{ fields }` query fragment that adds a model's custom-fields
+ * `link` relations. Pass `base` to merge onto a curated field set (list/detail
+ * queries); omit it to merge purely onto the route defaults (`+link.*` only), so
+ * unprefixed base fields never replace the route defaults. Returns `{}` (or
+ * `{ fields: base }`) when the model declares no links, leaving the fetch
+ * unchanged. Non-hook variant for react-router loaders.
+ */
+export const getLinkQuery = (
+  model: string,
+  base?: string,
+): { fields?: string } => {
+  const links = getExtensionRegistry()?.getLinks(model) ?? []
+  if (!links.length) {
+    return base ? { fields: base } : {}
+  }
+  return { fields: base ? withLinkFields(base, links) : linkFields(links) }
+}
+
+/** Hook variant of {@link getLinkQuery} for use inside components. */
+export const useLinkQuery = (model: string, base?: string): { fields?: string } => {
+  const links = useExtension().getLinks(model)
+  if (!links.length) {
+    return base ? { fields: base } : {}
+  }
+  return { fields: base ? withLinkFields(base, links) : linkFields(links) }
+}

--- a/packages/vendor/src/hooks/api/campaigns.tsx
+++ b/packages/vendor/src/hooks/api/campaigns.tsx
@@ -30,7 +30,7 @@ export const useCampaign = (
   >
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: campaignsQueryKeys.detail(id),
+    queryKey: campaignsQueryKeys.detail(id, query),
     queryFn: async () => sdk.vendor.campaigns.$id.query({ $id: id, ...query }),
     ...options,
   });

--- a/packages/vendor/src/hooks/api/collections.tsx
+++ b/packages/vendor/src/hooks/api/collections.tsx
@@ -24,6 +24,10 @@ export const collectionsQueryKeys = queryKeysFactory(COLLECTION_QUERY_KEY);
 
 export const useCollection = (
   id: string,
+  query?: Omit<
+    InferClientInput<typeof sdk.vendor.collections.$id.query>,
+    "$id"
+  >,
   options?: UseQueryOptions<
     unknown,
     ClientError,
@@ -31,8 +35,8 @@ export const useCollection = (
   >,
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: collectionsQueryKeys.detail(id),
-    queryFn: async () => sdk.vendor.collections.$id.query({ $id: id }),
+    queryKey: collectionsQueryKeys.detail(id, query),
+    queryFn: async () => sdk.vendor.collections.$id.query({ $id: id, ...query }),
     ...options,
   });
 

--- a/packages/vendor/src/hooks/api/customers.tsx
+++ b/packages/vendor/src/hooks/api/customers.tsx
@@ -30,7 +30,7 @@ export const useCustomer = (
   >,
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: customersQueryKeys.detail(id),
+    queryKey: customersQueryKeys.detail(id, query),
     queryFn: async () => sdk.vendor.customers.$id.query({ $id: id, ...query }),
     ...options,
   });

--- a/packages/vendor/src/hooks/api/inventory.tsx
+++ b/packages/vendor/src/hooks/api/inventory.tsx
@@ -57,7 +57,7 @@ export const useInventoryItem = (
 ) => {
   const { data, ...rest } = useQuery({
     queryFn: () => sdk.vendor.inventoryItems.$id.query({ $id: id, ...query }),
-    queryKey: inventoryItemsQueryKeys.detail(id),
+    queryKey: inventoryItemsQueryKeys.detail(id, query),
     ...options,
   });
 

--- a/packages/vendor/src/hooks/api/members.tsx
+++ b/packages/vendor/src/hooks/api/members.tsx
@@ -20,6 +20,7 @@ export const membersQueryKeys = {
 };
 
 export const useMe = (
+  query?: Record<string, unknown>,
   options?: UseQueryOptions<
     any,
     ClientError,
@@ -27,8 +28,11 @@ export const useMe = (
   >,
 ) => {
   const { data, ...rest } = useQuery({
-    queryFn: () => sdk.vendor.members.me.query(),
-    queryKey: membersQueryKeys.me(),
+    queryFn: () =>
+      sdk.vendor.members.me.query(
+        query as Parameters<typeof sdk.vendor.members.me.query>[0],
+      ),
+    queryKey: query ? [...membersQueryKeys.me(), query] : membersQueryKeys.me(),
     ...options,
   });
 

--- a/packages/vendor/src/hooks/api/promotions.tsx
+++ b/packages/vendor/src/hooks/api/promotions.tsx
@@ -45,6 +45,10 @@ export const promotionsQueryKeys = {
 
 export const usePromotion = (
   id: string,
+  query?: Omit<
+    InferClientInput<typeof sdk.vendor.promotions.$id.query>,
+    "$id"
+  >,
   options?: UseQueryOptions<
     unknown,
     ClientError,
@@ -52,8 +56,8 @@ export const usePromotion = (
   >,
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: promotionsQueryKeys.detail(id),
-    queryFn: async () => sdk.vendor.promotions.$id.query({ $id: id }),
+    queryKey: promotionsQueryKeys.detail(id, query),
+    queryFn: async () => sdk.vendor.promotions.$id.query({ $id: id, ...query }),
     ...options,
   });
 

--- a/packages/vendor/src/hooks/api/reservations.tsx
+++ b/packages/vendor/src/hooks/api/reservations.tsx
@@ -35,7 +35,7 @@ export const useReservationItem = (
   >
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: reservationItemsQueryKeys.detail(id),
+    queryKey: reservationItemsQueryKeys.detail(id, query),
     queryFn: async () => sdk.vendor.reservations.$id.query({ $id: id, ...query }),
     ...options,
   });

--- a/packages/vendor/src/hooks/api/sellers.tsx
+++ b/packages/vendor/src/hooks/api/sellers.tsx
@@ -31,6 +31,26 @@ export const useCurrentSeller = () => {
   };
 };
 
+export const useSeller = (
+  id: string,
+  query?: Omit<InferClientInput<typeof sdk.vendor.sellers.$id.query>, "$id">,
+  options?: Omit<
+    UseQueryOptions<
+      InferClientOutput<typeof sdk.vendor.sellers.$id.query>,
+      ClientError
+    >,
+    "queryFn" | "queryKey"
+  >,
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: sellersQueryKeys.detail(id, query),
+    queryFn: () => sdk.vendor.sellers.$id.query({ $id: id, ...query }),
+    ...options,
+  });
+
+  return { ...data, ...rest };
+};
+
 export const useSellers = (
   query?: InferClientInput<typeof sdk.vendor.sellers.query>,
   options?: Omit<

--- a/packages/vendor/src/pages/campaigns/[id]/campaign-detail-page.tsx
+++ b/packages/vendor/src/pages/campaigns/[id]/campaign-detail-page.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { WidgetZone, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useCampaign } from "@hooks/api/campaigns";
 import { usePromotionTableQuery } from "@hooks/table/query/use-promotion-table-query";
 
@@ -20,9 +20,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>;
   const { id } = useParams();
   const { searchParams } = usePromotionTableQuery({});
+  const linkQuery = useLinkQuery("campaign", CAMPAIGN_DETAIL_FIELDS);
   const { campaign, isLoading, isError, error } = useCampaign(
     id!,
-    { ...searchParams, fields: CAMPAIGN_DETAIL_FIELDS },
+    { ...searchParams, ...linkQuery },
     {
       placeholderData: initialData,
     },

--- a/packages/vendor/src/pages/campaigns/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/campaigns/[id]/edit/index.tsx
@@ -2,6 +2,7 @@
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "@components/modals"
 import { VisuallyHidden } from "@components/utilities/visually-hidden"
 import { useCampaign } from "@hooks/api/campaigns"
@@ -11,7 +12,8 @@ export const Component = () => {
   const { t } = useTranslation()
 
   const { id } = useParams()
-  const { campaign, isLoading, isError, error } = useCampaign(id!)
+  const query = useLinkQuery("campaign")
+  const { campaign, isLoading, isError, error } = useCampaign(id!, query)
 
   if (isError) {
     throw error

--- a/packages/vendor/src/pages/campaigns/[id]/loader.tsx
+++ b/packages/vendor/src/pages/campaigns/[id]/loader.tsx
@@ -1,4 +1,5 @@
 import { LoaderFunctionArgs } from "react-router-dom";
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
 
 import { campaignsQueryKeys } from "@hooks/api/campaigns";
 import { fetchQuery } from "@lib/client";
@@ -6,16 +7,17 @@ import { queryClient } from "@lib/query-client";
 
 import { CAMPAIGN_DETAIL_FIELDS } from "./constants";
 
-const campaignDetailQuery = (id: string) => ({
-  queryKey: campaignsQueryKeys.detail(id, { fields: CAMPAIGN_DETAIL_FIELDS }),
-  queryFn: async () =>
-    fetchQuery(`/vendor/campaigns/${id}`, {
-      method: "GET",
-      query: {
-        fields: CAMPAIGN_DETAIL_FIELDS,
-      },
-    }),
-});
+const campaignDetailQuery = (id: string) => {
+  const query = getLinkQuery("campaign", CAMPAIGN_DETAIL_FIELDS);
+  return {
+    queryKey: campaignsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      fetchQuery(`/vendor/campaigns/${id}`, {
+        method: "GET",
+        query,
+      }),
+  };
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/campaigns/_components/campaign-list-table/campaign-list-data-table.tsx
+++ b/packages/vendor/src/pages/campaigns/_components/campaign-list-table/campaign-list-data-table.tsx
@@ -3,7 +3,7 @@ import { AdminCampaign } from "@medusajs/types";
 import { toast, usePrompt } from "@medusajs/ui";
 import { keepPreviousData } from "@tanstack/react-query";
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -22,6 +22,7 @@ const PAGE_SIZE = 20;
 export const CampaignListDataTable = () => {
   const { t } = useTranslation();
   const { raw, searchParams } = useCampaignTableQuery({ pageSize: PAGE_SIZE });
+  const linkQuery = useLinkQuery("campaign");
 
   const {
     campaigns,
@@ -29,9 +30,12 @@ export const CampaignListDataTable = () => {
     isPending: isLoading,
     isError,
     error,
-  } = useCampaigns(searchParams, {
-    placeholderData: keepPreviousData,
-  });
+  } = useCampaigns(
+    { ...searchParams, ...linkQuery },
+    {
+      placeholderData: keepPreviousData,
+    },
+  );
 
   const { columns } = useColumns();
 

--- a/packages/vendor/src/pages/categories/[id]/category-detail-page.tsx
+++ b/packages/vendor/src/pages/categories/[id]/category-detail-page.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 import { useProductCategory } from "@hooks/api";
 
 import { CategoryGeneralSection } from "./_components/category-general-section";
@@ -15,14 +15,14 @@ import { CategoryProductSection } from "./_components/category-product-section";
 const Root = ({ children }: { children?: ReactNode }) => {
   const { id } = useParams();
 
+  const linkQuery = useLinkQuery("category", "+is_active,+is_internal");
+
   const {
     product_category,
     isLoading: categoryLoading,
     isError: categoryError,
     error,
-  } = useProductCategory(id!, {
-    fields: "+is_active,+is_internal",
-  });
+  } = useProductCategory(id!, linkQuery);
 
   if (categoryLoading || !product_category) {
     return (

--- a/packages/vendor/src/pages/categories/[id]/loader.tsx
+++ b/packages/vendor/src/pages/categories/[id]/loader.tsx
@@ -1,16 +1,22 @@
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
 import { LoaderFunctionArgs } from "react-router-dom";
 
 import { categoriesQueryKeys } from "@hooks/api/categories";
 import { fetchQuery } from "@lib/client";
 import { queryClient } from "@lib/query-client";
 
-const categoryDetailQuery = (id: string) => ({
-  queryKey: categoriesQueryKeys.detail(id),
-  queryFn: async () =>
-    fetchQuery(`/vendor/product-categories/${id}`, {
-      method: "GET",
-    }),
-});
+const categoryDetailQuery = (id: string) => {
+  const query = getLinkQuery("category");
+
+  return {
+    queryKey: categoriesQueryKeys.detail(id, query),
+    queryFn: async () =>
+      fetchQuery(`/vendor/product-categories/${id}`, {
+        method: "GET",
+        query,
+      }),
+  };
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/categories/_components/category-list-table/category-list-data-table.tsx
+++ b/packages/vendor/src/pages/categories/_components/category-list-table/category-list-data-table.tsx
@@ -1,6 +1,6 @@
 import { keepPreviousData } from "@tanstack/react-query";
 import { type ColumnDef } from "@tanstack/react-table";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useMemo } from "react";
 import { AdminProductCategoryResponse } from "@medusajs/types";
 
@@ -17,16 +17,25 @@ export const CategoryListDataTable = () => {
     pageSize: PAGE_SIZE,
   });
 
+  const ancestorsLinkQuery = useLinkQuery(
+    "category",
+    "id,name,handle,is_active,is_internal,parent_category",
+  );
+  const descendantsLinkQuery = useLinkQuery(
+    "category",
+    "id,name,category_children,handle,is_internal,is_active",
+  );
+
   const query = raw.q
     ? {
         include_ancestors_tree: true,
-        fields: "id,name,handle,is_active,is_internal,parent_category",
+        ...ancestorsLinkQuery,
         ...searchParams,
       }
     : {
         include_descendants_tree: true,
         parent_category_id: "null",
-        fields: "id,name,category_children,handle,is_internal,is_active",
+        ...descendantsLinkQuery,
         ...searchParams,
       };
 

--- a/packages/vendor/src/pages/collections/[id]/breadcrumb.tsx
+++ b/packages/vendor/src/pages/collections/[id]/breadcrumb.tsx
@@ -8,7 +8,7 @@ type CollectionDetailBreadcrumbProps =
 
 export const Breadcrumb = (props: CollectionDetailBreadcrumbProps) => {
   const { id } = props.params || {};
-  const { collection } = useCollection(id!, {
+  const { collection } = useCollection(id!, undefined, {
     initialData: { collection: props.data?.collection },
   });
 

--- a/packages/vendor/src/pages/collections/[id]/collection-detail-page.tsx
+++ b/packages/vendor/src/pages/collections/[id]/collection-detail-page.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { SingleColumnPageSkeleton } from "@components/common/skeleton";
 import { SingleColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { WidgetZone, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useCollection } from "@hooks/api/collections";
 
 import { CollectionGeneralSection } from "./_components/collection-general-section";
@@ -16,9 +16,13 @@ import type { loader } from "./loader";
 const Root = ({ children }: { children?: ReactNode }) => {
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>;
   const { id } = useParams();
-  const { collection, isLoading, isError, error } = useCollection(id!, {
-    initialData,
-  });
+  const { collection, isLoading, isError, error } = useCollection(
+    id!,
+    useLinkQuery("collection"),
+    {
+      initialData,
+    },
+  );
 
   if (isLoading || !collection) {
     return <SingleColumnPageSkeleton sections={4} />;

--- a/packages/vendor/src/pages/collections/[id]/loader.tsx
+++ b/packages/vendor/src/pages/collections/[id]/loader.tsx
@@ -1,13 +1,19 @@
 import { LoaderFunctionArgs } from "react-router-dom";
 
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
+
 import { collectionsQueryKeys } from "@hooks/api/collections";
 import { sdk } from "@lib/client";
 import { queryClient } from "@lib/query-client";
 
-const collectionDetailQuery = (id: string) => ({
-  queryKey: collectionsQueryKeys.detail(id),
-  queryFn: async () => sdk.vendor.collections.$id.query({ $id: id }),
-});
+const collectionDetailQuery = (id: string) => {
+  const query = getLinkQuery("collection");
+  return {
+    queryKey: collectionsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      sdk.vendor.collections.$id.query({ $id: id, ...query }),
+  };
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/collections/_components/collection-list-table/collection-list-data-table.tsx
+++ b/packages/vendor/src/pages/collections/_components/collection-list-table/collection-list-data-table.tsx
@@ -4,7 +4,7 @@ import { type ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
 
 import { HttpTypes } from "@mercurjs/types";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 
 import { _DataTable } from "@components/table/data-table";
 import { useCollections } from "@hooks/api/collections";
@@ -23,7 +23,7 @@ export const CollectionListDataTable = () => {
   const { collections, count, isError, error, isLoading } = useCollections(
     {
       ...searchParams,
-      fields: "*products",
+      ...useLinkQuery("collection", "*products"),
     },
     {
       placeholderData: keepPreviousData,

--- a/packages/vendor/src/pages/customer-groups/customer-group-detail/customer-group-detail.tsx
+++ b/packages/vendor/src/pages/customer-groups/customer-group-detail/customer-group-detail.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { SingleColumnPageSkeleton } from "@components/common/skeleton";
 import { SingleColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 import { useCustomerGroup } from "@hooks/api/customer-groups";
 
 import { CustomerGroupCustomerSection } from "./components/customer-group-customer-section";
@@ -17,11 +17,10 @@ const Root = ({ children }: { children?: ReactNode }) => {
   >;
 
   const { id } = useParams();
+  const query = useLinkQuery("customer_group", CUSTOMER_GROUP_DETAIL_FIELDS);
   const { customer_group, isLoading, isError, error } = useCustomerGroup(
     id!,
-    {
-      fields: CUSTOMER_GROUP_DETAIL_FIELDS,
-    },
+    query,
     { initialData },
   );
 

--- a/packages/vendor/src/pages/customer-groups/customer-group-detail/loader.ts
+++ b/packages/vendor/src/pages/customer-groups/customer-group-detail/loader.ts
@@ -1,19 +1,23 @@
 import { LoaderFunctionArgs } from "react-router-dom";
 
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
 import { sdk } from "@lib/client";
 import { queryClient } from "@lib/query-client";
 
 import { customerGroupsQueryKeys } from "@hooks/api/customer-groups";
 import { CUSTOMER_GROUP_DETAIL_FIELDS } from "./constants";
 
-const customerGroupDetailQuery = (id: string) => ({
-  queryKey: customerGroupsQueryKeys.detail(id),
-  queryFn: async () =>
-    sdk.vendor.customerGroups.$id.query({
-      $id: id,
-      fields: CUSTOMER_GROUP_DETAIL_FIELDS,
-    }),
-});
+const customerGroupDetailQuery = (id: string) => {
+  const query = getLinkQuery("customer_group", CUSTOMER_GROUP_DETAIL_FIELDS);
+  return {
+    queryKey: customerGroupsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      sdk.vendor.customerGroups.$id.query({
+        $id: id,
+        ...query,
+      }),
+  };
+};
 
 export const customerGroupLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/customer-groups/customer-group-edit/customer-group-edit.tsx
+++ b/packages/vendor/src/pages/customer-groups/customer-group-edit/customer-group-edit.tsx
@@ -1,4 +1,5 @@
 import { Heading } from "@medusajs/ui";
+import { useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
@@ -9,7 +10,11 @@ import { EditCustomerGroupForm } from "./components/edit-customer-group-form";
 
 export const CustomerGroupEdit = () => {
   const { id } = useParams();
-  const { customer_group, isLoading, isError, error } = useCustomerGroup(id!);
+  const query = useLinkQuery("customer_group");
+  const { customer_group, isLoading, isError, error } = useCustomerGroup(
+    id!,
+    query,
+  );
 
   const { t } = useTranslation();
 

--- a/packages/vendor/src/pages/customer-groups/customer-group-list/components/customer-group-list-table/customer-group-list-table.tsx
+++ b/packages/vendor/src/pages/customer-groups/customer-group-list/components/customer-group-list-table/customer-group-list-table.tsx
@@ -3,7 +3,7 @@ import { HttpTypes } from "@medusajs/types";
 import { Button, Container, Heading, toast, usePrompt } from "@medusajs/ui";
 import { keepPreviousData } from "@tanstack/react-query";
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { Children, ReactNode, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, Outlet } from "react-router-dom";
@@ -86,12 +86,17 @@ export const CustomerGroupListDataTable = () => {
     pageSize: PAGE_SIZE,
   });
 
+  const linkQuery = useLinkQuery(
+    "customer_group",
+    "id,name,created_at,updated_at,customers.id",
+  );
+
   const { customer_groups, count, isPending, isError, error } =
     useCustomerGroups(
       {
         ...searchParams,
         order: searchParams.order || "name",
-        fields: "id,name,created_at,updated_at,customers.id",
+        ...linkQuery,
       },
       {
         placeholderData: keepPreviousData,

--- a/packages/vendor/src/pages/customers/[id]/customer-detail-page.tsx
+++ b/packages/vendor/src/pages/customers/[id]/customer-detail-page.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { WidgetZone, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useCustomer } from "@hooks/api/customers";
 
 import { CustomerAddressSection } from "./_components/customer-address-section";
@@ -16,11 +16,10 @@ import type { loader } from "./loader";
 const Root = ({ children }: { children?: ReactNode }) => {
   const { id } = useParams();
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>;
-  const { customer, isLoading, isError, error } = useCustomer(
-    id!,
-    {},
-    { initialData },
-  );
+  const query = useLinkQuery("customer", "*groups, *groups.customers");
+  const { customer, isLoading, isError, error } = useCustomer(id!, query, {
+    initialData,
+  });
 
   if (isLoading || !customer) {
     return <TwoColumnPageSkeleton mainSections={3} sidebarSections={1} />;

--- a/packages/vendor/src/pages/customers/[id]/loader.tsx
+++ b/packages/vendor/src/pages/customers/[id]/loader.tsx
@@ -1,17 +1,21 @@
 import { LoaderFunctionArgs } from "react-router-dom";
 
-import { productsQueryKeys } from "@hooks/api/products";
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
+import { customersQueryKeys } from "@hooks/api/customers";
 import { fetchQuery } from "@lib/client";
 import { queryClient } from "@lib/query-client";
 
-const customerDetailQuery = (id: string) => ({
-  queryKey: productsQueryKeys.detail(id),
-  queryFn: async () =>
-    fetchQuery(`/vendor/customers/${id}`, {
-      method: "GET",
-      query: { fields: "*groups, *groups.customers" },
-    }),
-});
+const customerDetailQuery = (id: string) => {
+  const query = getLinkQuery("customer", "*groups, *groups.customers");
+  return {
+    queryKey: customersQueryKeys.detail(id, query),
+    queryFn: async () =>
+      fetchQuery(`/vendor/customers/${id}`, {
+        method: "GET",
+        query,
+      }),
+  };
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/customers/_components/customer-list-table/customer-list-data-table.tsx
+++ b/packages/vendor/src/pages/customers/_components/customer-list-table/customer-list-data-table.tsx
@@ -1,7 +1,7 @@
 import { keepPreviousData } from "@tanstack/react-query";
 import { type ColumnDef } from "@tanstack/react-table";
 import { HttpTypes } from "@medusajs/types";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -21,9 +21,11 @@ export const CustomerListDataTable = () => {
     pageSize: PAGE_SIZE,
   });
 
+  const linkQuery = useLinkQuery("customer");
   const { customers, count, isLoading, isError, error } = useCustomers(
     {
       ...searchParams,
+      ...linkQuery,
     },
     {
       placeholderData: keepPreviousData,

--- a/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/edit-item-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/edit-item-drawer.tsx
@@ -1,6 +1,7 @@
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "@components/modals"
 import { useInventoryItem } from "@hooks/api/inventory"
 import { EditInventoryItemForm } from "./components/edit-item-form"
@@ -14,7 +15,7 @@ export const InventoryItemEdit = () => {
     isPending: isLoading,
     isError,
     error,
-  } = useInventoryItem(id!)
+  } = useInventoryItem(id!, useLinkQuery("inventory_item"))
 
   const ready = !isLoading && inventoryItem
 

--- a/packages/vendor/src/pages/inventory/[id]/inventory-detail-page.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/inventory-detail-page.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 import { useInventoryItem } from "@hooks/api/inventory";
 
 import { InventoryItemAttributeSection } from "./_components/inventory-item-attributes/attributes-section";
@@ -19,7 +19,7 @@ const Root = ({ children }: { children?: ReactNode }) => {
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>;
   const { inventory_item, isPending: isLoading } = useInventoryItem(
     id!,
-    { fields: INVENTORY_DETAIL_FIELDS },
+    useLinkQuery("inventory_item", INVENTORY_DETAIL_FIELDS),
     { initialData },
   );
 

--- a/packages/vendor/src/pages/inventory/[id]/loader.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/loader.tsx
@@ -1,19 +1,24 @@
 import { LoaderFunctionArgs } from "react-router-dom";
 
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
+
 import { inventoryItemsQueryKeys } from "@hooks/api/inventory";
 import { fetchQuery } from "@lib/client";
 import { queryClient } from "@lib/query-client";
 
 import { INVENTORY_DETAIL_FIELDS } from "./constants";
 
-const inventoryDetailQuery = (id: string) => ({
-  queryKey: inventoryItemsQueryKeys.detail(id),
-  queryFn: async () =>
-    fetchQuery(
-      `/vendor/inventory-items/${id}?fields=${INVENTORY_DETAIL_FIELDS}`,
-      { method: "GET" },
-    ),
-});
+const inventoryDetailQuery = (id: string) => {
+  const query = getLinkQuery("inventory_item", INVENTORY_DETAIL_FIELDS);
+  return {
+    queryKey: inventoryItemsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      fetchQuery(
+        `/vendor/inventory-items/${id}?fields=${query.fields}`,
+        { method: "GET" },
+      ),
+  };
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/inventory/_components/inventory-list-data-table.tsx
+++ b/packages/vendor/src/pages/inventory/_components/inventory-list-data-table.tsx
@@ -1,6 +1,6 @@
 import { InventoryTypes } from "@medusajs/types";
 
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { ColumnDef, RowSelectionState } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -35,6 +35,7 @@ export const InventoryListDataTable = () => {
   } = useInventoryItems(
     {
       ...searchParams,
+      ...useLinkQuery("inventory_item"),
     },
     {
       placeholderData: keepPreviousData,

--- a/packages/vendor/src/pages/offers/[id]/edit/offer-edit-page.tsx
+++ b/packages/vendor/src/pages/offers/[id]/edit/offer-edit-page.tsx
@@ -2,6 +2,8 @@ import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
+
 import { RouteDrawer } from "../../../../components/modals"
 import { useOffer } from "../../../../hooks/api/offers"
 import { OFFER_DETAIL_FIELDS } from "../../common/constants"
@@ -16,7 +18,7 @@ export const OfferEditPage = () => {
     isPending,
     isError,
     error,
-  } = useOffer(id!, { fields: OFFER_DETAIL_FIELDS })
+  } = useOffer(id!, useLinkQuery("offer", OFFER_DETAIL_FIELDS))
 
   if (isError) throw error
 

--- a/packages/vendor/src/pages/offers/[id]/loader.ts
+++ b/packages/vendor/src/pages/offers/[id]/loader.ts
@@ -1,4 +1,5 @@
 import { LoaderFunctionArgs } from "react-router-dom"
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 
 import { productsQueryKeys } from "../../../hooks/api/products"
 import { sdk } from "../../../lib/client"
@@ -10,16 +11,17 @@ import { OFFER_PRODUCT_DETAIL_FIELDS } from "../common/constants"
  * and the page reads `/vendor/products/:id` with the seller's offers
  * wrapped under each variant (`variants.offers.*` triggers the wrap).
  */
-const offerProductDetailQuery = (id: string) => ({
-  queryKey: productsQueryKeys.detail(id, {
-    fields: OFFER_PRODUCT_DETAIL_FIELDS,
-  }),
-  queryFn: async () =>
-    sdk.vendor.products.$id.query({
-      $id: id,
-      fields: OFFER_PRODUCT_DETAIL_FIELDS,
-    }),
-})
+const offerProductDetailQuery = (id: string) => {
+  const query = getLinkQuery("offer", OFFER_PRODUCT_DETAIL_FIELDS)
+  return {
+    queryKey: productsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      sdk.vendor.products.$id.query({
+        $id: id,
+        ...query,
+      }),
+  }
+}
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/vendor/src/pages/offers/[id]/offer-detail-page.tsx
+++ b/packages/vendor/src/pages/offers/[id]/offer-detail-page.tsx
@@ -1,7 +1,7 @@
 import { Children, ReactNode } from "react"
 import { useLoaderData, useParams } from "react-router-dom"
 
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared"
 
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../components/layout/pages"
@@ -17,12 +17,11 @@ import { loader } from "./loader"
 const Root = ({ children }: { children?: ReactNode }) => {
   const { id } = useParams()
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>
+  const query = useLinkQuery("offer", OFFER_PRODUCT_DETAIL_FIELDS)
 
-  const { product, isLoading, isError, error } = useProduct(
-    id!,
-    { fields: OFFER_PRODUCT_DETAIL_FIELDS },
-    { initialData },
-  )
+  const { product, isLoading, isError, error } = useProduct(id!, query, {
+    initialData,
+  })
 
   if (isError) {
     throw error

--- a/packages/vendor/src/pages/offers/_components/use-offer-table-query.tsx
+++ b/packages/vendor/src/pages/offers/_components/use-offer-table-query.tsx
@@ -1,4 +1,5 @@
 import { InferClientInput } from "@mercurjs/client"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 
 import { sdk } from "../../../lib/client"
 import { useQueryParams } from "../../../hooks/use-query-params"
@@ -49,6 +50,8 @@ export const useOfferTableQuery = ({
     q,
   } = raw
 
+  const { fields } = useLinkQuery("offer", OFFER_PRODUCT_LIST_FIELDS)
+
   const searchParams = {
     limit: pageSize,
     offset: offset ? Number(offset) : 0,
@@ -62,7 +65,7 @@ export const useOfferTableQuery = ({
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,
     has_offer: "true",
-    fields: OFFER_PRODUCT_LIST_FIELDS,
+    fields,
   } as ProductQuery
 
   return {

--- a/packages/vendor/src/pages/orders/[id]/loader.tsx
+++ b/packages/vendor/src/pages/orders/[id]/loader.tsx
@@ -1,3 +1,4 @@
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
 import { LoaderFunctionArgs } from "react-router-dom";
 
 import { ordersQueryKeys } from "@hooks/api/orders";
@@ -6,14 +7,17 @@ import { queryClient } from "@lib/query-client";
 
 import { DEFAULT_FIELDS } from "./constants";
 
-const orderDetailQuery = (id: string) => ({
-  queryKey: ordersQueryKeys.detail(id),
-  queryFn: async () =>
-    fetchQuery(`/vendor/orders/${id}`, {
-      method: "GET",
-      query: { fields: DEFAULT_FIELDS },
-    }),
-});
+const orderDetailQuery = (id: string) => {
+  const { fields } = getLinkQuery("order", DEFAULT_FIELDS);
+  return {
+    queryKey: ordersQueryKeys.detail(id, { fields }),
+    queryFn: async () =>
+      fetchQuery(`/vendor/orders/${id}`, {
+        method: "GET",
+        query: { fields },
+      }),
+  };
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/orders/[id]/order-detail-page.tsx
+++ b/packages/vendor/src/pages/orders/[id]/order-detail-page.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 import { useOrder, useOrderPreview } from "@hooks/api/orders";
 
 import { ActiveOrderClaimSection } from "./_components/active-order-claim-section";
@@ -25,11 +25,11 @@ const Root = ({ children }: { children?: ReactNode }) => {
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>;
   const { id } = useParams();
 
+  const query = useLinkQuery("order", DEFAULT_FIELDS);
+
   const { order, isLoading, isError, error } = useOrder(
     id!,
-    {
-      fields: DEFAULT_FIELDS,
-    },
+    query,
     {
       initialData,
     },

--- a/packages/vendor/src/pages/orders/_components/order-list-table/order-list-data-table.tsx
+++ b/packages/vendor/src/pages/orders/_components/order-list-table/order-list-data-table.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { type ColumnDef } from "@tanstack/react-table";
 import { HttpTypes } from "@medusajs/types";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 
 import { _DataTable } from "@components/table/data-table/data-table";
 import { useOrders } from "@hooks/api/orders";
@@ -19,8 +19,9 @@ export const OrderListDataTable = () => {
     pageSize: PAGE_SIZE,
   });
 
-  const { orders, count, isError, error, isLoading } = useOrders({
-    fields: [
+  const linkQuery = useLinkQuery(
+    "order",
+    [
       "id",
       "status",
       "created_at",
@@ -34,6 +35,10 @@ export const OrderListDataTable = () => {
       "*customer",
       "*payment_collections",
     ].join(","),
+  );
+
+  const { orders, count, isError, error, isLoading } = useOrders({
+    ...linkQuery,
     ...searchParams,
   });
 

--- a/packages/vendor/src/pages/price-lists/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/edit/index.tsx
@@ -2,6 +2,7 @@
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "@components/modals"
 import { usePriceList } from "@hooks/api/price-lists"
 import { PriceListEditForm } from "./price-list-edit-form"
@@ -10,7 +11,8 @@ export const Component = () => {
   const { t } = useTranslation()
   const { id } = useParams()
 
-  const { price_list, isLoading, isError, error } = usePriceList(id!)
+  const linkQuery = useLinkQuery("price_list")
+  const { price_list, isLoading, isError, error } = usePriceList(id!, linkQuery)
 
   const ready = !isLoading && price_list
 

--- a/packages/vendor/src/pages/price-lists/[id]/loader.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/loader.tsx
@@ -1,16 +1,22 @@
 import { LoaderFunctionArgs } from "react-router-dom";
 
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
+
 import { priceListsQueryKeys } from "@hooks/api/price-lists";
 import { fetchQuery } from "@lib/client";
 import { queryClient } from "@lib/query-client";
 
-const pricingDetailQuery = (id: string) => ({
-  queryKey: priceListsQueryKeys.detail(id),
-  queryFn: async () =>
-    await fetchQuery(`/vendor/price-lists/${id}`, {
-      method: "GET",
-    }),
-});
+const pricingDetailQuery = (id: string) => {
+  const query = getLinkQuery("price_list");
+  return {
+    queryKey: priceListsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      await fetchQuery(`/vendor/price-lists/${id}`, {
+        method: "GET",
+        query,
+      }),
+  };
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/price-lists/[id]/price-list-detail-page.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/price-list-detail-page.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 import { usePriceList } from "@hooks/api/price-lists";
 
 import { PriceListConfigurationSection } from "./_components/price-list-configuration-section";
@@ -16,7 +16,8 @@ const Root = ({ children }: { children?: ReactNode }) => {
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>;
   const { id } = useParams();
 
-  const { price_list, isLoading, isError, error } = usePriceList(id!, undefined, {
+  const linkQuery = useLinkQuery("price_list");
+  const { price_list, isLoading, isError, error } = usePriceList(id!, linkQuery, {
     placeholderData: initialData,
   });
 

--- a/packages/vendor/src/pages/price-lists/_components/price-list-list-table/price-list-list-data-table.tsx
+++ b/packages/vendor/src/pages/price-lists/_components/price-list-list-table/price-list-list-data-table.tsx
@@ -2,7 +2,7 @@ import { keepPreviousData } from "@tanstack/react-query";
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { ExtendedPriceList } from "@custom-types/price-list";
 import { _DataTable } from "@components/table/data-table";
 import { usePriceLists } from "@hooks/api/price-lists";
@@ -20,8 +20,9 @@ export const PriceListListDataTable = () => {
   const { searchParams, raw } = usePricingTableQuery({
     pageSize: PAGE_SIZE,
   });
+  const linkQuery = useLinkQuery("price_list");
   const { price_lists, count, isLoading, isError, error } = usePriceLists(
-    searchParams,
+    { ...searchParams, ...linkQuery },
     {
       placeholderData: keepPreviousData,
     },

--- a/packages/vendor/src/pages/promotions/[id]/breadcrumb.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/breadcrumb.tsx
@@ -1,4 +1,5 @@
 import { HttpTypes } from "@medusajs/types";
+import { useLinkQuery } from "@mercurjs/dashboard-shared";
 import { UIMatch } from "react-router-dom";
 
 import { usePromotion } from "@hooks/api/promotions";
@@ -7,7 +8,8 @@ type PromotionDetailBreadcrumbProps = UIMatch<HttpTypes.AdminPromotionResponse>;
 
 export const Breadcrumb = (props: PromotionDetailBreadcrumbProps) => {
   const { id } = props.params || {};
-  const { promotion } = usePromotion(id!, {
+  const linkQuery = useLinkQuery("promotion", "+status");
+  const { promotion } = usePromotion(id!, linkQuery, {
     initialData: props.data,
     enabled: Boolean(id),
   });

--- a/packages/vendor/src/pages/promotions/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/edit/index.tsx
@@ -1,5 +1,6 @@
 // Route: /promotions/:id/edit
 import { Heading } from "@medusajs/ui"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
 import { RouteDrawer } from "@components/modals"
@@ -9,7 +10,8 @@ import { EditPromotionDetailsForm } from "./edit-promotion-form"
 export const Component = () => {
   const { id } = useParams()
   const { t } = useTranslation()
-  const { promotion, isLoading, isError, error } = usePromotion(id!)
+  const linkQuery = useLinkQuery("promotion")
+  const { promotion, isLoading, isError, error } = usePromotion(id!, linkQuery)
 
   if (isError) throw error
 

--- a/packages/vendor/src/pages/promotions/[id]/loader.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/loader.tsx
@@ -1,17 +1,21 @@
+import { getLinkQuery } from "@mercurjs/dashboard-shared";
 import { LoaderFunctionArgs } from "react-router-dom";
 
 import { promotionsQueryKeys } from "@hooks/api/promotions";
 import { fetchQuery } from "@lib/client";
 import { queryClient } from "@lib/query-client";
 
-const promotionDetailQuery = (id: string) => ({
-  queryKey: promotionsQueryKeys.detail(id),
-  queryFn: async () =>
-    fetchQuery(`/vendor/promotions/${id}`, {
-      method: "GET",
-      query: { fields: "+status" },
-    }),
-});
+const promotionDetailQuery = (id: string) => {
+  const query = getLinkQuery("promotion", "+status");
+  return {
+    queryKey: promotionsQueryKeys.detail(id, query),
+    queryFn: async () =>
+      fetchQuery(`/vendor/promotions/${id}`, {
+        method: "GET",
+        query,
+      }),
+  };
+};
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id;

--- a/packages/vendor/src/pages/promotions/[id]/promotion-detail-page.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/promotion-detail-page.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared";
 import { usePromotion, usePromotionRules } from "@hooks/api/promotions";
 
 import { CampaignSection } from "./_components/campaign-section";
@@ -15,7 +15,10 @@ import type { loader } from "./loader";
 const Root = ({ children }: { children?: ReactNode }) => {
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>;
   const { id } = useParams();
-  const { promotion, isLoading } = usePromotion(id!, { initialData });
+  const linkQuery = useLinkQuery("promotion", "+status");
+  const { promotion, isLoading } = usePromotion(id!, linkQuery, {
+    initialData,
+  });
   const query: Record<string, string> = {};
   if (promotion?.type === "buyget") query.promotion_type = promotion.type;
 

--- a/packages/vendor/src/pages/promotions/_components/promotion-list-table/promotion-list-data-table.tsx
+++ b/packages/vendor/src/pages/promotions/_components/promotion-list-table/promotion-list-data-table.tsx
@@ -2,7 +2,7 @@ import { PencilSquare, Trash } from "@medusajs/icons";
 import { HttpTypes } from "@medusajs/types";
 import { usePrompt } from "@medusajs/ui";
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Outlet, useNavigate } from "react-router-dom";
@@ -26,6 +26,7 @@ export const PromotionListDataTable = () => {
   const { searchParams, raw } = usePromotionTableQuery({
     pageSize: PAGE_SIZE,
   });
+  const linkQuery = useLinkQuery("promotion", "+status");
   const {
     promotions: data,
     count,
@@ -33,7 +34,7 @@ export const PromotionListDataTable = () => {
     isError,
     error,
   } = usePromotions({
-    fields: "+status",
+    ...linkQuery,
     ...searchParams,
   });
 

--- a/packages/vendor/src/pages/reservations/[id]/_components/edit-reservation/edit-reservation-modal.tsx
+++ b/packages/vendor/src/pages/reservations/[id]/_components/edit-reservation/edit-reservation-modal.tsx
@@ -2,6 +2,7 @@ import { InventoryTypes } from "@medusajs/types"
 import { Heading } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { useParams } from "react-router-dom"
+import { useLinkQuery } from "@mercurjs/dashboard-shared"
 import { RouteDrawer } from "@components/modals"
 import {
   useInventoryItem,
@@ -15,7 +16,10 @@ export const ReservationEdit = () => {
   const { id } = useParams()
   const { t } = useTranslation()
 
-  const { reservation, isPending, isError, error } = useReservationItem(id!)
+  const { reservation, isPending, isError, error } = useReservationItem(
+    id!,
+    useLinkQuery("reservation")
+  )
   const { inventory_item: inventoryItem } = useInventoryItem(
     reservation?.inventory_item_id,
     undefined,

--- a/packages/vendor/src/pages/reservations/[id]/index.tsx
+++ b/packages/vendor/src/pages/reservations/[id]/index.tsx
@@ -4,7 +4,7 @@ import { HttpTypes } from "@medusajs/types"
 import { UIMatch } from "react-router-dom"
 import { TwoColumnPageSkeleton } from "@components/common/skeleton"
 import { TwoColumnPage } from "@components/layout/pages"
-import { WidgetZone } from "@mercurjs/dashboard-shared"
+import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared"
 import { useDashboardExtension } from "@/extensions"
 import { useReservationItem } from "@hooks/api/reservations"
 import { useInventoryItem } from "@hooks/api"
@@ -36,12 +36,15 @@ export const Breadcrumb = (props: ReservationDetailBreadcrumbProps) => {
 export const Component = () => {
   const { id } = useParams()
 
-  const { reservation, isLoading } = useReservationItem(id!)
+  const { reservation, isLoading } = useReservationItem(
+    id!,
+    useLinkQuery("reservation")
+  )
 
   // TEMP: fetch directly since the fields are not populated with reservation call
   const { inventory_item } = useInventoryItem(
     reservation?.inventory_item?.id,
-    { fields: "*location_levels" }
+    useLinkQuery("inventory_item", "*location_levels")
   )
 
   const { getWidgets } = useDashboardExtension()

--- a/packages/vendor/src/pages/reservations/_components/reservation-list-table/reservation-list-table.tsx
+++ b/packages/vendor/src/pages/reservations/_components/reservation-list-table/reservation-list-table.tsx
@@ -3,7 +3,7 @@ import { Button, Container, Heading, Text } from "@medusajs/ui"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
-import { useExtendableTable } from "@mercurjs/dashboard-shared"
+import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared"
 import { _DataTable } from "@components/table/data-table"
 import { useReservationItems } from "@hooks/api/reservations"
 import { useDataTable } from "@hooks/use-data-table"
@@ -52,6 +52,7 @@ export const ReservationListTable = () => {
   const { reservations, count, isPending } =
     useReservationItems({
       ...searchParams,
+      ...useLinkQuery("reservation"),
     })
 
   const baseFilters = useReservationTableFilters()

--- a/packages/vendor/src/pages/settings/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
+++ b/packages/vendor/src/pages/settings/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
@@ -2,7 +2,11 @@ import { Button, Input, Select, toast } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import * as zod from "zod"
 
-import { FormExtensionZone, useExtendableForm } from "@mercurjs/dashboard-shared"
+import {
+  FormExtensionZone,
+  useExtendableForm,
+  useExtension,
+} from "@mercurjs/dashboard-shared"
 
 import { Form } from "../../../../../../components/common/form"
 import { RouteDrawer, useRouteModal } from "../../../../../../components/modals"
@@ -22,7 +26,12 @@ export const EditProfileForm = () => {
   const { handleSuccess } = useRouteModal()
   const direction = useDocumentDirection()
 
-  const { seller_member } = useMe()
+  const memberLinks = useExtension().getLinks("member")
+  const meQuery = memberLinks.length
+    ? { fields: memberLinks.map((link) => `+member.${link}.*`).join(",") }
+    : undefined
+
+  const { seller_member } = useMe(meQuery)
   const member = seller_member?.member
 
   const form = useExtendableForm({

--- a/packages/vendor/src/pages/settings/store/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/store/edit/index.tsx
@@ -1,15 +1,27 @@
 import { Heading } from "@medusajs/ui";
+import { useExtension, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { useTranslation } from "react-i18next";
 import { RouteDrawer } from "@components/modals";
-import { useMe } from "@hooks/api";
+import { useMe, useSeller } from "@hooks/api";
 import { EditStoreForm } from "./_components/edit-store-form";
 
 const StoreEdit = () => {
   const { t } = useTranslation();
   const { seller_member, isPending, isError, error } = useMe();
 
-  const seller = seller_member?.seller;
-  const ready = !isPending && !!seller;
+  const meSeller = seller_member?.seller;
+
+  const needsLinks = useExtension().getLinks("seller").length > 0;
+  const query = useLinkQuery("seller");
+
+  const { seller: linkedSeller, isPending: linkedPending } = useSeller(
+    meSeller?.id ?? "",
+    query,
+    { enabled: needsLinks && !!meSeller?.id },
+  );
+
+  const seller = needsLinks ? linkedSeller : meSeller;
+  const ready = !isPending && !!seller && (!needsLinks || !linkedPending);
 
   if (isError) {
     throw error;


### PR DESCRIPTION
## Problem

Custom-fields extension zones (`FormExtensionZone`, `DisplayExtensionZone`, `useExtendableForm`, `useExtendableTable`) render fields whose components read from the host page's fetched `data`. A custom-fields config `link` (linked-module data) only reaches `data` if the page's fetch merges it with the `+link.*` convention — this is per-fetch, with no central choke point.

Only the `product` model wired this. Every other model mounted zones but never merged links, so any custom field reading linked-module data rendered empty. Surfaced on the seller/store-edit pages, then found to be systemic across both panels.

## Fix

Add two standardized helpers to `@mercurjs/dashboard-shared` (`extensions/links.ts`):

- `useLinkQuery(model, base?)` — hook, for components/hooks
- `getLinkQuery(model, base?)` — non-hook, for react-router loaders

Both merge a model's declared `link` relations using the `+link.*` convention (onto route defaults, or onto a curated `base` field set) and are a **no-op until a developer actually declares a link**, so every call site is safe by default.

These are wired into the three fetch tiers for every model in **both** panels:
- **Detail** fetch (one fetch feeds all `DisplayExtensionZone` sections)
- **Edit-form** host fetch (feeds `useExtendableForm`)
- **List** query (feeds `useExtendableTable`)

Where a `useX(id, query)` hook gained a query param, its query key now includes the query (`detail(id, query)`) so caches don't collide, and loader + detail component pass the same merged query so their keys align.

Models covered: `seller`, `customer`, `customer_group`, `collection`, `category`, `campaign`, `promotion`, `price_list`, `order`, `offer`, `inventory_item`, `reservation`, `member`, plus closing the one remaining `product` gap (admin detail loader).

## Deliberate skips

- **Admin order list** — uses `useOrderGroups` with orders nested then flattened; top-level `link.*` doesn't map to that shape, so left unwired rather than reshaping the group transform.
- **Vendor member** — comes from `useMe()`, so links are merged with the `member.*` prefix (`+member.<link>.*`).

## Verification

`bun run build` green for both panels — ESM + full DTS (tsc) type-check + extension-target generation all exit 0. The passing DTS builds confirm the hook-signature changes (`usePromotion` / `useCollection` / `useSeller` / `useMe` gained query params) type-check across all downstream callers.