### PR TITLE
fix(dashboard): scope custom-field validation to the form's zone

### DIFF
--- a/packages/admin/src/pages/campaigns/campaign-edit/components/edit-campaign-form/edit-campaign-form.tsx
+++ b/packages/admin/src/pages/campaigns/campaign-edit/components/edit-campaign-form/edit-campaign-form.tsx
@@ -30,6 +30,7 @@ export const EditCampaignForm = ({ campaign }: EditCampaignFormProps) => {
   const form = useExtendableForm({
     schema: EditCampaignSchema,
     model: "campaign",
+    zone: "edit",
     data: campaign,
     defaultValues: {
       name: campaign.name || "",

--- a/packages/admin/src/pages/categories/category-edit/components/edit-category-form/edit-category-form.tsx
+++ b/packages/admin/src/pages/categories/category-edit/components/edit-category-form/edit-category-form.tsx
@@ -34,6 +34,7 @@ export const EditCategoryForm = ({ category }: EditCategoryFormProps) => {
   const form = useExtendableForm({
     schema: EditCategorySchema,
     model: "category",
+    zone: "edit",
     data: category,
     defaultValues: {
       name: category.name,

--- a/packages/admin/src/pages/collections/collection-edit/components/edit-collection-form/edit-collection-form.tsx
+++ b/packages/admin/src/pages/collections/collection-edit/components/edit-collection-form/edit-collection-form.tsx
@@ -31,6 +31,7 @@ export const EditCollectionForm = ({ collection }: EditCollectionFormProps) => {
   const form = useExtendableForm({
     schema: EditCollectionSchema,
     model: "collection",
+    zone: "edit",
     data: collection,
     defaultValues: {
       title: collection.title,

--- a/packages/admin/src/pages/customer-groups/customer-group-edit/components/edit-customer-group-form/edit-customer-group-form.tsx
+++ b/packages/admin/src/pages/customer-groups/customer-group-edit/components/edit-customer-group-form/edit-customer-group-form.tsx
@@ -28,6 +28,7 @@ export const EditCustomerGroupForm = ({
   const form = useExtendableForm({
     schema: EditCustomerGroupSchema,
     model: "customer_group",
+    zone: "edit",
     data: group,
     defaultValues: {
       name: group.name || "",

--- a/packages/admin/src/pages/customers/customer-edit/components/edit-customer-form/edit-customer-form.tsx
+++ b/packages/admin/src/pages/customers/customer-edit/components/edit-customer-form/edit-customer-form.tsx
@@ -34,6 +34,7 @@ export const EditCustomerForm = ({ customer }: EditCustomerFormProps) => {
   const form = useExtendableForm({
     schema: EditCustomerSchema,
     model: "customer",
+    zone: "edit",
     data: customer,
     defaultValues: {
       email: customer.email || "",

--- a/packages/admin/src/pages/inventory/inventory-detail/components/edit-inventory-item/components/edit-item-form.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/components/edit-inventory-item/components/edit-item-form.tsx
@@ -36,6 +36,7 @@ export const EditInventoryItemForm = ({ item }: EditInventoryItemFormProps) => {
   const form = useExtendableForm({
     schema: EditInventoryItemSchema,
     model: "inventory_item",
+    zone: "edit",
     data: item,
     defaultValues: getDefaultValues(item),
   })

--- a/packages/admin/src/pages/price-lists/price-list-edit/components/price-list-edit-form/edit-price-list-form.tsx
+++ b/packages/admin/src/pages/price-lists/price-list-edit/components/price-list-edit-form/edit-price-list-form.tsx
@@ -40,6 +40,7 @@ export const PriceListEditForm = ({ priceList }: PriceListEditFormProps) => {
   const form = useExtendableForm({
     schema: PriceListEditSchema,
     model: "price_list",
+    zone: "edit",
     data: priceList,
     defaultValues: {
       type: priceList.type as PriceListType,

--- a/packages/admin/src/pages/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
+++ b/packages/admin/src/pages/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
@@ -74,6 +74,7 @@ export const EditPromotionDetailsForm = ({
   const form = useExtendableForm({
     schema: EditPromotionSchema,
     model: "promotion",
+    zone: "edit",
     data: promotion,
     defaultValues: {
       is_automatic: promotion.is_automatic!.toString(),

--- a/packages/admin/src/pages/reservations/reservation-detail/components/edit-reservation/components/edit-reservation-form.tsx
+++ b/packages/admin/src/pages/reservations/reservation-detail/components/edit-reservation/components/edit-reservation-form.tsx
@@ -65,6 +65,7 @@ export const EditReservationForm = ({
   const form = useExtendableForm({
     schema: EditReservationSchema,
     model: "reservation",
+    zone: "edit",
     data: reservation,
     defaultValues: getDefaultValues(reservation),
   })

--- a/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
+++ b/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
@@ -104,6 +104,7 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
   const form = useExtendableForm({
     schema: EditStoreSchema,
     model: "seller",
+    zone: "edit",
     data: seller,
     defaultValues: {
       status: (seller.status as SellerStatus) ?? SellerStatus.OPEN,

--- a/packages/dashboard-shared/src/extensions/custom-fields-form.ts
+++ b/packages/dashboard-shared/src/extensions/custom-fields-form.ts
@@ -30,10 +30,15 @@ export function createFormHelper<TData>() {
  */
 export function buildAdditionalDataSchema(
   registry: ExtensionRegistry,
-  model: string
+  model: string,
+  zone?: string,
+  tab?: string
 ): z.ZodObject<Record<string, z.ZodTypeAny>> {
   const shape: Record<string, z.ZodTypeAny> = {}
-  for (const { name, field } of registry.getAllFormFields(model)) {
+  const fields = zone
+    ? registry.getFormFields(model, zone, tab)
+    : registry.getAllFormFields(model)
+  for (const { name, field } of fields) {
     shape[name] = field.validation as unknown as z.ZodTypeAny
   }
   return z.object(shape)
@@ -43,10 +48,15 @@ export function buildAdditionalDataSchema(
 export function buildAdditionalDataDefaults(
   registry: ExtensionRegistry,
   model: string,
-  data?: unknown
+  data?: unknown,
+  zone?: string,
+  tab?: string
 ): Record<string, unknown> {
   const defaults: Record<string, unknown> = {}
-  for (const { name, field } of registry.getAllFormFields(model)) {
+  const fields = zone
+    ? registry.getFormFields(model, zone, tab)
+    : registry.getAllFormFields(model)
+  for (const { name, field } of fields) {
     if (typeof field.defaultValue === "function") {
       defaults[name] = (field.defaultValue as (d: unknown) => unknown)(data)
     } else if (field.defaultValue !== undefined) {

--- a/packages/dashboard-shared/src/extensions/use-extendable-form.ts
+++ b/packages/dashboard-shared/src/extensions/use-extendable-form.ts
@@ -29,6 +29,14 @@ export interface UseExtendableFormProps<
   model: string
   /** Loaded entity, used to resolve custom-field default values. */
   data?: TData
+  /**
+   * Form zone (and optional tab) this form renders. When set, only custom
+   * fields registered for that zone extend the schema/defaults — so a required
+   * field defined for another zone (e.g. onboarding) doesn't block this form.
+   * Omit to include every field for the model (legacy behaviour).
+   */
+  zone?: string
+  tab?: string
 }
 
 /**
@@ -47,6 +55,8 @@ export const useExtendableForm = <
   defaultValues: baseDefaultValues,
   model,
   data,
+  zone,
+  tab,
   ...props
 }: UseExtendableFormProps<TSchema, TContext>) => {
   const extension = useExtension()
@@ -54,19 +64,25 @@ export const useExtendableForm = <
   const schema = useMemo(
     () =>
       baseSchema.extend({
-        additional_data: buildAdditionalDataSchema(extension, model)
+        additional_data: buildAdditionalDataSchema(extension, model, zone, tab)
           .partial()
           .optional(),
       }),
-    [baseSchema, extension, model]
+    [baseSchema, extension, model, zone, tab]
   )
 
   const defaultValues = useMemo(
     () => ({
       ...baseDefaultValues,
-      additional_data: buildAdditionalDataDefaults(extension, model, data),
+      additional_data: buildAdditionalDataDefaults(
+        extension,
+        model,
+        data,
+        zone,
+        tab
+      ),
     }),
-    [baseDefaultValues, extension, model, data]
+    [baseDefaultValues, extension, model, data, zone, tab]
   )
 
   return useForm<

--- a/packages/vendor/src/components/onboarding-wizard/steps/store-step.tsx
+++ b/packages/vendor/src/components/onboarding-wizard/steps/store-step.tsx
@@ -44,6 +44,7 @@ export const StoreStep = ({ onSubmit, isPending }: StoreStepProps) => {
   const form = useExtendableForm({
     schema: StoreStepSchema,
     model: "seller",
+    zone: "onboarding",
     data: store,
     defaultValues: {
       name: "",

--- a/packages/vendor/src/pages/campaigns/[id]/edit/edit-campaign-form/edit-campaign-form.tsx
+++ b/packages/vendor/src/pages/campaigns/[id]/edit/edit-campaign-form/edit-campaign-form.tsx
@@ -30,6 +30,7 @@ export const EditCampaignForm = ({ campaign }: EditCampaignFormProps) => {
   const form = useExtendableForm({
     schema: EditCampaignSchema,
     model: "campaign",
+    zone: "edit",
     data: campaign,
     defaultValues: {
       name: campaign.name || "",

--- a/packages/vendor/src/pages/customer-groups/customer-group-edit/components/edit-customer-group-form/edit-customer-group-form.tsx
+++ b/packages/vendor/src/pages/customer-groups/customer-group-edit/components/edit-customer-group-form/edit-customer-group-form.tsx
@@ -33,6 +33,7 @@ export const EditCustomerGroupForm = ({
   const form = useExtendableForm({
     schema: EditCustomerGroupSchema,
     model: "customer_group",
+    zone: "edit",
     data: group,
     defaultValues: {
       name: group.name || "",

--- a/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/components/edit-item-form.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/components/edit-item-form.tsx
@@ -34,6 +34,7 @@ export const EditInventoryItemForm = ({ item }: EditInventoryItemFormProps) => {
   const form = useExtendableForm({
     schema: EditInventoryItemSchema,
     model: "inventory_item",
+    zone: "edit",
     data: item,
     defaultValues: getDefaultValues(item),
   })

--- a/packages/vendor/src/pages/offers/[id]/edit/edit-offer-form/edit-offer-form.tsx
+++ b/packages/vendor/src/pages/offers/[id]/edit/edit-offer-form/edit-offer-form.tsx
@@ -27,6 +27,7 @@ export const EditOfferForm = ({ offer }: Props) => {
   const form = useExtendableForm({
     schema: EditOfferSchema,
     model: "offer",
+    zone: "edit",
     data: offer,
     defaultValues: {
       sku: offer.sku ?? "",

--- a/packages/vendor/src/pages/price-lists/[id]/edit/price-list-edit-form/edit-price-list-form.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/edit/price-list-edit-form/edit-price-list-form.tsx
@@ -39,6 +39,7 @@ export const PriceListEditForm = ({ priceList }: PriceListEditFormProps) => {
   const form = useExtendableForm({
     schema: PriceListEditSchema,
     model: "price_list",
+    zone: "edit",
     data: priceList,
     defaultValues: {
       type: priceList.type as PriceListType,

--- a/packages/vendor/src/pages/products/[id]/edit/edit-product-form/edit-product-form.tsx
+++ b/packages/vendor/src/pages/products/[id]/edit/edit-product-form/edit-product-form.tsx
@@ -38,6 +38,7 @@ export const EditProductForm = ({ product }: EditProductFormProps) => {
   const form = useExtendableForm({
     schema: EditProductSchema,
     model: "product",
+    zone: "edit",
     data: product,
     defaultValues: {
       title: product.title,

--- a/packages/vendor/src/pages/promotions/[id]/edit/edit-promotion-form/edit-promotion-details-form.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/edit/edit-promotion-form/edit-promotion-details-form.tsx
@@ -34,6 +34,7 @@ export const EditPromotionDetailsForm = ({ promotion }: EditPromotionFormProps) 
   const form = useExtendableForm({
     schema: EditPromotionSchema,
     model: "promotion",
+    zone: "edit",
     data: promotion,
     defaultValues: {
       is_automatic: promotion.is_automatic!.toString(),

--- a/packages/vendor/src/pages/reservations/[id]/_components/edit-reservation/components/edit-reservation-form.tsx
+++ b/packages/vendor/src/pages/reservations/[id]/_components/edit-reservation/components/edit-reservation-form.tsx
@@ -64,6 +64,7 @@ export const EditReservationForm = ({
   const form = useExtendableForm({
     schema: EditReservationSchema,
     model: "reservation",
+    zone: "edit",
     data: reservation,
     defaultValues: getDefaultValues(reservation),
   })

--- a/packages/vendor/src/pages/settings/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
+++ b/packages/vendor/src/pages/settings/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
@@ -37,6 +37,7 @@ export const EditProfileForm = () => {
   const form = useExtendableForm({
     schema: EditProfileSchema,
     model: "member",
+    zone: "edit",
     data: member,
     defaultValues: {
       first_name: member?.first_name ?? "",

--- a/packages/vendor/src/pages/settings/store/address/store-address-form.tsx
+++ b/packages/vendor/src/pages/settings/store/address/store-address-form.tsx
@@ -39,6 +39,7 @@ export const StoreAddressForm = ({ seller }: StoreAddressFormProps) => {
   const form = useExtendableForm({
     schema: StoreAddressSchema,
     model: "seller",
+    zone: "address",
     data: seller,
     defaultValues: {
       name: address?.name ?? "",

--- a/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
+++ b/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
@@ -1,11 +1,10 @@
 import i18n from "i18next";
-import { InformationCircleSolid } from "@medusajs/icons";
 import {
   Button,
   Heading,
+  Hint,
   Input,
   Select,
-  Text,
   Textarea,
   toast,
 } from "@medusajs/ui";
@@ -14,7 +13,10 @@ import { useTranslation } from "react-i18next";
 import * as zod from "zod";
 import { useCallback } from "react";
 
-import { FormExtensionZone, useExtendableForm } from "@mercurjs/dashboard-shared";
+import {
+  FormExtensionZone,
+  useExtendableForm,
+} from "@mercurjs/dashboard-shared";
 
 import { FileType, FileUpload } from "@components/common/file-upload";
 import { Form } from "@components/common/form";
@@ -94,6 +96,7 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
   const form = useExtendableForm({
     schema: EditStoreSchema,
     model: "seller",
+    zone: "edit",
     data: seller,
     defaultValues: {
       name: seller.name ?? "",
@@ -103,10 +106,24 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
       description: seller.description ?? "",
       website_url: stripWebsiteProtocol(seller.website_url),
       media: seller.logo
-        ? [{ id: "existing-logo", url: seller.logo, isThumbnail: false, file: null }]
+        ? [
+            {
+              id: "existing-logo",
+              url: seller.logo,
+              isThumbnail: false,
+              file: null,
+            },
+          ]
         : [],
       bannerMedia: seller.banner
-        ? [{ id: "existing-banner", url: seller.banner, isThumbnail: false, file: null }]
+        ? [
+            {
+              id: "existing-banner",
+              url: seller.banner,
+              isThumbnail: false,
+              file: null,
+            },
+          ]
         : [],
     },
   });
@@ -394,17 +411,7 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
                 );
               }}
             />
-            <div className="bg-ui-bg-component shadow-elevation-card-rest flex items-start gap-x-2 rounded-lg px-4 py-3">
-              <InformationCircleSolid className="text-ui-fg-interactive mt-[2px]" />
-              <div className="flex flex-col gap-y-0.5">
-                <Text size="small" weight="plus" className="text-ui-fg-base">
-                  {t("store.edit.mediaTipLabel")}
-                </Text>
-                <Text size="small" className="text-ui-fg-subtle">
-                  {t("store.edit.mediaTipBody")}
-                </Text>
-              </div>
-            </div>
+            <Hint>{t("store.edit.mediaTipBody")}</Hint>
           </div>
           <FormExtensionZone
             model="seller"

--- a/packages/vendor/src/pages/settings/store/payment-details/store-payment-details-form.tsx
+++ b/packages/vendor/src/pages/settings/store/payment-details/store-payment-details-form.tsx
@@ -43,6 +43,7 @@ export const StorePaymentDetailsForm = ({
   const form = useExtendableForm({
     schema: StorePaymentDetailsSchema,
     model: "seller",
+    zone: "payment-details",
     data: seller,
     defaultValues: {
       country_code: details?.country_code ?? "",

--- a/packages/vendor/src/pages/settings/store/professional-details/store-professional-details-form.tsx
+++ b/packages/vendor/src/pages/settings/store/professional-details/store-professional-details-form.tsx
@@ -30,6 +30,7 @@ export const StoreProfessionalDetailsForm = ({
   const form = useExtendableForm({
     schema: StoreProfessionalDetailsSchema,
     model: "seller",
+    zone: "professional-details",
     data: seller,
     defaultValues: {
       corporate_name: details?.corporate_name ?? "",


### PR DESCRIPTION
## Problem

Adding a custom field for the `seller` model in one zone (e.g. `onboarding` — accept-terms) with validation caused **other** seller forms (like edit-store in the vendor panel) to fail validation and block saving.

### Root cause

Custom-field validation was built per **model**, not per **zone**. `useExtendableForm` compiled its zod schema from `registry.getAllFormFields(model)` — every field registered for the model across **all** zones — while each form only *renders* one zone via `FormExtensionZone`. So a required field defined for the `onboarding` zone was injected into every seller form's schema without a rendered input, leaving its value unset and permanently failing `zodResolver` → save blocked.

This was also latent for `product` (which has both `edit` and `shipping-profile` zones).

## Fix

- `useExtendableForm` and the `additional_data` schema/default builders now accept an optional `zone`/`tab`. When set, only fields registered for that zone extend the schema/defaults (falls back to all fields when omitted — backward compatible).
- Pass the matching `zone` at every call site that pairs with a `FormExtensionZone` — the seller forms (`onboarding`, `edit`, `address`, `payment-details`, `professional-details`) plus all other `edit`-zone forms across admin + vendor.
- Minor: normalize the store media tip to the standard `Hint` primitive.

## Result

Each form only validates/defaults the custom fields it actually renders, so a field defined for one zone no longer blocks unrelated forms of the same model.