### PR TITLE
chore(deps): roll back typescript to 5.9.3

### DIFF
--- a/apps/admin-test/package.json
+++ b/apps/admin-test/package.json
@@ -43,7 +43,7 @@
     "prettier": "^3.7.4",
     "ts-node": "^10.9.2",
     "turbo": "^2.7.4",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "@types/node": "^26.1.0"
   }
 }

--- a/apps/vendor/package.json
+++ b/apps/vendor/package.json
@@ -44,7 +44,7 @@
     "prettier": "^3.7.4",
     "ts-node": "^10.9.2",
     "turbo": "^2.7.4",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "@types/node": "^26.1.0",
     "@mercurjs/types": "workspace:*"
   }

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "pg-god": "^1.0.12",
         "prettier": "^3.7.4",
         "turbo": "^2.7.4",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
         "typescript-eslint": "^8.53.0",
       },
     },
@@ -56,7 +56,7 @@
         "prettier": "^3.7.4",
         "ts-node": "^10.9.2",
         "turbo": "^2.7.4",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^8.1.3",
       },
@@ -127,7 +127,7 @@
         "prettier": "^3.7.4",
         "ts-node": "^10.9.2",
         "turbo": "^2.7.4",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
         "typescript-eslint": "^8.46.4",
         "vite": "^8.1.3",
       },
@@ -213,7 +213,7 @@
         "postcss": "^8.4.49",
         "tailwindcss": "^4.3.2",
         "tsup": "^8.0.2",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
       },
       "peerDependencies": {
         "react": "^18.0.0",
@@ -253,7 +253,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/prompts": "^2.4.9",
         "tsup": "^8.5.0",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
       },
     },
     "packages/client": {
@@ -267,7 +267,7 @@
         "@medusajs/framework": "2.17.2",
         "@types/qs": "^6.9.18",
         "tsup": "^8.5.0",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
       },
       "peerDependencies": {
         "typescript": ">=4.8.0",
@@ -308,7 +308,7 @@
         "react-dom": "^18.2.0",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.2",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
         "yalc": "^1.0.0-pre.53",
         "zod": "4.4.3",
       },
@@ -351,7 +351,7 @@
         "@types/validate-npm-package-name": "^4.0.2",
         "@types/wait-on": "^5.3.4",
         "tsup": "^8.5.0",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
       },
     },
     "packages/dashboard-sdk": {
@@ -367,7 +367,7 @@
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
         "tsup": "^8.0.2",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
         "vite": "^8.1.3",
       },
     },
@@ -422,7 +422,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^18.2.22",
         "tsup": "^8.0.2",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
       },
     },
     "packages/docs": {
@@ -494,7 +494,7 @@
         "@medusajs/types": "2.17.2",
       },
       "devDependencies": {
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
       },
     },
     "packages/vendor": {
@@ -553,7 +553,7 @@
         "postcss": "^8.4.49",
         "tailwindcss": "^4.3.2",
         "tsup": "^8.0.2",
-        "typescript": "7.0.2",
+        "typescript": "5.9.3",
       },
       "peerDependencies": {
         "react": "^18.0.0",
@@ -3347,7 +3347,7 @@
 
     "typedarray-to-buffer": ["typedarray-to-buffer@3.1.5", "", { "dependencies": { "is-typedarray": "^1.0.0" } }, "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q=="],
 
-    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.60.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.60.0", "@typescript-eslint/parser": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0", "@typescript-eslint/utils": "8.60.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw=="],
 
@@ -3774,6 +3774,8 @@
     "@mercurjs/core/pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "@mercurjs/dashboard-shared/react-jwt": ["react-jwt@1.3.0", "", { "optionalDependencies": { "fsevents": "^2.3.2" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-aC+X6q8pi63zoO7A060/4mfF5jM6Ay+4YyY4QgdD8dDOqp89sPcg0IhWEHyPACnVETMjBWzmxMPgIPosQNeYyw=="],
+
+    "@mercurjs/integration-tests/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "@mercurjs/registry/react-jwt": ["react-jwt@2.0.0", "", { "optionalDependencies": { "fsevents": "^2.3.3" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-3TL+KTT51VLHNzXzM89UpKALtgnJrS5+jfo1p48CU1IpPwf62F/P1U+VKZTuQs+kCirPduT9TacrV5lvXqIH5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pg-god": "^1.0.12",
     "prettier": "^3.7.4",
     "turbo": "^2.7.4",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.53.0"
   },
   "engines": {

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -86,7 +86,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^4.3.2",
     "tsup": "^8.0.2",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "@medusajs/types": "2.17.2",
     "@mercurjs/core": "2.2.0-canary.52",
     "@mercurjs/dashboard-sdk": "2.2.0-canary.52",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,6 +64,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/prompts": "^2.4.9",
     "tsup": "^8.5.0",
-    "typescript": "7.0.2"
+    "typescript": "5.9.3"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -42,7 +42,7 @@
     "@medusajs/framework": "2.17.2",
     "@types/qs": "^6.9.18",
     "tsup": "^8.5.0",
-    "typescript": "7.0.2"
+    "typescript": "5.9.3"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,7 @@
     "react-dom": "^18.2.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "yalc": "^1.0.0-pre.53",
     "@medusajs/types": "2.17.2",
     "zod": "4.4.3",

--- a/packages/create-mercur-app/package.json
+++ b/packages/create-mercur-app/package.json
@@ -60,7 +60,7 @@
     "@types/validate-npm-package-name": "^4.0.2",
     "@types/wait-on": "^5.3.4",
     "tsup": "^8.5.0",
-    "typescript": "7.0.2"
+    "typescript": "5.9.3"
   },
   "engines": {
     "node": ">=20"

--- a/packages/dashboard-sdk/package.json
+++ b/packages/dashboard-sdk/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/node": "^26.1.0",
     "tsup": "^8.0.2",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "vite": "^8.1.3",
     "@types/react": "^19.2.17"
   }

--- a/packages/dashboard-shared/package.json
+++ b/packages/dashboard-shared/package.json
@@ -67,7 +67,7 @@
     "@mercurjs/core": "2.2.0-canary.52",
     "@mercurjs/dashboard-sdk": "2.2.0-canary.52",
     "tsup": "^8.0.2",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "@types/lodash.debounce": "^4.0.8",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^18.2.22"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -39,7 +39,7 @@
     "@medusajs/types": "2.17.2"
   },
   "devDependencies": {
-    "typescript": "7.0.2"
+    "typescript": "5.9.3"
   },
   "engines": {
     "node": ">=20"

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -86,7 +86,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^4.3.2",
     "tsup": "^8.0.2",
-    "typescript": "7.0.2",
+    "typescript": "5.9.3",
     "@medusajs/types": "2.17.2",
     "@mercurjs/core": "2.2.0-canary.52",
     "@mercurjs/dashboard-sdk": "2.2.0-canary.52",


### PR DESCRIPTION
## Problem

The `main` build is failing in CI ([run 29019194035](https://github.com/mercurjs/mercur/actions/runs/29019194035/job/86121489158)):

```
TypeError [Error]: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')
    at .../rollup-plugin-dts@6.1.1_.../rollup-plugin-dts.cjs
```

This was introduced by #1210, which bumped TypeScript from 5.9.3 to **7.0.2**. TypeScript 7 is incompatible with the `rollup-plugin-dts` version that tsup uses to emit declaration files, so the `@mercurjs/client` build crashes.

## Fix

Roll TypeScript back to `5.9.3` across all workspace packages and regenerate the lockfile.

## Verification

- `bun run build` passes locally (all 11 tasks successful).