### PR TITLE
fix(admin): match collection products empty state to design

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -893,6 +893,7 @@
     "removeProductsWarning_other": "You are about to remove {{count}} products from the collection. This action cannot be undone.",
     "products": {
       "list": {
+        "noRecordsTitle": "No products yet",
         "noRecordsMessage": "There are no products in the collection."
       },
       "add": {

--- a/packages/admin/src/pages/collections/collection-detail/components/collection-product-section/collection-product-section.tsx
+++ b/packages/admin/src/pages/collections/collection-detail/components/collection-product-section/collection-product-section.tsx
@@ -140,6 +140,8 @@ export const CollectionProductSection = ({
           },
         ]}
         noRecords={{
+          icon: null,
+          title: t("collections.products.list.noRecordsTitle"),
           message: t("collections.products.list.noRecordsMessage"),
         }}
       />


### PR DESCRIPTION
## Summary
- Collection products section empty state now shows a bold **No products yet** title with no icon, matching the Figma design (MER-263 item 1).
- Adds the `collections.products.list.noRecordsTitle` translation and sets `icon: null` on the section's `noRecords`, mirroring the category products section.

Item 2 (default title sort) was already shipped in #1180.

## Linear
[MER-263](https://linear.app/rigbyjs/issue/MER-263)

## Test plan
- [ ] Open a collection with no products in the admin panel → empty state reads "No products yet" / "There are no products in the collection." with no icon
- [x] `bun run build`