### PR TITLE
fix(panels): respect base path on session-expiry login redirect

### DIFF
--- a/packages/admin/src/lib/client/client.ts
+++ b/packages/admin/src/lib/client/client.ts
@@ -2,6 +2,8 @@ import { createClient, InferClient } from '@mercurjs/client'
 import { Routes } from '@mercurjs/core/_generated'
 import config from 'virtual:mercur/config'
 
+import { assetUrl } from '../../utils/asset-url'
+
 export const backendUrl = config.backendUrl ?? 'http://localhost:9000'
 
 export const sdk: InferClient<Routes> = createClient({
@@ -66,7 +68,7 @@ export const fetchQuery = async (
     const errorData = await response.json()
 
     if (response.status === 401) {
-      window.location.href = '/login?reason=Unauthorized'
+      window.location.href = `${assetUrl('/login')}?reason=Unauthorized`
       return
     }
 

--- a/packages/admin/src/utils/asset-url.ts
+++ b/packages/admin/src/utils/asset-url.ts
@@ -1,0 +1,8 @@
+export function assetUrl(path: string): string {
+  const base = (typeof __BASE__ !== "undefined" ? __BASE__ : "/").replace(
+    /\/+$/,
+    ""
+  )
+  const cleanPath = path.startsWith("/") ? path : `/${path}`
+  return `${base}${cleanPath}`
+}

--- a/packages/vendor/src/lib/client/client.ts
+++ b/packages/vendor/src/lib/client/client.ts
@@ -2,6 +2,8 @@ import { createClient, InferClient } from '@mercurjs/client'
 import { Routes } from '@mercurjs/core/_generated'
 import config from 'virtual:mercur/config'
 
+import { assetUrl } from '../../utils/asset-url'
+
 export const backendUrl = config.backendUrl ?? 'http://localhost:9000'
 
 export const sdk: InferClient<Routes> = createClient({
@@ -66,7 +68,7 @@ export const fetchQuery = async (
     const errorData = await response.json()
 
     if (response.status === 401) {
-      window.location.href = '/login?reason=Unauthorized'
+      window.location.href = `${assetUrl('/login')}?reason=Unauthorized`
       return
     }
 


### PR DESCRIPTION
## Problem

Closes #1173.

When a panel session expires (or an unauthenticated request fires), the `fetchQuery` 401 handler in both dashboards redirected with a hard-coded origin-root path:

```ts
window.location.href = '/login?reason=Unauthorized'
```

On the documented single-origin deployment — admin built with base `/dashboard`, vendor with base `/seller`, served next to the API on one origin — there is nothing at `/<origin>/login`, so operators/sellers land on a **404 dead end** instead of the login form.

Every React-Router redirect (`<Navigate to="/login">`, `navigate("/login")`) already resolves against the router `basename`, so those were fine. Only these two raw `window.location` redirects bypassed the base path.

## Fix

Route the redirect through the `assetUrl` helper, which prefixes `__BASE__` — the exact value fed to the router `basename` in `app.tsx`. The redirect now lands on `<base>/login` (`/seller/login`, `/dashboard/login`), and stays `/login` when no base is configured (default `/`).

- `packages/vendor/src/lib/client/client.ts` — reuse the existing `assetUrl` helper.
- `packages/admin/src/utils/asset-url.ts` — add the same helper (mirrors vendor) since admin had none.
- `packages/admin/src/lib/client/client.ts` — use it in the 401 handler.

## Tests

Added `packages/vendor/src/utils/asset-url.spec.ts` covering the base-path prefixing (incl. the `/login` regression, trailing-slash normalization, and the default-root fallback). All 4 pass under vitest.

Both `@mercurjs/admin` and `@mercurjs/vendor` build clean; changed files lint clean.