### PR TITLE
fix(admin): align category toast messages with product copy

### DIFF
--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -970,7 +970,7 @@
         "details": "Details",
         "organize": "Organize Ranking"
       },
-      "successToast": "Category {{name}} was successfully created."
+      "successToast": "Category was successfully created."
     },
     "edit": {
       "header": "Edit Category",
@@ -979,19 +979,19 @@
     },
     "delete": {
       "confirmation": "You are about to delete the category {{name}}. This action cannot be undone.",
-      "successToast": "Category {{name}} was successfully deleted."
+      "successToast": "Category was successfully deleted."
     },
     "products": {
       "add": {
         "disabledTooltip": "The product is already in this category.",
-        "successToast_one": "Added {{count}} product to the category.",
-        "successToast_other": "Added {{count}} products to the category."
+        "successToast_one": "Product was successfully added to the category.",
+        "successToast_other": "Products were successfully added to the category."
       },
       "remove": {
         "confirmation_one": "You are about to remove {{count}} product from the category. This action cannot be undone.",
         "confirmation_other": "You are about to remove {{count}} products from the category. This action cannot be undone.",
-        "successToast_one": "Removed {{count}} product from the category.",
-        "successToast_other": "Removed {{count}} products from the category."
+        "successToast_one": "Product was successfully removed from the category.",
+        "successToast_other": "Products were successfully removed from the category."
       },
       "list": {
         "noRecordsTitle": "No products yet",
@@ -1001,7 +1001,7 @@
     "organize": {
       "header": "Organize",
       "action": "Edit ranking",
-      "successToast": "Category ranking was updated successfully."
+      "successToast": "Ranking was successfully updated."
     },
     "media": {
       "label": "Media",

--- a/packages/admin/src/pages/categories/category-create/components/create-category-form/create-category-form.tsx
+++ b/packages/admin/src/pages/categories/category-create/components/create-category-form/create-category-form.tsx
@@ -78,11 +78,7 @@ export const CreateCategoryForm = ({
       },
       {
         onSuccess: ({ product_category }) => {
-          toast.success(
-            t("categories.create.successToast", {
-              name: product_category.name,
-            })
-          )
+          toast.success(t("categories.create.successToast"))
 
           handleSuccess(`/categories/${product_category.id}`)
         },

--- a/packages/admin/src/pages/categories/common/hooks/use-delete-product-category-action.tsx
+++ b/packages/admin/src/pages/categories/common/hooks/use-delete-product-category-action.tsx
@@ -29,11 +29,7 @@ export const useDeleteProductCategoryAction = (
 
     await mutateAsync(undefined, {
       onSuccess: () => {
-        toast.success(
-          t("categories.delete.successToast", {
-            name: category.name,
-          })
-        )
+        toast.success(t("categories.delete.successToast"))
 
         navigate("/categories", {
           replace: true,


### PR DESCRIPTION
## Summary
- Update the admin category **create**, **delete**, and **ranking** success toasts to the approved copy ("Category was successfully created / deleted.", "Ranking was successfully updated.").
- Update the **add** / **remove** product toasts to singular/plural copy driven by the existing count ("Product was…" vs "Products were… added to / removed from the category.").
- Drop the now-unused `{{name}}` interpolation from the create and delete toasts; product add/remove keep count-based pluralization.

## Linear
[MER-266](https://linear.app/rigbyjs/issue/MER-266)

## Test plan
- [ ] Remove one product from a category → "Product was successfully removed from the category."
- [ ] Remove multiple products → "Products were successfully removed from the category."
- [ ] Add one product → "Product was successfully added to the category."
- [ ] Add multiple products → "Products were successfully added to the category."
- [ ] Edit ranking → "Ranking was successfully updated."
- [ ] Create a category → "Category was successfully created."
- [ ] Delete a category → "Category was successfully deleted."
