### PR TITLE
fix(template): drop product-level shipping profile and guard fulfillment set in seed

### DIFF
--- a/templates/basic/packages/api/src/scripts/seed.ts
+++ b/templates/basic/packages/api/src/scripts/seed.ts
@@ -387,7 +387,10 @@ export default async function seedDemoData({ container }: ExecArgs) {
     fields: ["id", "fulfillment_sets.id"],
     filters: { id: sellerStockLocation.id },
   });
-  const sellerFulfillmentSetId = locationWithSet.fulfillment_sets![0].id;
+  const sellerFulfillmentSetId = locationWithSet?.fulfillment_sets?.[0]?.id;
+  if (!sellerFulfillmentSetId) {
+    throw new Error("Seller fulfillment set was not created");
+  }
 
   const { result: sellerServiceZones } = await createServiceZonesWorkflow(
     container
@@ -483,7 +486,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
           handle: "t-shirt",
           weight: 400,
           status: ProductStatus.PUBLISHED,
-          shipping_profile_id: sellerShippingProfileId,
           seller_ids: [demoSeller.id],
           images: [
             { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/tee-black-front.png" },
@@ -517,7 +519,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
           handle: "sweatshirt",
           weight: 400,
           status: ProductStatus.PUBLISHED,
-          shipping_profile_id: sellerShippingProfileId,
           seller_ids: [demoSeller.id],
           images: [
             { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/sweatshirt-vintage-front.png" },
@@ -544,7 +545,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
           handle: "sweatpants",
           weight: 400,
           status: ProductStatus.PUBLISHED,
-          shipping_profile_id: sellerShippingProfileId,
           seller_ids: [demoSeller.id],
           images: [
             { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/sweatpants-gray-front.png" },
@@ -571,7 +571,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
           handle: "shorts",
           weight: 400,
           status: ProductStatus.PUBLISHED,
-          shipping_profile_id: sellerShippingProfileId,
           seller_ids: [demoSeller.id],
           images: [
             { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/shorts-vintage-front.png" },


### PR DESCRIPTION
## Summary

Follow-up to #1233. With the template's real `node_modules` types resolved, `bun run build` still surfaced two remaining errors in `templates/basic/packages/api/src/scripts/seed.ts`.

## Changes

- **`shipping_profile_id` invalid on `CreateProductDTO`** — removed the product-level `shipping_profile_id` from all four seeded products. Shipping is offer-scoped in Mercur; the offers and shipping options created in the script still set it where valid.
- **`fulfillment_sets` possibly null** — replaced the non-null assertion with optional chaining plus an explicit guard/throw, so `tsc` no longer flags the lookup as possibly null and a genuinely missing fulfillment set fails loudly.

## Testing

Each change maps directly to a reported `tsc` error. A local build wasn't run (the generated test projects that carry `node_modules` are ephemeral); CI validates the full build.