### PR TITLE
fix(vendor): update auth footer strings on language switch

### DIFF
--- a/packages/vendor/src/pages/login/login.tsx
+++ b/packages/vendor/src/pages/login/login.tsx
@@ -163,12 +163,14 @@ const LoginForm = () => {
 };
 
 const LoginFooter = () => {
+  const { t } = useTranslation();
   const { feature_flags } = useFeatureFlags();
 
   return (
     <div className="mt-auto flex flex-col gap-y-2">
       <span className="text-ui-fg-muted txt-small">
         <Trans
+          t={t}
           i18nKey="login.forgotPassword"
           components={[
             <Link
@@ -182,6 +184,7 @@ const LoginFooter = () => {
       {feature_flags?.[MercurFeatureFlags.SELLER_REGISTRATION] && (
         <span className="text-ui-fg-muted txt-small">
           <Trans
+            t={t}
             i18nKey="login.notSellerYet"
             components={[
               <Link

--- a/packages/vendor/src/pages/register/register.tsx
+++ b/packages/vendor/src/pages/register/register.tsx
@@ -148,10 +148,13 @@ const RegisterForm = () => {
 }
 
 const RegisterFooter = () => {
+  const { t } = useTranslation()
+
   return (
     <div className="mt-auto">
       <span className="text-ui-fg-muted txt-small">
         <Trans
+          t={t}
           i18nKey="register.alreadySeller"
           components={[
             <Link


### PR DESCRIPTION
## Problem

On the vendor login and register pages, the footer strings only updated **after a full page refresh** when switching languages via the language switcher:

- "Forgot password? Reset"
- "Don't have a store yet? Create an account"
- "Already a seller? …" (register)

The rest of each page switched instantly.

## Root cause

These footer components (`LoginFooter`, `RegisterFooter`) render the strings through `<Trans>` but never called `useTranslation()`. `<Trans>` does not subscribe to i18next's `languageChanged` event on its own — only the `useTranslation()` hook does and triggers a re-render. Since the footer components subscribed to nothing translation-related, they only re-rendered (and picked up the new language) on a page refresh.

## Fix

Add `useTranslation()` to each footer component and pass `t` to `<Trans>`, so they re-render live when the language changes. `<Trans>` is kept because the link is inline within the translated sentence (`<0>…</0>`), which lets translators keep natural word order per locale.

reset-password was already correct — its `<Trans>` usages sit inside components that call `useTranslation()`.

## Scope

- `packages/vendor/src/pages/login/login.tsx`
- `packages/vendor/src/pages/register/register.tsx`