### PR TITLE
fix(dashboard-sdk): double-quoted import path in virtual components module

### DIFF
--- a/packages/dashboard-sdk/src/virtual-modules.ts
+++ b/packages/dashboard-sdk/src/virtual-modules.ts
@@ -66,7 +66,7 @@ function loadComponentsModule(mercurConfig: BuiltMercurConfig, cwd: string): str
 
     Object.entries(components).forEach(([name, componentPath]) => {
         const resolvedPath = path.resolve(cwd, 'src', componentPath)
-        imports.push(`import _${name} from "${JSON.stringify(resolvedPath)}"`)
+        imports.push(`import _${name} from ${JSON.stringify(resolvedPath)}`)
         exports.push(`${name}: _${name}`)
     })
 


### PR DESCRIPTION
## Problem

`loadComponentsModule` in `packages/dashboard-sdk/src/virtual-modules.ts` generates component-override imports as:

```ts
imports.push(`import _${name} from "${JSON.stringify(resolvedPath)}"`)
```

`JSON.stringify` already wraps the path in quotes, and the template literal adds another pair, so the generated `virtual:mercur/components` module contains:

```js
import _StoreSetup from ""/abs/path/src/components/store-setup/store-setup""
```

This breaks the vendor (and admin) panel dev server for any project that declares a component override in `mercurDashboardPlugin` — including the in-repo `apps/vendor`, which overrides `StoreSetup` in its `vite.config.ts`. Vite fails with:

```
[plugin:vite:import-analysis] Failed to resolve import "" from " virtual:mercur/components". Does the file exist?
```

## Reproduction

1. `bun install && bun run build`
2. `cd apps/vendor && bun run dev`
3. Open http://localhost:7001 — the Vite error overlay above appears instead of the login page.

## Fix

Drop the outer quotes and let `JSON.stringify` do the quoting (it also escapes special characters in paths correctly):

```ts
imports.push(`import _${name} from ${JSON.stringify(resolvedPath)}`)
```

After the fix the vendor panel loads normally with the `StoreSetup` override applied. `packages/dashboard-sdk` builds clean (`tsup` + DTS).

Note: `packages/dashboard-sdk` currently has no test runner configured, so no test is included; happy to add one if you point me at the preferred setup.