### PR TITLE
feat(dashboard): wire custom-field links and explicit fields on store/product/order pages

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -77,6 +77,7 @@
                       "rc/resources/tutorials/add-a-widget",
                       "rc/resources/tutorials/extend-forms-and-tables",
                       "rc/resources/tutorials/extend-onboarding",
+                      "rc/resources/tutorials/store-setup-checklist",
                       "rc/resources/tutorials/customize-navigation",
                       "rc/resources/tutorials/custom-api-route"
                     ]
@@ -158,6 +159,12 @@
                 "group": "Overview",
                 "pages": [
                   "rc/references/overview"
+                ]
+              },
+              {
+                "group": "Panel Extension API",
+                "pages": [
+                  "rc/references/panel-extension-api"
                 ]
               },
               {

--- a/apps/docs/rc/references/overview.mdx
+++ b/apps/docs/rc/references/overview.mdx
@@ -58,6 +58,16 @@ Mercur extends the Medusa server with three route surfaces. Start with the conve
   </Card>
 </CardGroup>
 
+## Panel extension API
+
+The file-based helpers for extending the admin and vendor panels without forking.
+
+<CardGroup cols={1}>
+  <Card title="Panel Extension API" href="/rc/references/panel-extension-api">
+    <code>defineWidgetConfig</code>, <code>defineNavigationConfig</code>, <code>defineCustomFieldsConfig</code>, and <code>createFormHelper</code> — config shapes and the exact props passed to every component you supply.
+  </Card>
+</CardGroup>
+
 ## Workflows and configuration
 
 <CardGroup cols={2}>

--- a/apps/docs/rc/references/panel-extension-api.mdx
+++ b/apps/docs/rc/references/panel-extension-api.mdx
@@ -1,0 +1,337 @@
+---
+title: "Panel Extension API"
+description: "The file-based helpers for extending the admin and vendor panels — defineWidgetConfig, defineNavigationConfig, defineCustomFieldsConfig, createFormHelper — and the exact props passed to every component you supply."
+---
+
+This is the technical contract for the panel extension API.
+Where the [Extend forms and tables](/rc/resources/tutorials/extend-forms-and-tables),
+[Add a widget](/rc/resources/tutorials/add-a-widget), and
+[Customize navigation](/rc/resources/tutorials/customize-navigation) tutorials
+walk through *building* an extension, this page documents the exact config shape
+of each helper and — most importantly — **the props each `component` you pass in
+receives at render time**.
+
+<Info>
+  **Separate apps, no `surface` field.** Admin (`@mercurjs/admin`, port 7000) and
+  vendor (`@mercurjs/vendor`, port 7001) are separate Vite apps. A file dropped
+  under a panel's `src/` targets *that* panel — the folder you author in *is* the
+  surface. The helpers are the same in both; import them from
+  `@mercurjs/dashboard-sdk` (config helpers) and `@mercurjs/dashboard-shared`
+  (`createFormHelper`).
+</Info>
+
+## Typed targets (register once)
+
+Zone ids, nav item ids, models, and built-in field ids are typed per panel from a
+generated `extension-targets.d.ts`. Reference it once per host app so every
+extension file type-checks with no per-file import:
+
+```typescript apps/vendor/src/extension-targets.d.ts
+/// <reference types="@mercurjs/vendor/extension-targets" />
+```
+
+```typescript apps/admin-test/src/extension-targets.d.ts
+/// <reference types="@mercurjs/admin/extension-targets" />
+```
+
+A wrong `zone`, `model`, or nav `id` fails `tsc` (`bun run lint`) rather than
+silently no-op'ing at runtime.
+
+---
+
+## `defineWidgetConfig`
+
+A widget is a React component attached to a named zone on a built-in page. The
+placement (`before | after | replace`) is the last segment of the zone id.
+
+```tsx apps/vendor/src/widgets/product-list-banner.tsx
+import { defineWidgetConfig } from "@mercurjs/dashboard-sdk"
+
+export const config = defineWidgetConfig({
+  zone: "product.list.before", // WidgetZoneId — <domain>.<view>[.<slot>].<before|after|replace>
+})
+
+export default ProductListBanner
+```
+
+### Config
+
+| Field  | Type                            | Description                                                                 |
+| ------ | ------------------------------- | --------------------------------------------------------------------------- |
+| `zone` | `WidgetZoneId \| WidgetZoneId[]` | Target zone(s). Placement is the suffix. Multiple widgets stack in order.    |
+| `id`   | `string` (optional)             | Stable id; derived from the file path at build time when omitted.           |
+
+### Component props
+
+The widget component receives a single prop:
+
+| Prop   | Type      | Description                                                                                |
+| ------ | --------- | ----------------------------------------------------------------------------------------- |
+| `data` | `unknown` | The zone's contextual entity — e.g. the loaded product on a `product.detail.*` zone. Undefined on list/public zones that have no single entity. |
+
+```tsx
+const ProductDetailNote = ({ data }: { data?: HttpTypes.AdminProduct }) => (
+  <Container>{data?.title}</Container>
+)
+```
+
+<Note>
+  The public `login.logo` / `login.before` / `login.after` zones render before
+  authentication and receive no `data`.
+</Note>
+
+---
+
+## `defineNavigationConfig`
+
+Reorder, hide, relabel, or re-parent **built-in** sidebar items. Single
+host-owned file — blocks cannot contribute nav overrides.
+
+```ts apps/vendor/src/_navigation.ts
+import { defineNavigationConfig } from "@mercurjs/dashboard-sdk"
+
+export default defineNavigationConfig({
+  items: [
+    { id: "orders", rank: 0 },
+    { id: "price-lists", hidden: true },
+    { id: "payouts", label: "settlements" },
+    { id: "categories", nested: null, rank: 1 },
+    { id: "campaigns", nested: "orders" },
+  ],
+})
+```
+
+### `NavItemOverride`
+
+| Field    | Type                       | Description                                                                    |
+| -------- | -------------------------- | ------------------------------------------------------------------------------ |
+| `id`     | `NavItemId`                | Built-in item to override (top-level or nested). Typed against the panel registry. |
+| `rank`   | `number` (optional)        | Order within the item's parent (or among top-level items).                     |
+| `hidden` | `boolean` (optional)       | Remove from the sidebar (route may still be directly reachable).               |
+| `label`  | `string` (optional)        | i18n key or literal replacing the item's label.                                |
+| `icon`   | `ComponentType` (optional) | Icon component replacing the item's icon (from `@medusajs/icons`).             |
+| `nested` | `NavParentId \| null` (optional) | Re-parent under a built-in parent id; `null` promotes a nested item to top level. |
+
+There is no `component` prop here — navigation overrides reshape existing items
+only.
+
+---
+
+## `defineCustomFieldsConfig`
+
+The model-scoped surface. One file per model adds form fields, section displays,
+section actions, and list-table columns. Import
+`createFormHelper` from `@mercurjs/dashboard-shared` to turn a Zod schema into an
+input type + validation.
+
+```tsx apps/vendor/src/custom-fields/product.tsx
+import { defineCustomFieldsConfig } from "@mercurjs/dashboard-sdk"
+import { createFormHelper } from "@mercurjs/dashboard-shared"
+
+type ProductWithMeta = { metadata?: Record<string, unknown> }
+const form = createFormHelper<ProductWithMeta>()
+
+export default defineCustomFieldsConfig({
+  model: "product",
+  link: "brand", // string | string[] — module link(s) fetched alongside the entity
+  forms: [/* ... */],
+  displays: [/* ... */],
+  list: {/* ... */},
+})
+```
+
+### Top-level config
+
+| Field      | Type                     | Description                                                              |
+| ---------- | ------------------------ | ------------------------------------------------------------------------ |
+| `model`    | `CustomFieldModel`       | Target model (start with `"product"`). Typed against `CustomFieldsRegistry`. |
+| `link`     | `string \| string[]`     | Module link(s) fetched alongside the entity; their data is available to columns and displays via the `+link.*` fetch. |
+| `forms`    | `CustomFormEntry[]`      | Fields injected into built-in create/edit/onboarding forms.              |
+| `displays` | `CustomDisplayEntry[]`   | Field replace/remove/add + `ActionMenu` actions on detail sections.      |
+| `list`     | `CustomListExtension`    | Columns, bulk actions, filters, view defaults on the model's list table. |
+
+### `forms[]` — form fields
+
+```tsx
+forms: [
+  {
+    zone: "edit",         // CustomFormZone — "create" | "edit" | "organize" | "attributes" | "onboarding"
+    tab: "general",       // TabbedForm tab id, or wizard step id for zone: "onboarding"
+    fields: {
+      erp_id: form.define({
+        validation: form.string().nullish(), // Zod → input type + validation
+        defaultValue: (data) => (data?.metadata?.erp_id as string) ?? "",
+        label: "ERP ID",
+        description: "External system identifier",
+        placeholder: "ERP-000",
+        component: MyErpInput, // optional custom render
+      }),
+    },
+  },
+]
+```
+
+Each field is a `CustomFormField`:
+
+| Field          | Type                                     | Description                                                       |
+| -------------- | ---------------------------------------- | ----------------------------------------------------------------- |
+| `validation`   | Zod schema                               | Drives both the default input type and validation.                |
+| `defaultValue` | `unknown \| ((data) => unknown)`         | Static value or a resolver from the loaded entity.                |
+| `label`        | `string` (optional)                      | Field label.                                                      |
+| `description`  | `string` (optional)                      | Help text below the input.                                        |
+| `placeholder`  | `string` (optional)                      | Input placeholder.                                                |
+| `component`    | `ComponentType` (optional)               | Custom render; falls back to a default input for the Zod type.    |
+
+<Warning>
+  **Form-field `component` receives no props.** It is rendered as `<Component />`
+  inside the field's `additional_data.<field>` React Hook Form context. Read and
+  write the value with RHF's `useFormContext()` / `useController()`, and render
+  through the mandated `Form.Field → Form.Item` chain — do not use a raw
+  `Controller`. Values live in form state under `additional_data`; in the MVP,
+  `product` custom fields persist onto the product's `metadata`.
+</Warning>
+
+### `displays[]` — detail sections
+
+```tsx
+displays: [
+  {
+    zone: "general", // CustomFieldsRegistry displayZones — an existing detail section id
+    fields: [
+      { id: "erp_id", component: ErpRow },           // ADD (unknown id → new read-only row)
+      { id: "status", component: BrandedStatusBadge }, // REPLACE a built-in field's render
+      { id: "created_by", component: null },           // REMOVE a built-in field
+    ],
+    actions: [
+      { rank: 0, component: SyncErpAction },            // add to the section's ActionMenu
+    ],
+  },
+]
+```
+
+`fields[]` is `CustomDisplayField`:
+
+| Field       | Type                                    | Description                                                                            |
+| ----------- | --------------------------------------- | -------------------------------------------------------------------------------------- |
+| `id`        | `displayFieldIds \| (string & {})`      | Built-in field id (autocompletes) → replace/remove; any other string → add a new row.  |
+| `component` | `ComponentType<{ data? }> \| null`      | Render component, or `null` to remove a built-in field.                                |
+
+**Display field `component` props:**
+
+| Prop   | Type      | Description                        |
+| ------ | --------- | ---------------------------------- |
+| `data` | `unknown` | The loaded detail entity, **including any `link`ed module data**. If the config declares `link: "brand"`, read it off `data.brand` here. |
+
+```tsx
+// with `link: "brand"` on the config, the linked module data rides on `data`
+const BrandRow = ({ data }: { data?: { brand?: { name: string } } }) => (
+  <Text>{data?.brand?.name}</Text>
+)
+```
+
+`actions[]` is `SectionAction` (the same shape as list `bulkActions`):
+
+| Field       | Type                            | Description                                                       |
+| ----------- | ------------------------------- | ----------------------------------------------------------------- |
+| `rank`      | `number` (optional)             | Position within the section's `ActionMenu`.                       |
+| `component` | `ComponentType<{ data? }>`      | Owns its own label, icon, group placement, and `onClick`.         |
+
+**Section-action `component` props:**
+
+| Prop   | Type      | Description                                                              |
+| ------ | --------- | ----------------------------------------------------------------------- |
+| `data` | `unknown` | The loaded detail entity, **including any `link`ed module data** (e.g. `data.brand`). |
+
+### `list` — list table
+
+```tsx
+list: {
+  columns: [
+    { id: "title", component: ({ value }) => <strong>{value}</strong> }, // override a cell
+    { id: "brand_name", header: "Brand", component: ({ row }) => row.brand?.name }, // add (from link)
+  ],
+  bulkActions: [{ rank: 0, component: ArchiveBulkAction }],
+  filters: [/* add / remove list filters */],
+  viewDefaults: {
+    columnVisibility: { created_at: false }, // hide a column
+    columnOrder: ["title", "sku", "erp_id"],
+  },
+}
+```
+
+`columns[]` is `CustomColumn`:
+
+| Field       | Type                                       | Description                                              |
+| ----------- | ------------------------------------------ | -------------------------------------------------------- |
+| `id`        | `string`                                   | Column id — matches a built-in column to override, or adds a new one. |
+| `header`    | `string` (optional)                        | Column header text (for added columns).                 |
+| `component` | `ComponentType<{ row?, value? }>` (optional) | Cell renderer.                                          |
+
+**Column `component` props:**
+
+| Prop    | Type      | Description                                               |
+| ------- | --------- | -------------------------------------------------------- |
+| `row`   | `unknown` | The full row entity (including `link`ed module data).    |
+| `value` | `unknown` | The cell value for this column id, when derivable.       |
+
+`bulkActions[]` is `SectionAction` (`{ rank?, component }`, component props `{ data? }`).
+
+<Note>
+  **Bulk-action rendering is deferred in the MVP.** `bulkActions` are accepted and
+  surfaced by the config but not yet mounted into the list toolbar.
+</Note>
+
+<Warning>
+  **Vendor product list is field-constrained.** The vendor `product` list must use
+  the curated fields from `useProductTableQuery` — the SDK merges `link` fetches
+  with the `+`/`-` convention, never bare fields, or the list 500s. You never
+  hand-write the field list; the `link` declaration drives it.
+</Warning>
+
+---
+
+## `createFormHelper`
+
+`createFormHelper<T>()` returns Medusa's zod surface for describing field
+validation and value types:
+
+```ts
+const form = createFormHelper<ProductWithMeta>()
+
+form.define({ validation, defaultValue?, label?, description?, placeholder?, component? })
+form.string() / form.number() / form.boolean() / form.date()
+form.array() / form.object() / form.null() / form.nullable() / form.coerce
+```
+
+The generated registry types the **target** (which zone/tab/field ids exist); the
+Zod `validation` types the **value**. The two compose — codegen types the address,
+Zod types the payload.
+
+---
+
+## Persistence
+
+<Warning>
+  **The MVP is a UI surface only.** Custom fields render, validate, and display
+  through the built-in forms/sections/tables — there is no generic core-side write
+  path. For `product`, values are submitted under `additional_data` and persisted
+  onto `metadata`. To store data for other models, wire your own route/workflow or
+  use the backend [Custom Fields module](/rc/resources/customization/custom-fields).
+</Warning>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Extend forms and tables" href="/rc/resources/tutorials/extend-forms-and-tables">
+    Step-by-step build with `defineCustomFieldsConfig`.
+  </Card>
+  <Card title="Add a widget" href="/rc/resources/tutorials/add-a-widget">
+    Inject a component into a zone.
+  </Card>
+  <Card title="Customize navigation" href="/rc/resources/tutorials/customize-navigation">
+    Reorder and hide sidebar items.
+  </Card>
+  <Card title="Custom Fields module" href="/rc/references/modules/custom-fields">
+    The backend storage layer.
+  </Card>
+</CardGroup>

--- a/apps/docs/rc/resources/tutorials/add-a-widget.mdx
+++ b/apps/docs/rc/resources/tutorials/add-a-widget.mdx
@@ -70,7 +70,7 @@ Zones mounted today in the **vendor portal**:
 | Zone | Where it renders |
 |------|------------------|
 | `product.list.before` / `.after` | Vendor product list page |
-| `store.setup.before` / `.after` | The store-setup / onboarding surface (dashboard home + store settings), passed the `seller` as `data` |
+| `seller.setup.before` / `.after` | The store-setup / onboarding surface (dashboard home + store settings), passed the `seller` as `data` |
 | `login.logo.*` | The logo slot on the public login screen |
 | `login.before.*` / `login.after.*` | Around the login form (rendered before authentication) |
 

--- a/apps/docs/rc/resources/tutorials/extend-onboarding.mdx
+++ b/apps/docs/rc/resources/tutorials/extend-onboarding.mdx
@@ -3,10 +3,10 @@ title: "Extend the onboarding flow"
 description: "Add a field to the vendor store-setup surface, submit it through additional_data, and persist it durably from a workflow hook — end to end, without forking."
 ---
 
-The vendor **store-setup / onboarding** surface is a widget zone (`store.setup`) that renders the full `seller` object as its `data`. That makes onboarding a full extension seam: drop a widget to add UI, carry the new value to the API on the built-in seller routes through `additional_data`, and persist it from a workflow hook — the same three layers you'd wire in plain Medusa, kept intact by Mercur.
+The vendor **store-setup / onboarding** surface is a widget zone (`seller.setup`) that renders the full `seller` object as its `data`. That makes onboarding a full extension seam: drop a widget to add UI, carry the new value to the API on the built-in seller routes through `additional_data`, and persist it from a workflow hook — the same three layers you'd wire in plain Medusa, kept intact by Mercur.
 
 <Info>
-  **Three layers, one flow.** The panel (a `store.setup` widget) *renders and collects*. The vendor seller route *carries* the value through `additional_data` — no core schema change. A `sellersUpdated` workflow hook *persists* it. Each layer is additive: nothing built-in is replaced.
+  **Three layers, one flow.** The panel (a `seller.setup` widget) *renders and collects*. The vendor seller route *carries* the value through `additional_data` — no core schema change. A `sellersUpdated` workflow hook *persists* it. Each layer is additive: nothing built-in is replaced.
 </Info>
 
 ## What you'll build
@@ -21,13 +21,13 @@ Widget zones are typed ids the vendor panel generates from its own pages and shi
 /// <reference types="@mercurjs/vendor/extension-targets" />
 ```
 
-With it present, `store.setup` autocompletes and an invalid zone fails `tsc` instead of silently doing nothing.
+With it present, `seller.setup` autocompletes and an invalid zone fails `tsc` instead of silently doing nothing.
 
 ## 1 — Render on the onboarding surface
 
 <Steps>
   <Step title="Add the store-setup widget">
-    Drop a file under `src/widgets/`. Export the component as the **default** and a `config` with `zone: "store.setup.before"`. The zone hands your component the `seller` as `data`:
+    Drop a file under `src/widgets/`. Export the component as the **default** and a `config` with `zone: "seller.setup.before"`. The zone hands your component the `seller` as `data`:
 
     ```tsx apps/vendor/src/widgets/tax-id-setup.tsx
     import "@mercurjs/vendor/extension-targets"
@@ -40,7 +40,7 @@ With it present, `store.setup` autocompletes and an invalid zone fails `tsc` ins
     import { client } from "../lib/client"
 
     export const config = defineWidgetConfig({
-      zone: "store.setup.before",
+      zone: "seller.setup.before",
     })
 
     const TaxIdSetup = ({ data: seller }: { data?: SellerDTO }) => {
@@ -94,14 +94,14 @@ With it present, `store.setup` autocompletes and an invalid zone fails `tsc` ins
     ```
   </Step>
   <Step title="Understand where it renders">
-    `store.setup` is hosted in two places, both passing the same `seller` as `data`:
+    `seller.setup` is hosted in two places, both passing the same `seller` as `data`:
 
     | Host | When it shows |
     |------|---------------|
     | The vendor shell (above the page outlet) | On top-level routes — the dashboard "home" onboarding banner |
     | The store settings detail page | Always, above the store status banner |
 
-    A single widget file covers both. Multiple `store.setup.before` / `.after` widgets stack in registration order.
+    A single widget file covers both. Multiple `seller.setup.before` / `.after` widgets stack in registration order.
   </Step>
 </Steps>
 
@@ -203,7 +203,7 @@ That is the whole "wiring" step: your `{ tax_id }` payload arrives in the workfl
 ## How the layers connect
 
 ```
-store.setup widget  →  client.vendor.sellers.$id.mutate({ additional_data })
+seller.setup widget  →  client.vendor.sellers.$id.mutate({ additional_data })
         │
         ▼
 POST /vendor/sellers/:id  →  updateSellersWorkflow({ update, additional_data })

--- a/apps/docs/rc/resources/tutorials/store-setup-checklist.mdx
+++ b/apps/docs/rc/resources/tutorials/store-setup-checklist.mdx
@@ -1,0 +1,214 @@
+---
+title: "Build a store-setup checklist"
+description: "Render an onboarding progress checklist on the vendor store-setup surface with a seller.setup widget — the seller is handed to you as data, no fetching required."
+---
+
+The vendor **store-setup / onboarding** surface is a widget zone (`seller.setup`)
+that renders the full `seller` object as its `data`. That makes it the perfect
+seam for an onboarding **checklist**: derive completion from the seller you're
+handed, show what's left, and link each step to the page that completes it — all
+from a single widget file, with nothing fetched and nothing forked.
+
+<Info>
+  **This is the pattern the built-in store-setup card uses.** The shipped
+  "Complete store profile" card is itself a `seller.setup` widget that reads the
+  `seller` and renders a progress list. This tutorial rebuilds it so you can
+  shape your own onboarding steps.
+</Info>
+
+## What you'll build
+
+A collapsible progress card on the store-setup surface that checks four parts of
+the seller profile (details, address, company, payment), draws a progress bar,
+and routes the vendor to the settings page for each incomplete step. When every
+step is done, the card removes itself.
+
+## Register the typed targets (once)
+
+Widget zones are typed ids the vendor panel generates from its own pages and
+ships as `@mercurjs/vendor/extension-targets`. Reference them once so `seller.setup`
+autocompletes and a wrong zone fails `tsc`:
+
+```typescript apps/vendor/src/extension-targets.d.ts
+/// <reference types="@mercurjs/vendor/extension-targets" />
+```
+
+## Build the checklist widget
+
+<Steps>
+  <Step title="Derive the steps from the seller">
+    The `data` prop is the full `SellerDTO`. Compute each step's `completed` flag
+    from it — no request needed. Give every step a `path` to the settings page
+    that finishes it:
+
+    ```tsx apps/vendor/src/widgets/store-setup-checklist.tsx
+    import "@mercurjs/vendor/extension-targets"
+    import { SellerDTO } from "@mercurjs/types"
+
+    type ProfileStep = {
+      key: string
+      label: string
+      completed: boolean
+      path: string
+    }
+
+    function getProfileSteps(seller: SellerDTO): ProfileStep[] {
+      const hasStoreDetails = !!(seller.name && seller.email && seller.description)
+      const hasAddress = !!(
+        seller.address?.address_1 &&
+        seller.address?.city &&
+        seller.address?.country_code
+      )
+      const hasCompanyDetails = !!seller.professional_details?.corporate_name
+      const hasPaymentDetails = !!(
+        seller.payment_details?.holder_name &&
+        seller.payment_details?.country_code
+      )
+
+      return [
+        { key: "store_details", label: "Add store details", completed: hasStoreDetails, path: "/settings/store/edit" },
+        { key: "address", label: "Add address", completed: hasAddress, path: "/settings/store/address" },
+        { key: "company_details", label: "Add company details", completed: hasCompanyDetails, path: "/settings/store/professional-details" },
+        { key: "payment_details", label: "Add payment details", completed: hasPaymentDetails, path: "/settings/store/payment-details" },
+      ]
+    }
+    ```
+
+  </Step>
+  <Step title="Render the collapsible progress card">
+    Use `@medusajs/ui` primitives and `@medusajs/icons` only. Draw a progress bar
+    from the completed ratio, list each step with a status icon, and navigate on
+    click. Return `null` when everything is done so the card disappears:
+
+    ```tsx apps/vendor/src/widgets/store-setup-checklist.tsx
+    import { useMemo, useState } from "react"
+    import { useNavigate } from "react-router-dom"
+    import { Container, Text, clx } from "@medusajs/ui"
+    import { CheckCircleSolid, TriangleDownMini, CircleDottedLine } from "@medusajs/icons"
+    import { Collapsible as RadixCollapsible } from "radix-ui"
+
+    const StoreSetupChecklist = ({ data: seller }: { data?: SellerDTO }) => {
+      const navigate = useNavigate()
+      const [open, setOpen] = useState(true)
+
+      const steps = useMemo(
+        () => (seller ? getProfileSteps(seller) : []),
+        [seller]
+      )
+
+      if (!seller) {
+        return null
+      }
+
+      const completedCount = steps.filter((s) => s.completed).length
+      const totalCount = steps.length
+      const progressPercent = (completedCount / totalCount) * 100
+
+      if (completedCount === totalCount) {
+        return null
+      }
+
+      return (
+        <RadixCollapsible.Root open={open} onOpenChange={setOpen}>
+          <Container className="overflow-hidden p-0">
+            <div
+              className="h-1 bg-ui-tag-green-icon transition-all duration-500"
+              style={{ width: `${progressPercent}%` }}
+            />
+            <div className="p-6">
+              <RadixCollapsible.Trigger asChild>
+                <button className="flex w-full items-center justify-between">
+                  <Text size="large" weight="plus" leading="compact">
+                    Complete store profile
+                  </Text>
+                  <TriangleDownMini
+                    className={clx(
+                      "text-ui-fg-muted transition-transform duration-200",
+                      !open && "-rotate-90"
+                    )}
+                  />
+                </button>
+              </RadixCollapsible.Trigger>
+
+              <RadixCollapsible.Content>
+                <div className="mt-4 flex flex-col gap-y-3">
+                  {steps.map((step) => (
+                    <button
+                      key={step.key}
+                      className="flex items-center gap-x-3 text-left"
+                      onClick={() => !step.completed && navigate(step.path)}
+                      disabled={step.completed}
+                    >
+                      {step.completed ? (
+                        <CheckCircleSolid className="text-ui-tag-green-icon shrink-0" />
+                      ) : (
+                        <CircleDottedLine className="text-ui-fg-muted shrink-0" />
+                      )}
+                      <Text size="small" leading="compact" className="text-ui-fg-base">
+                        {step.label}
+                      </Text>
+                    </button>
+                  ))}
+                </div>
+              </RadixCollapsible.Content>
+            </div>
+          </Container>
+        </RadixCollapsible.Root>
+      )
+    }
+    ```
+
+  </Step>
+  <Step title="Attach it to the store-setup zone">
+    Export the component as the **default** and a `config` with a `seller.setup`
+    zone. `before` renders it above the built-in card; use `after` to place it
+    below:
+
+    ```tsx apps/vendor/src/widgets/store-setup-checklist.tsx
+    import { defineWidgetConfig } from "@mercurjs/dashboard-sdk"
+
+    export const config = defineWidgetConfig({
+      zone: "seller.setup.before",
+    })
+
+    export default StoreSetupChecklist
+    ```
+
+  </Step>
+</Steps>
+
+## Where it renders
+
+`seller.setup` is hosted in two places, both passing the same `seller` as `data`:
+
+| Host                                     | When it shows                                                |
+| ---------------------------------------- | ------------------------------------------------------------ |
+| The vendor shell (above the page outlet) | On top-level routes — the dashboard "home" onboarding banner |
+| The store settings detail page           | Always, above the store status banner                        |
+
+A single widget file covers both. Multiple `seller.setup.before` / `.after`
+widgets stack in registration order, so your checklist and the built-in card can
+coexist — or hide the built-in one by rendering your own and letting theirs
+complete.
+
+<Note>
+  **No data fetching.** Because the zone hands you the resolved `seller`, the
+  widget is pure render — you never call the SDK. To *collect and persist* a new
+  onboarding value (e.g. a Tax ID) rather than just link to existing pages, see
+  [Extend the onboarding flow](/rc/resources/tutorials/extend-onboarding), which
+  carries a value through `additional_data` to a workflow hook.
+</Note>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Extend the onboarding flow"
+    href="/rc/resources/tutorials/extend-onboarding"
+  >
+    Collect a new value and persist it through a workflow hook.
+  </Card>
+  <Card title="Add a widget" href="/rc/resources/tutorials/add-a-widget">
+    The full widget model and the published zone registry.
+  </Card>
+</CardGroup>

--- a/apps/vendor/src/widgets/store-setup.tsx
+++ b/apps/vendor/src/widgets/store-setup.tsx
@@ -5,7 +5,7 @@ import { SellerDTO } from "@mercurjs/types"
 import StoreSetup from "../components/store-setup/store-setup"
 
 export const config = defineWidgetConfig({
-  zone: "store.setup.before",
+  zone: "seller.setup.before",
 })
 
 const StoreSetupWidget = ({ data }: { data?: SellerDTO }) => {

--- a/packages/admin/src/hooks/table/query/use-product-table-query.tsx
+++ b/packages/admin/src/hooks/table/query/use-product-table-query.tsx
@@ -1,4 +1,5 @@
 import type { ProductStatus } from "@mercurjs/types";
+import { useExtension, withLinkFields } from "@mercurjs/dashboard-shared";
 import { useQueryParams } from "@hooks/use-query-params";
 
 type UseProductTableQueryProps = {
@@ -13,6 +14,7 @@ export const useProductTableQuery = ({
   prefix,
   pageSize = 20,
 }: UseProductTableQueryProps) => {
+  const links = useExtension().getLinks("product");
   const queryObject = useQueryParams(
     [
       "offset",
@@ -55,7 +57,7 @@ export const useProductTableQuery = ({
     type_id: type_id?.split(","),
     status: status?.split(",") as ProductStatus[],
     q,
-    fields: DEFAULT_FIELDS,
+    fields: withLinkFields(DEFAULT_FIELDS, links),
   };
 
   return {

--- a/packages/admin/src/hooks/table/query/use-sellers-table-query.tsx
+++ b/packages/admin/src/hooks/table/query/use-sellers-table-query.tsx
@@ -1,3 +1,4 @@
+import { linkFields, useExtension } from "@mercurjs/dashboard-shared";
 import { useQueryParams } from "@hooks/use-query-params";
 import { SellerStatus } from "@mercurjs/types";
 
@@ -16,6 +17,7 @@ export const useSellersTableQuery = ({
   prefix,
   pageSize = 20,
 }: UseSellersTableQueryProps) => {
+  const links = useExtension().getLinks("seller");
   const queryObject = useQueryParams(
     ["offset", "q", "created_at", "updated_at", "status", "is_premium", "order"],
     prefix,
@@ -32,6 +34,7 @@ export const useSellersTableQuery = ({
     is_premium: is_premium ? is_premium === "true" : undefined,
     q,
     order: order ? order : "-created_at",
+    ...(links.length ? { fields: linkFields(links) } : {}),
   };
 
   return {

--- a/packages/admin/src/pages/orders/order-list/components/order-list-table/order-list-data-table.tsx
+++ b/packages/admin/src/pages/orders/order-list/components/order-list-table/order-list-data-table.tsx
@@ -6,7 +6,11 @@ import { IconButton, clx } from "@medusajs/ui";
 import { TriangleRightMini } from "@medusajs/icons";
 import { keepPreviousData } from "@tanstack/react-query";
 import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
-import { useExtendableTable } from "@mercurjs/dashboard-shared";
+import {
+  useExtendableTable,
+  useExtension,
+  withLinkFields,
+} from "@mercurjs/dashboard-shared";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -113,10 +117,12 @@ export const OrderListDataTable = () => {
     pageSize: PAGE_SIZE,
   });
 
+  const links = useExtension().getLinks("order");
+
   const { order_groups, count, isError, error, isLoading } = useOrderGroups(
     {
       ...searchParams,
-      fields: DEFAULT_FIELDS,
+      fields: withLinkFields(DEFAULT_FIELDS, links),
     },
     {
       placeholderData: keepPreviousData,

--- a/packages/admin/src/pages/price-lists/price-list-detail/loader.ts
+++ b/packages/admin/src/pages/price-lists/price-list-detail/loader.ts
@@ -1,12 +1,17 @@
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 import { LoaderFunctionArgs } from "react-router-dom"
 import { priceListsQueryKeys } from "../../../hooks/api/price-lists"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
-const pricingDetailQuery = (id: string) => ({
-  queryKey: priceListsQueryKeys.detail(id),
-  queryFn: async () => sdk.admin.priceLists.$id.query({ $id: id }),
-})
+const pricingDetailQuery = (id: string) => {
+  const query = getLinkQuery("price_list")
+
+  return {
+    queryKey: priceListsQueryKeys.detail(id, query),
+    queryFn: async () => sdk.admin.priceLists.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const pricingLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id

--- a/packages/admin/src/pages/products/product-edit/product-edit.tsx
+++ b/packages/admin/src/pages/products/product-edit/product-edit.tsx
@@ -2,6 +2,8 @@ import { Heading } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
+import { useExtension, withLinkFields } from "@mercurjs/dashboard-shared";
+
 import { RouteDrawer } from "../../../components/modals";
 import { useProduct } from "../../../hooks/api/products";
 import { PRODUCT_DETAIL_QUERY } from "../constants";
@@ -11,7 +13,10 @@ export const ProductEdit = () => {
   const { id } = useParams();
   const { t } = useTranslation();
 
-  const { product, isLoading, isError, error } = useProduct(id!, PRODUCT_DETAIL_QUERY);
+  const links = useExtension().getLinks("product");
+  const { product, isLoading, isError, error } = useProduct(id!, {
+    fields: withLinkFields(PRODUCT_DETAIL_QUERY.fields, links),
+  });
 
   if (isError) {
     throw error;

--- a/packages/admin/src/pages/stores/store-details/components/store-details.tsx
+++ b/packages/admin/src/pages/stores/store-details/components/store-details.tsx
@@ -2,13 +2,14 @@ import { ReactNode, Children, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
-import { WidgetZone } from "@mercurjs/dashboard-shared";
+import { WidgetZone, useLinkQuery } from "@mercurjs/dashboard-shared";
 
 import { TwoColumnPageSkeleton } from "../../../../components/common/skeleton";
 import { TwoColumnPage } from "../../../../components/layout/pages";
 import { useSeller } from "@/hooks/api";
 import { SellerStatus } from "@mercurjs/types";
 
+import { STORE_DETAIL_FIELDS } from "../loader";
 import { StoreGeneralSection } from "./store-general-section";
 import { StorePaymentDetailsSection } from "./store-payment-details-section";
 import { StoreCompanyDetailsSection } from "./store-company-details-section";
@@ -83,7 +84,8 @@ const Root = ({ children }: { children?: ReactNode }) => {
   const { id } = useParams();
   const [activeTab, setActiveTab] = useState<Tab>("orders");
 
-  const { seller, isLoading, isError, error } = useSeller(id!);
+  const query = useLinkQuery("seller", STORE_DETAIL_FIELDS);
+  const { seller, isLoading, isError, error } = useSeller(id!, query);
 
   if (isLoading || !seller) {
     return <TwoColumnPageSkeleton mainSections={3} sidebarSections={3} />;

--- a/packages/admin/src/pages/stores/store-details/loader.ts
+++ b/packages/admin/src/pages/stores/store-details/loader.ts
@@ -1,13 +1,21 @@
+import { getLinkQuery } from "@mercurjs/dashboard-shared"
 import { LoaderFunctionArgs } from "react-router-dom"
 
 import { sellersQueryKeys } from "../../../hooks/api/sellers"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
-const sellerDetailQuery = (id: string) => ({
-  queryKey: sellersQueryKeys.detail(id),
-  queryFn: async () => sdk.admin.sellers.$id.query({ $id: id }),
-})
+export const STORE_DETAIL_FIELDS =
+  "+address.*,+payment_details.*,+professional_details.*"
+
+const sellerDetailQuery = (id: string) => {
+  const query = getLinkQuery("seller", STORE_DETAIL_FIELDS)
+
+  return {
+    queryKey: sellersQueryKeys.detail(id, query),
+    queryFn: async () => sdk.admin.sellers.$id.query({ $id: id, ...query }),
+  }
+}
 
 export const storeDetailLoader = async ({ params }: LoaderFunctionArgs) => {
   const id = params.id!

--- a/packages/vendor/src/pages/orders/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/orders/[id]/edit/index.tsx
@@ -11,6 +11,8 @@ import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate, useParams } from "react-router-dom"
 
+import { useExtension, withLinkFields } from "@mercurjs/dashboard-shared"
+
 import { RouteFocusModal } from "@components/modals"
 import { useCreateOrderEdit } from "@hooks/api/order-edits"
 import { useOrder, useOrderPreview } from "@hooks/api/orders"
@@ -28,13 +30,18 @@ export const Component = () => {
 
   const orderId = id ?? ""
 
+  const links = useExtension().getLinks("order")
+
   const { order } = useOrder(orderId, {
     // Use the `<rel>.*` suffix form. Combining `*foo` with `*foo.bar`
     // (or the `+foo.bar.baz` form) makes Medusa's query parser try to
     // look up a literal property called `*items` / `+items` on Order
     // and 500. See packages/core/src/api/vendor/orders/query-config.ts
     // for the matching guidance applied to the defaults.
-    fields: "currency_code,total,items.*,items.variant.*",
+    fields: withLinkFields(
+      "currency_code,total,items.*,items.variant.*",
+      links,
+    ),
   })
 
   const { order: preview } = useOrderPreview(orderId)

--- a/packages/vendor/src/pages/products/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/edit/index.tsx
@@ -3,6 +3,8 @@ import { Heading } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 
+import { linkFields, useExtension } from "@mercurjs/dashboard-shared";
+
 import { RouteDrawer } from "@components/modals";
 import { useProduct } from "@hooks/api/products";
 import { EditProductForm } from "./edit-product-form";
@@ -11,7 +13,11 @@ export const Component = () => {
   const { id } = useParams();
   const { t } = useTranslation();
 
-  const { product, isLoading, isError, error } = useProduct(id!);
+  const links = useExtension().getLinks("product");
+  const { product, isLoading, isError, error } = useProduct(
+    id!,
+    links.length ? { fields: linkFields(links) } : undefined,
+  );
 
   if (isError) {
     throw error;

--- a/packages/vendor/src/pages/settings/store/store-detail-page.tsx
+++ b/packages/vendor/src/pages/settings/store/store-detail-page.tsx
@@ -4,8 +4,12 @@ import { useTranslation } from "react-i18next";
 
 import { TwoColumnPageSkeleton } from "@components/common/skeleton";
 import { TwoColumnPage } from "@components/layout/pages";
-import { WidgetZone } from "@mercurjs/dashboard-shared";
-import { useMe } from "@/hooks/api";
+import {
+  WidgetZone,
+  useExtension,
+  useLinkQuery,
+} from "@mercurjs/dashboard-shared";
+import { useMe, useSeller } from "@/hooks/api";
 import { SellerStatus } from "@mercurjs/types";
 
 import { StoreAddressSection } from "./_components/store-address-section";
@@ -20,18 +24,36 @@ import {
   StoreDetailEditButton,
 } from "./_components/store-detail-header";
 
+const ME_SELLER_FIELDS =
+  "+seller.*,+seller.address.*,+seller.payment_details.*,+seller.professional_details.*";
+const SELLER_DETAIL_FIELDS =
+  "+address.*,+payment_details.*,+professional_details.*";
+
 const Root = ({ children }: { children?: ReactNode }) => {
   const { t } = useTranslation();
-  const { seller_member, isPending, isError, error } = useMe();
+  const { seller_member, isPending, isError, error } = useMe({
+    fields: ME_SELLER_FIELDS,
+  });
 
-  const seller = seller_member?.seller;
+  const meSeller = seller_member?.seller;
 
-  if (isPending || !seller) {
-    return <TwoColumnPageSkeleton mainSections={3} sidebarSections={3} />;
-  }
+  const needsLinks = useExtension().getLinks("seller").length > 0;
+  const query = useLinkQuery("seller", SELLER_DETAIL_FIELDS);
+
+  const { seller: linkedSeller, isPending: linkedPending } = useSeller(
+    meSeller?.id ?? "",
+    query,
+    { enabled: needsLinks && !!meSeller?.id },
+  );
+
+  const seller = needsLinks ? linkedSeller : meSeller;
 
   if (isError) {
     throw error;
+  }
+
+  if (isPending || !seller || (needsLinks && linkedPending)) {
+    return <TwoColumnPageSkeleton mainSections={3} sidebarSections={3} />;
   }
 
   const statusAlert = (() => {


### PR DESCRIPTION
## What

Several dashboard entity pages fetched their entity **plain** or with a **hardcoded** `fields` string, so custom-field `link` relations (SPEC-021/024) were never fetched and linked columns/sections had no data. This wires them using the explicit `useExtension().getLinks(model)` + `withLinkFields`/`linkFields` form.

## Changes

**Product edit** (`product`):
- `packages/admin/.../product-edit/product-edit.tsx`
- `packages/vendor/.../products/[id]/edit/index.tsx`

**Store** (`seller`):
- `packages/admin/.../stores/store-details/store-details.tsx` + `loader.ts`
- `packages/admin/.../hooks/table/query/use-sellers-table-query.tsx` (store list)
- `packages/vendor/.../settings/store/store-detail-page.tsx` (links via conditional `useSeller`)

**Orders** (`order`):
- `packages/admin/.../order-list/.../order-list-data-table.tsx`
- `packages/vendor/.../orders/[id]/edit/index.tsx`

**Products / Price lists**:
- `packages/admin/.../hooks/table/query/use-product-table-query.tsx` (product list)
- `packages/admin/.../price-lists/price-list-detail/loader.ts`

Also included: pending `apps/docs/*` updates and an `apps/vendor/.../store-setup.tsx` widget tweak that were already in the working tree.

## Correctness notes

- **Additive only**: pages with no curated base use `linkFields(links)` gated on `links.length`, never a bare `fields` (which would replace route defaults and drop fields — the vendor-products-500 trap).
- **Loader/component key parity**: price-list & store loaders use `getLinkQuery` to match their sibling components' `useLinkQuery` output, so react-query cache keys align and prefetches are reused.
- Two thorough audits (admin + vendor) confirm no remaining plain/hardcoded entity fetches across the 13 link-supported domains.

All edited files type-check clean (the pre-existing `ProductDTO`/`AdminProduct` error in product-edit is unrelated — verified present before this change).