### PR TITLE
feat(vendor): fetch seller custom-field links in onboarding wizard

### DIFF
--- a/packages/vendor/src/components/onboarding-wizard/onboarding-wizard.tsx
+++ b/packages/vendor/src/components/onboarding-wizard/onboarding-wizard.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from "motion/react";
 import { useNavigate } from "react-router-dom";
 
+import { linkFields, useExtension } from "@mercurjs/dashboard-shared";
 import { useLogout, useSellers } from "@hooks/api";
 import { queryClient } from "@lib/query-client";
 import { WizardSidebar } from "./wizard-sidebar";
@@ -19,7 +20,10 @@ type OnboardingWizardProps = {
 export const OnboardingWizard = ({ memberEmail }: OnboardingWizardProps) => {
   const navigate = useNavigate();
   const { mutateAsync: logoutMutation } = useLogout();
-  const { seller_members } = useSellers();
+  const links = useExtension().getLinks("seller");
+  const { seller_members } = useSellers(
+    links.length ? { fields: linkFields(links) } : undefined,
+  );
   const hasStores = (seller_members?.length ?? 0) > 0;
 
   const {


### PR DESCRIPTION
## What

Wires custom-field `link` support into the onboarding wizard's seller fetch, consistent with the rest of the panel link work.

`packages/vendor/src/components/onboarding-wizard/onboarding-wizard.tsx`:
```ts
const links = useExtension().getLinks("seller");
const { seller_members } = useSellers(
  links.length ? { fields: linkFields(links) } : undefined,
);
```

- `getLinks("seller")` reads registered custom-field link relations for the `seller` model.
- `linkFields(links)` (no-base sibling of `withLinkFields`, `+link.*` additive) is applied only when links exist, so with no registered links the fetch is unchanged and route defaults are never replaced.

## Notes

- `useSellers()` here drives the `hasStores` count/back-button routing; the wiring is a no-op until a `seller` link is registered, at which point linked data rides along on the same fetch.
- Type-checks clean.