### PR TITLE
fix(vendor): validate tab-scoped custom fields in the onboarding wizard

### DIFF
--- a/packages/vendor/src/components/onboarding-wizard/steps/store-step.tsx
+++ b/packages/vendor/src/components/onboarding-wizard/steps/store-step.tsx
@@ -45,6 +45,7 @@ export const StoreStep = ({ onSubmit, isPending }: StoreStepProps) => {
     schema: StoreStepSchema,
     model: "seller",
     zone: "onboarding",
+    tab: "store",
     data: store,
     defaultValues: {
       name: "",


### PR DESCRIPTION
## Problem

Follow-up to #1195. After scoping custom-field validation to each form's zone, validation stopped working for custom fields in the **onboarding wizard**.

## Root cause

The onboarding store step registers its custom field with **both** a zone (`onboarding`) and a tab (`store`), and `FormExtensionZone` renders it with `tab="store"`. But `useExtendableForm` was passed only `zone: "onboarding"` — no tab.

`registry.getFormFields` skips tab-scoped fields when no tab is supplied:

```ts
if (form.tab && !tab) continue
```

So the field was **rendered but excluded from the zod schema** → never validated.

## Fix

Pass `tab: "store"` to `useExtendableForm` in `store-step.tsx` so the validated field set matches exactly what `FormExtensionZone` renders (zone `onboarding` + tab `store`).

## Scope check

Scanned every page/component using `useExtendableForm` / `FormExtensionZone` across admin + vendor (26 files). All other live forms already have matching zone/tab; `store-step` was the only real mismatch. (The two `product-shipping-profile-form` hits are commented-out dead code.)

**Invariant:** `useExtendableForm`'s `zone`/`tab` must match the form's `FormExtensionZone`.