### PR TITLE
fix(vendor): resolve create-return issues on the order return form

### DIFF
--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -6418,6 +6418,25 @@
             "activeChangeError": {
               "type": "string"
             },
+            "emptyState": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "description"
+              ],
+              "additionalProperties": false
+            },
+            "emptyItemsError": {
+              "type": "string"
+            },
             "cancel": {
               "type": "object",
               "properties": {
@@ -6605,6 +6624,8 @@
             "damagedItemReceived",
             "damagedItemsReturned",
             "activeChangeError",
+            "emptyState",
+            "emptyItemsError",
             "cancel",
             "placeholders",
             "receive",

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1581,6 +1581,11 @@
       "damagedItemReceived": "Damaged items received",
       "damagedItemsReturned": "{{quantity}}x damaged items returned",
       "activeChangeError": "There is an active order change in progress on this order. Please finish or discard the change first.",
+      "emptyState": {
+        "title": "No records yet",
+        "description": "Add at least one item from the order to create the return"
+      },
+      "emptyItemsError": "Please add at least one item from the order",
       "cancel": {
         "title": "Cancel Return",
         "description": "Are you sure you want to cancel the return request?"

--- a/packages/vendor/src/pages/orders/[id]/returns/create/_components/return-create-form/return-create-form.tsx
+++ b/packages/vendor/src/pages/orders/[id]/returns/create/_components/return-create-form/return-create-form.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { PencilSquare } from "@medusajs/icons"
+import { PencilSquare, Tag } from "@medusajs/icons"
 import {
   AdminOrder,
   AdminOrderPreview,
@@ -7,8 +7,10 @@ import {
 } from "@medusajs/types"
 import {
   Button,
+  clx,
   CurrencyInput,
   Heading,
+  Hint,
   IconButton,
   Switch,
   Text,
@@ -307,9 +309,19 @@ export const ReturnCreateForm = ({
   }, [isShippingPriceEdit])
 
   const showPlaceholder = !items.length
+  const itemsError = form.formState.errors.items
   const locationId = form.watch("location_id")
   const shippingOptionId = form.watch("option_id")
   const prompt = usePrompt()
+
+  // Clear the "no items" validation error as soon as an item lands on the
+  // draft (items sync in from the preview refetch, not synchronously on Save).
+  useEffect(() => {
+    if (items.length) {
+      form.clearErrors("items")
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items.length])
 
   const locationName = useMemo(() => {
     if (!locationId) return null
@@ -345,6 +357,14 @@ export const ReturnCreateForm = ({
     )
 
   const handleSubmit = form.handleSubmit(async (data) => {
+    if (!items.length) {
+      form.setError("items", {
+        type: "manual",
+        message: t("orders.returns.emptyItemsError"),
+      })
+      return
+    }
+
     try {
       const res = await prompt({
         title: t("general.areYouSure"),
@@ -450,15 +470,14 @@ export const ReturnCreateForm = ({
               <Heading level="h2">{t("orders.returns.inbound")}</Heading>
               <StackedFocusModal id="items">
                 <StackedFocusModal.Trigger asChild>
-                  {/* oxlint-disable-next-line jsx-a11y/anchor-is-valid */}
-                  <a
-                    href="#"
-                    onClick={(e) => e.preventDefault()}
-                    className="focus-visible:shadow-borders-focus transition-fg txt-compact-small-plus cursor-pointer text-blue-500 outline-none hover:text-blue-400"
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="small"
                     data-testid="return-create-add-items-trigger"
                   >
                     {t("actions.addItems")}
-                  </a>
+                  </Button>
                 </StackedFocusModal.Trigger>
                 <StackedFocusModal.Content>
                   <StackedFocusModal.Header />
@@ -508,13 +527,34 @@ export const ReturnCreateForm = ({
             </div>
 
             {showPlaceholder && (
-              <div
-                style={{
-                  background:
-                    "repeating-linear-gradient(-45deg, rgb(212, 212, 216, 0.15), rgb(212, 212, 216,.15) 10px, transparent 10px, transparent 20px)",
-                }}
-                className="bg-ui-bg-field mt-4 block h-[56px] w-full rounded-lg border border-dashed"
-              />
+              <div>
+                <div
+                  className={clx(
+                    "bg-ui-bg-field mt-4 flex w-full flex-col items-center justify-center gap-y-3 rounded-lg border px-6 py-8",
+                    { "border-ui-border-error": !!itemsError }
+                  )}
+                  data-testid="return-create-empty-state"
+                >
+                  <Tag className="text-ui-fg-subtle" />
+                  <div className="flex flex-col items-center gap-y-1">
+                    <Text size="small" leading="compact" weight="plus">
+                      {t("orders.returns.emptyState.title")}
+                    </Text>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {t("orders.returns.emptyState.description")}
+                    </Text>
+                  </div>
+                </div>
+                {itemsError && (
+                  <Hint
+                    variant="error"
+                    className="mt-2"
+                    data-testid="return-create-empty-state-error"
+                  >
+                    {itemsError.message}
+                  </Hint>
+                )}
+              </div>
             )}
 
             {items


### PR DESCRIPTION
## Summary
Fixes the four reported issues on the vendor **Create Return** flow (order → returns → create):

- **Add items now works.** The trigger was an `<a href="#" onClick={preventDefault}>`. Because Radix's `Trigger asChild` composes handlers with `checkForDefaultPrevented`, the child's `preventDefault()` suppressed Radix's own open handler, so the items picker never opened. Replaced it with a `<Button>` (no `preventDefault`).
- **"Add items" is a secondary button** matching the design (was a blue text link).
- **Empty state** matches the design: a bordered card with a Tag icon, "No records yet", and "Add at least one item from the order to create the return" (replacing the striped dashed placeholder).
- **Validation:** confirming with no items added now sets an error — the empty-state card gets a red border and an error hint ("Please add at least one item from the order") appears below it. The error clears automatically once an item is added.

## Linear
[MER-212](https://linear.app/rigbyjs/issue/MER-212-orders-create-return-issues)

## Test plan
- [ ] Open an order with fulfilled items → **Create Return**
- [ ] Confirm the empty state renders (Tag icon + title + description)
- [ ] Click **Confirm** with no items → red border + error hint appears
- [ ] Click **Add items** (secondary button) → items picker opens; select item(s) → **Save** → items appear and the error clears
- [ ] `bun run build`