### PR TITLE
fix(template): drop product-level sales_channels in seed

### DIFF
--- a/templates/basic/packages/api/src/scripts/seed.ts
+++ b/templates/basic/packages/api/src/scripts/seed.ts
@@ -507,7 +507,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
             { title: "XL / Black", sku: "SHIRT-XL-BLACK", options: { Size: "XL", Color: "Black" } },
             { title: "XL / White", sku: "SHIRT-XL-WHITE", options: { Size: "XL", Color: "White" } },
           ],
-          sales_channels: [{ id: defaultSalesChannel[0].id }],
         },
         {
           title: "Basic Sweatshirt",
@@ -533,7 +532,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
             { title: "L", sku: "SWEATSHIRT-L", options: { Size: "L" } },
             { title: "XL", sku: "SWEATSHIRT-XL", options: { Size: "XL" } },
           ],
-          sales_channels: [{ id: defaultSalesChannel[0].id }],
         },
         {
           title: "Basic Sweatpants",
@@ -559,7 +557,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
             { title: "L", sku: "SWEATPANTS-L", options: { Size: "L" } },
             { title: "XL", sku: "SWEATPANTS-XL", options: { Size: "XL" } },
           ],
-          sales_channels: [{ id: defaultSalesChannel[0].id }],
         },
         {
           title: "Basic Shorts",
@@ -585,7 +582,6 @@ export default async function seedDemoData({ container }: ExecArgs) {
             { title: "L", sku: "SHORTS-L", options: { Size: "L" } },
             { title: "XL", sku: "SHORTS-XL", options: { Size: "XL" } },
           ],
-          sales_channels: [{ id: defaultSalesChannel[0].id }],
         },
       ],
     },


### PR DESCRIPTION
## Summary

Follow-up to #1234. `bun run build` still failed on the template seed script (`templates/basic/packages/api/src/scripts/seed.ts`) because the four seeded products passed `sales_channels`, which is not part of Mercur's `CreateProduct` input type.

## Changes

- Removed the product-level `sales_channels` from all four seeded products.

The default sales channel is still wired up — via the store's `default_sales_channel_id` and the publishable API key link — so seeding behavior is unchanged.

## Testing

Maps directly to the reported `tsc` errors (lines 510/536/562/588). CI validates the full build.