### PR TITLE
fix(dashboard): unwrap zod wrappers when picking custom-field input control

### DIFF
--- a/packages/dashboard-shared/src/extensions/form-extension-zone.tsx
+++ b/packages/dashboard-shared/src/extensions/form-extension-zone.tsx
@@ -4,9 +4,37 @@ import type { CustomFormField } from "@mercurjs/dashboard-sdk"
 import { Form } from "../components/common/form"
 import { useExtension } from "./context"
 
-function zodType(field: CustomFormField): string {
-  const def = (field.validation as unknown as { def?: { type?: string } })?.def
-  return def?.type ?? "string"
+type FieldControlType = "boolean" | "number" | "string" | "textarea"
+
+// Zod wrappers that carry the base schema on `def.innerType` — unwrap them so an
+// `optional()`/`nullable()`/`default()` field maps to its underlying control.
+const ZOD_WRAPPER_TYPES = new Set([
+  "optional",
+  "nullable",
+  "default",
+  "prefault",
+  "nonoptional",
+  "readonly",
+  "catch",
+])
+
+type ZodDef = { type?: string; innerType?: { def?: ZodDef } }
+
+function zodType(field: CustomFormField): FieldControlType {
+  let def = (field.validation as unknown as { def?: ZodDef })?.def
+
+  while (def && ZOD_WRAPPER_TYPES.has(def.type ?? "")) {
+    def = def.innerType?.def
+  }
+
+  switch (def?.type) {
+    case "boolean":
+    case "number":
+    case "string":
+      return def.type
+    default:
+      return "textarea"
+  }
 }
 
 type FieldProps = {


### PR DESCRIPTION
## Problem

`FormExtensionZone`'s `zodType` read only the outermost `validation.def.type`, so any wrapped custom-field schema resolved to the wrapper name instead of its base type and fell through to the Textarea branch:

| schema | old result | control | correct? |
|---|---|---|---|
| `z.string()` | `string` | Input | ✅ |
| `z.string().optional()` | `optional` | Textarea | ❌ |
| `z.boolean().nullable()` | `nullable` | Textarea | ❌ |
| `z.number().default(1)` | `default` | Textarea | ❌ |

This is live: the shipped demo `apps/vendor/src/custom-fields/product.tsx` uses `form.string().optional()`, which renders as a Textarea instead of a text Input. `createFormHelper` exposes `.nullable`/`.coerce`, so wrapped schemas are expected.

## Fix

- Unwrap zod wrapper types (`optional`, `nullable`, `default`, `prefault`, `nonoptional`, `readonly`, `catch`) via `def.innerType.def` until the base schema is reached, then map to the control.
- Tighten the return to a `FieldControlType` union (`"boolean" | "number" | "string" | "textarea"`) so the mapping is exhaustive rather than a bare `string`.

Behavior verified empirically against zod 4.4.3 (`.def.type` / `.def.innerType`). Rebuilt `dashboard-shared`; type-checks clean.