### PR TITLE
fix(admin): align product request modals with design

### DIFF
--- a/packages/admin/src/components/common/confirm-prompt/confirm-prompt.tsx
+++ b/packages/admin/src/components/common/confirm-prompt/confirm-prompt.tsx
@@ -92,7 +92,7 @@ export const ConfirmPrompt = ({
   return (
     <Prompt open={open} onOpenChange={handleOpenChange} variant={variant}>
       <Prompt.Content>
-        <Prompt.Header>
+        <Prompt.Header className={showNoteField ? "pb-6" : undefined}>
           <Prompt.Title>{title}</Prompt.Title>
           {description ? (
             <Prompt.Description>{description}</Prompt.Description>
@@ -100,7 +100,7 @@ export const ConfirmPrompt = ({
         </Prompt.Header>
 
         {showNoteField ? (
-          <div className="flex flex-col gap-y-2 px-6 py-4">
+          <div className="border-ui-border-base flex flex-col gap-y-2 border-y px-6 py-4">
             <Label size="small" weight="plus">
               {noteLabel}
               {noteOptional ? (

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -620,21 +620,21 @@
       },
       "confirmPrompt": {
         "title": "Confirm request",
-        "description": "You are about to confirm this product request. Once confirmed, the product will appear on the storefront. Only products with stock levels and prices set will be visible.",
-        "noteLabel": "Notes for store",
+        "description": "You are about to confirm this product update request. Once confirmed, any offers created for this product will appear on the storefront. Only offers with stock levels and prices set will be visible.",
+        "noteLabel": "Note for store",
         "notePlaceholder": "Specify changes you made or additional requests"
       },
       "requestUpdatePrompt": {
         "title": "Request update",
-        "description": "Request update to this product before publishing. Add notes to explain what needs to be updated.",
-        "noteLabel": "Notes for store",
+        "description": "Request update to this product before publishing. Add note to explain what needs to be updated.",
+        "noteLabel": "Note for store",
         "notePlaceholder": "Describe what needs to be updated (e.g., missing images, incorrect price, incomplete description)",
         "send": "Send"
       },
       "rejectPrompt": {
         "title": "Reject request",
         "description": "You are about to reject this product request.",
-        "noteLabel": "Notes for store",
+        "noteLabel": "Note for store",
         "notePlaceholder": "Explain why you reject the request",
         "confirm": "Reject"
       },
@@ -654,16 +654,16 @@
         "reject": "Reject"
       },
       "confirmPrompt": {
-        "title": "Confirm update request",
-        "description": "You are about to confirm this product update request. Once confirmed, the changes will be applied to the product and published on the storefront.",
-        "noteLabel": "Notes for store",
-        "notePlaceholder": "Add an optional note for the store"
+        "title": "Confirm request",
+        "description": "You are about to confirm this product update request. Once confirmed, the product will be updated on the storefront.",
+        "noteLabel": "Note for store",
+        "notePlaceholder": "Specify changes you made or additional requests"
       },
       "rejectPrompt": {
-        "title": "Reject update request",
-        "description": "You are about to reject this product update request. The requested changes will be discarded.",
-        "noteLabel": "Notes for store",
-        "notePlaceholder": "Explain why you reject the update request",
+        "title": "Reject request",
+        "description": "You are about to reject this product request.",
+        "noteLabel": "Note for store",
+        "notePlaceholder": "Explain why you reject the request or suggest changes",
         "confirm": "Reject"
       },
       "toast": {


### PR DESCRIPTION
## Summary
- Add top/bottom dividers around the note field in the shared `ConfirmPrompt`, matching the Medusa-styled design for the product request modals.
- Correct the copy (headings, supporting text, placeholders, and "Note for store" label) for the product request and product update request **confirm** and **reject** modals in the admin panel.

Scope is English copy + one shared modal style; no keys were added/removed, so the i18n schema test is unaffected. Polish (`pl.json`) keeps its own translated strings.

## Linear
[MER-260](https://linear.app/rigbyjs/issue/MER-260)

## Test plan
- [ ] Open a proposed product / product update request in the admin panel and trigger the confirm, request-update, and reject modals; verify headings, supporting text, placeholders, the "Note for store" label, and the dividers around the note field.
- [x] `bun run build` (admin package ESM + DTS green)