### PR TITLE
fix(core): grant super-admin role to invited admins on account creation

### DIFF
--- a/integration-tests/http/user/admin/invited-admin-role.spec.ts
+++ b/integration-tests/http/user/admin/invited-admin-role.spec.ts
@@ -1,0 +1,80 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+
+import assignAdminSuperAdminRoleHandler from "@mercurjs/core/subscribers/assign-admin-super-admin-role"
+
+jest.setTimeout(60_000)
+
+const SUPER_ADMIN_ROLE_ID = "role_super_admin"
+
+const rolesOf = async (container: MedusaContainer, userId: string) => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "user",
+    fields: ["id", "rbac_roles.id"],
+    filters: { id: userId },
+  })
+  return (data?.[0]?.rbac_roles ?? []).map((r: { id: string }) => r.id)
+}
+
+const runHandler = (container: MedusaContainer, userId: string) =>
+  assignAdminSuperAdminRoleHandler({
+    event: { data: { id: userId } },
+    container,
+  } as never)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer }) => {
+    describe("Invited admin gets the super-admin role", () => {
+      let container: MedusaContainer
+
+      beforeAll(async () => {
+        container = getContainer()
+      })
+
+      it("assigns role_super_admin to a role-less admin user", async () => {
+        const userModule = container.resolve(Modules.USER)
+        const user = await userModule.createUsers({
+          email: `invited-${Date.now()}@medusa.js`,
+          first_name: "Invited",
+          last_name: "Admin",
+        })
+
+        expect(await rolesOf(container, user.id)).toHaveLength(0)
+
+        await runHandler(container, user.id)
+
+        expect(await rolesOf(container, user.id)).toContain(
+          SUPER_ADMIN_ROLE_ID
+        )
+      })
+
+      it("leaves an admin that already has a role untouched", async () => {
+        const userModule = container.resolve(Modules.USER)
+        const rbac: any = container.resolve(Modules.RBAC)
+        const link = container.resolve(ContainerRegistrationKeys.LINK)
+
+        const user = await userModule.createUsers({
+          email: `scoped-${Date.now()}@medusa.js`,
+          first_name: "Scoped",
+          last_name: "Admin",
+        })
+        const role = await rbac.createRbacRoles({ name: "Scoped Admin" })
+        await link.create({
+          [Modules.USER]: { user_id: user.id },
+          [Modules.RBAC]: { rbac_role_id: role.id },
+        })
+
+        await runHandler(container, user.id)
+
+        const roles = await rolesOf(container, user.id)
+        expect(roles).toEqual([role.id])
+        expect(roles).not.toContain(SUPER_ADMIN_ROLE_ID)
+      })
+    })
+  },
+})

--- a/packages/core/src/subscribers/assign-admin-super-admin-role.ts
+++ b/packages/core/src/subscribers/assign-admin-super-admin-role.ts
@@ -1,0 +1,71 @@
+import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import {
+  ContainerRegistrationKeys,
+  FeatureFlag,
+  Modules,
+  UserWorkflowEvents,
+} from "@medusajs/framework/utils"
+
+const SUPER_ADMIN_ROLE_ID = "role_super_admin"
+
+/**
+ * Grants the seeded super-admin role to admin users created without any role.
+ *
+ * With the `rbac` feature flag on (always the case under `withMercur`), Medusa
+ * forbids any role-less admin from every policy-gated route — so an admin who
+ * accepts an invite that carried no role lands on a 403 the moment the panel
+ * boots. The seed CLI already assigns `role_super_admin` to the first admin;
+ * this mirrors that for invited admins so the marketplace has no half-created
+ * accounts that can authenticate but not use the panel.
+ */
+export default async function assignAdminSuperAdminRoleHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  if (!FeatureFlag.isFeatureEnabled("rbac")) {
+    return
+  }
+
+  const userId = event.data.id
+  if (!userId) {
+    return
+  }
+
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const link = container.resolve(ContainerRegistrationKeys.LINK)
+
+  const { data: users } = await query.graph({
+    entity: "user",
+    fields: ["id", "rbac_roles.id"],
+    filters: { id: userId },
+  })
+
+  const user = users?.[0] as
+    | { id: string; rbac_roles?: { id: string }[] | null }
+    | undefined
+
+  if (!user || user.rbac_roles?.length) {
+    return
+  }
+
+  const rbacService = container.resolve(Modules.RBAC)
+  const [superAdminRole] = await rbacService.listRbacRoles({
+    id: SUPER_ADMIN_ROLE_ID,
+  })
+
+  if (!superAdminRole) {
+    return
+  }
+
+  await link.create({
+    [Modules.USER]: { user_id: user.id },
+    [Modules.RBAC]: { rbac_role_id: superAdminRole.id },
+  })
+}
+
+export const config: SubscriberConfig = {
+  event: UserWorkflowEvents.CREATED,
+  context: {
+    subscriberId: "assign-admin-super-admin-role-handler",
+  },
+}


### PR DESCRIPTION
## Problem

A **403 Forbidden** is returned when an admin invited through the Admin Dashboard invitation flow logs in.

## Root cause

`withMercur()` enables Medusa's `rbac` feature flag. With RBAC on, every core admin route that declares `policies` (e.g. `/admin/users`, the RBAC/roles pages) runs `checkPermissions`, which **throws `FORBIDDEN` the moment `app_metadata.roles` is empty**:

```js
const roleIds = authContext?.app_metadata?.roles || []
if (!roleIds.length) {
  throw new MedusaError(MedusaError.Types.FORBIDDEN, "Forbidden")
}
```

The seeded first admin works because both the `medusa user` CLI and the `create-super-admin-role` migration link it to the pre-seeded `role_super_admin`. But an invited admin only receives a role if the **invite carried one** (`acceptInviteWorkflow` → `getInviteRolesStep`). Mercur invites carry no role, so the invited user is created role-less and every policy-gated route 403s — the panel is unusable even though login itself succeeds.

## Fix

Add a `user.created` subscriber that links any role-less admin user to the seeded `role_super_admin`, mirroring what the seed CLI / migration already do for the first admin. It is a no-op when:

- the `rbac` flag is off,
- the user already has a role (e.g. an invite that did carry roles), or
- `role_super_admin` is not present.

## Tests

`integration-tests/http/user/admin/invited-admin-role.spec.ts`:
- assigns `role_super_admin` to a role-less admin user, and
- leaves an admin that already has a role untouched.