### PR TITLE
chore: update dev ports for admin and vendor panels

### DIFF
--- a/apps/admin-test/package.json
+++ b/apps/admin-test/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "rm -rf node_modules/.vite && vite --port 7000",
+    "dev": "rm -rf node_modules/.vite && vite --port 7001",
     "lint": "oxlint",
     "preview": "vite preview --port 7000"
   },

--- a/apps/vendor/package.json
+++ b/apps/vendor/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "rm -rf node_modules/.vite && vite --port 7001",
+    "dev": "rm -rf node_modules/.vite && vite --port 7002",
     "lint": "oxlint",
     "preview": "vite preview --port 7001"
   },

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 REPO_ROOT="/Users/viktorholik/Desktop/mercur"
 
-# api=9000, admin=7000, vendor=7001
-PORTS=(9000 7000 7001)
+# api=9000, admin=7001, vendor=7002
+PORTS=(9000 7001 7002)
 
 echo "→ Killing previous dev processes"
 for port in "${PORTS[@]}"; do
@@ -38,11 +38,11 @@ echo "→ Starting apps/api       (http://localhost:9000)"
 (cd "$REPO_ROOT/apps/api" && bun run dev) &
 pids+=($!)
 
-echo "→ Starting apps/admin-test (http://localhost:7000)"
+echo "→ Starting apps/admin-test (http://localhost:7001)"
 (cd "$REPO_ROOT/apps/admin-test" && bun run dev) &
 pids+=($!)
 
-echo "→ Starting apps/vendor    (http://localhost:7001)"
+echo "→ Starting apps/vendor    (http://localhost:7002)"
 (cd "$REPO_ROOT/apps/vendor" && bun run dev) &
 pids+=($!)
 


### PR DESCRIPTION
## Summary

Updated dev ports for the dashboard apps:
- Admin panel (`apps/admin-test`): now runs on **7001**
- Vendor panel (`apps/vendor`): now runs on **7002**
- API unchanged on **9000**

`scripts/dev.sh` updated to match — both the port kill-list and startup URLs now reflect the new ports.