### PR TITLE
fix(vendor): refine create-fulfillment error messages

### DIFF
--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1808,7 +1808,8 @@
       "error": {
         "wrongQuantity": "Only one item is available for fulfillment",
         "wrongQuantity_other": "Quantity should be a number between 1 and {{number}}",
-        "noItems": "No items to fulfill.",
+        "noItems": "There are no items to fulfill.",
+        "exceedsReservedQuantity": "The quantity you want to fulfill exceeds the reserved quantity for items. Please review your fulfillment.",
         "noShippingOption": "Shipping option is required",
         "noLocation": "Location is required"
       },

--- a/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-form.tsx
+++ b/packages/vendor/src/pages/orders/[id]/fulfillment/order-create-fulfillment-form/order-create-fulfillment-form.tsx
@@ -173,13 +173,25 @@ export function OrderCreateFulfillmentForm({
         })),
     }
 
+    if (!payload.items.length) {
+      toast.error(t("orders.fulfillment.error.noItems"))
+      return
+    }
+
     try {
       await createOrderFulfillment(payload)
 
       toast.success(t("orders.fulfillment.toast.created"))
       handleSuccess(`/orders/${order.id}`)
     } catch (e: any) {
-      toast.error(e.message)
+      const message: string = e?.message ?? ""
+
+      if (message.includes("exceeds the reserved quantity")) {
+        toast.error(t("orders.fulfillment.error.exceedsReservedQuantity"))
+        return
+      }
+
+      toast.error(message)
     }
   })
 


### PR DESCRIPTION
## Summary
- Show **"There are no items to fulfill."** (previously "No items to fulfill.") when the fulfillment payload is empty — either no items are selected, or the chosen stock location has no available quantity.
- Surface **"The quantity you want to fulfill exceeds the reserved quantity for items. Please review your fulfillment."** when the requested quantity exceeds the reserved quantity, instead of leaking the raw backend error.

## Linear
[MER-190](https://linear.app/rigbyjs/issue/MER-190/orders-vendor-panel-create-fulfilment)

## Test plan
- [ ] Open a vendor order → Create Fulfillment. Deselect all items (or pick a stock location with no available quantity) and confirm → error toast reads "There are no items to fulfill."
- [ ] Enter a quantity greater than the reserved quantity and confirm → error toast reads the reserved-quantity message.
- [ ] `bun run lint`
- [ ] `bun run build`