### PR TITLE
fix(create-mercur-app): always pull template from main branch

### DIFF
--- a/packages/create-mercur-app/src/commands/create.ts
+++ b/packages/create-mercur-app/src/commands/create.ts
@@ -14,7 +14,7 @@ import terminalLink from "terminal-link";
 import validateProjectName from "validate-npm-package-name";
 import waitOn from "wait-on";
 
-import packageJson from "../../package.json";
+// import packageJson from "../../package.json";
 import {
   sendTelemetryEvent,
   setTelemetryEmail,
@@ -31,8 +31,7 @@ import { logger } from "../utils/logger";
 import { manageEnvFiles } from "../utils/manage-env-files";
 import { spinner } from "../utils/spinner";
 
-const IS_CANARY = packageJson.version?.includes("-canary");
-const DEFAULT_BRANCH = IS_CANARY ? "canary" : "main";
+const DEFAULT_BRANCH = "main";
 const MIN_SUPPORTED_NODE_VERSION = 20;
 
 const CREATE_TEMPLATES = {


### PR DESCRIPTION
## Problem

`create-mercur-app` downloaded the template tarball from the `canary` branch whenever the published CLI was a canary build (`IS_CANARY ? "canary" : "main"`). This meant `bun create mercur-app@<version>` could scaffold a project from an unexpected branch rather than `main`, and the generated project's pinned versions did not correspond to the requested CLI version.

## Change

Always download the template from the `main` branch, removing the canary branch switch.

## Notes

The `@<version>` in `bun create mercur-app@<version>` still only selects the CLI version — the template is now consistently sourced from `main`.