### PR TITLE
fix(payout): reconcile Stripe account forward instead of orphaning on failure

### DIFF
--- a/packages/core/src/modules/payout/services/payout-module-service.ts
+++ b/packages/core/src/modules/payout/services/payout-module-service.ts
@@ -92,7 +92,16 @@ export default class PayoutModuleService extends MedusaService({
                 sharedContext
             )
         } catch (error) {
-            if (payoutAccount?.id) {
+            if (providerAccount && payoutAccount?.id) {
+                await this.updatePayoutAccounts(
+                    {
+                        id: payoutAccount.id,
+                        data: providerAccount.data,
+                        status: providerAccount.status,
+                    },
+                    sharedContext
+                ).catch(() => null)
+            } else if (payoutAccount?.id) {
                 await this.deletePayoutAccounts(payoutAccount.id, sharedContext)
             }
             throw error


### PR DESCRIPTION
## Problem

Closes #1262.

`PayoutModuleService.createPayoutAccount` performs three non-atomic steps: create the local `pacc_…` row, create the remote Stripe connected account (`acct_…`), then persist the Stripe result back onto the local row. If that final persist throws, the original `catch` deleted the local row unconditionally — leaving the Stripe account orphaned with no local reference.

Because the local row id is also the Stripe idempotency key (`idempotency_key: payoutAccount.id`), deleting the row additionally defeated idempotency: a retry mints a new row → new key → a *second* orphaned account.

## Fix

The `catch` now branches on whether the remote was actually created:

- **Remote not created** (`providerAccount` is null — e.g. validation error before the Stripe call): delete the local row as before. No orphan.
- **Remote created** (Stripe returned `acct_…` but the local persist failed): do not delete. Reconcile the Stripe id/status forward onto the row (best-effort). If that also fails, the row is left intact so a retry adopts the same account via the existing idempotency key.

## Notes

This is a deliberately minimal, right-sized fix. The issue also proposes a durable outbox / adoption-workflow subsystem; that is not necessary here — the Stripe account is already tagged with `metadata.account_id = pacc_id` (so orphans are traceable), and the idempotency key already prevents duplicate creation once the row is preserved.

## Verification

- `@mercurjs/core` builds clean.
- Happy path is unchanged (the change lives entirely inside the existing `catch`).