### PR TITLE
chore(create-app): default to basic template without prompting

### DIFF
--- a/packages/create-mercur-app/src/commands/create.ts
+++ b/packages/create-mercur-app/src/commands/create.ts
@@ -104,24 +104,26 @@ export const create = new Command()
 
       let template = opts.template;
       if (!template) {
-        const { selectedTemplate } = await prompts({
-          type: "select",
-          name: "selectedTemplate",
-          message: `Which ${highlighter.info(
-            "template"
-          )} would you like to use?`,
-          choices: Object.entries(CREATE_TEMPLATES).map(([key, tmpl]) => ({
-            title: key,
-            value: key,
-            description: tmpl.description,
-          })),
-        });
-
-        if (!selectedTemplate) {
-          process.exit(0);
-        }
-
-        template = selectedTemplate;
+        // todo: re-enable template selection once more templates are ready
+        // const { selectedTemplate } = await prompts({
+        //   type: "select",
+        //   name: "selectedTemplate",
+        //   message: `Which ${highlighter.info(
+        //     "template"
+        //   )} would you like to use?`,
+        //   choices: Object.entries(CREATE_TEMPLATES).map(([key, tmpl]) => ({
+        //     title: key,
+        //     value: key,
+        //     description: tmpl.description,
+        //   })),
+        // });
+        //
+        // if (!selectedTemplate) {
+        //   process.exit(0);
+        // }
+        //
+        // template = selectedTemplate;
+        template = "basic";
       }
 
       if (!opts.skipEmail) {


### PR DESCRIPTION
## What

`create-mercur-app` no longer prompts for a template. When no `-t/--template` is passed, it defaults to `basic`.

## Why

Only the `basic` template is production-ready right now. Hiding the selection avoids surfacing incomplete options (`plugin`, WIP `registry`).

## Notes

- The template-selection `prompts(...)` block is commented out (not deleted) so it can be re-enabled once more templates are ready.
- `CREATE_TEMPLATES` is kept intact since `downloadTemplate` still resolves the template path from it.
- Passing `-t/--template` explicitly still works as before.