### PR TITLE
fix(registry): ship core-flows in scaffold to avoid duplicate workflow registration

### DIFF
--- a/packages/registry/r/product-import-export.json
+++ b/packages/registry/r/product-import-export.json
@@ -4,11 +4,10 @@
   "description": "CSV product import & export for vendors. Includes API routes, workflows, and vendor portal drawers.",
   "dependencies": [
     "multer",
-    "@types/multer",
-    "@medusajs/core-flows"
+    "@types/multer"
   ],
   "registryDependencies": [],
-  "docs": "## Product Import/Export Block\n\n### Dependencies\n\nInstall dependencies in the **API workspace** (not the project root):\n\n```bash\ncd packages/api\nbun add @medusajs/core-flows multer @types/multer\n```\n\n### Configuration\n\nNo additional modules needed — uses built-in Medusa product CSV steps.\n\n### Middleware Setup\n\nAdd the import middleware to your `api/middlewares.ts`:\n\n```ts\nimport { defineMiddlewares } from '@medusajs/medusa'\nimport { productImportExportMiddlewares } from './vendor/products/middlewares'\n\nexport default defineMiddlewares({\n  routes: [...productImportExportMiddlewares],\n})\n```\n\n### Run codegen\n\nAfter installing the block, regenerate SDK types:\n\n```bash\nnpx @mercurjs/cli@latest codegen\n```\n\n### Vendor Navigation\n\nThe block includes a `products/page.tsx` that overrides the default product list page, adding Import and Export buttons in the header. The buttons open drawer routes at `/products/import` and `/products/export`.",
+  "docs": "## Product Import/Export Block\n\n### Dependencies\n\nInstall dependencies in the **API workspace** (not the project root):\n\n```bash\ncd packages/api\nbun add multer @types/multer\n```\n\n### Configuration\n\nNo additional modules needed — uses built-in Medusa product CSV steps.\n\n### Middleware Setup\n\nAdd the import middleware to your `api/middlewares.ts`:\n\n```ts\nimport { defineMiddlewares } from '@medusajs/medusa'\nimport { productImportExportMiddlewares } from './vendor/products/middlewares'\n\nexport default defineMiddlewares({\n  routes: [...productImportExportMiddlewares],\n})\n```\n\n### Run codegen\n\nAfter installing the block, regenerate SDK types:\n\n```bash\nnpx @mercurjs/cli@latest codegen\n```\n\n### Vendor Navigation\n\nThe block includes a `products/page.tsx` that overrides the default product list page, adding Import and Export buttons in the header. The buttons open drawer routes at `/products/import` and `/products/export`.",
   "categories": [
     "api",
     "workflow",

--- a/packages/registry/r/registry.json
+++ b/packages/registry/r/registry.json
@@ -224,11 +224,10 @@
       "description": "CSV product import & export for vendors. Includes API routes, workflows, and vendor portal drawers.",
       "dependencies": [
         "multer",
-        "@types/multer",
-        "@medusajs/core-flows"
+        "@types/multer"
       ],
       "registryDependencies": [],
-      "docs": "## Product Import/Export Block\n\n### Dependencies\n\nInstall dependencies in the **API workspace** (not the project root):\n\n```bash\ncd packages/api\nbun add @medusajs/core-flows multer @types/multer\n```\n\n### Configuration\n\nNo additional modules needed \u2014 uses built-in Medusa product CSV steps.\n\n### Middleware Setup\n\nAdd the import middleware to your `api/middlewares.ts`:\n\n```ts\nimport { defineMiddlewares } from '@medusajs/medusa'\nimport { productImportExportMiddlewares } from './vendor/products/middlewares'\n\nexport default defineMiddlewares({\n  routes: [...productImportExportMiddlewares],\n})\n```\n\n### Run codegen\n\nAfter installing the block, regenerate SDK types:\n\n```bash\nnpx @mercurjs/cli@latest codegen\n```\n\n### Vendor Navigation\n\nThe block includes a `products/page.tsx` that overrides the default product list page, adding Import and Export buttons in the header. The buttons open drawer routes at `/products/import` and `/products/export`.",
+      "docs": "## Product Import/Export Block\n\n### Dependencies\n\nInstall dependencies in the **API workspace** (not the project root):\n\n```bash\ncd packages/api\nbun add multer @types/multer\n```\n\n### Configuration\n\nNo additional modules needed \u2014 uses built-in Medusa product CSV steps.\n\n### Middleware Setup\n\nAdd the import middleware to your `api/middlewares.ts`:\n\n```ts\nimport { defineMiddlewares } from '@medusajs/medusa'\nimport { productImportExportMiddlewares } from './vendor/products/middlewares'\n\nexport default defineMiddlewares({\n  routes: [...productImportExportMiddlewares],\n})\n```\n\n### Run codegen\n\nAfter installing the block, regenerate SDK types:\n\n```bash\nnpx @mercurjs/cli@latest codegen\n```\n\n### Vendor Navigation\n\nThe block includes a `products/page.tsx` that overrides the default product list page, adding Import and Export buttons in the header. The buttons open drawer routes at `/products/import` and `/products/export`.",
       "files": [
         {
           "path": "product-import-export/workflows/steps/get-seller-products.ts",

--- a/packages/registry/registry.json
+++ b/packages/registry/registry.json
@@ -224,11 +224,10 @@
       "description": "CSV product import & export for vendors. Includes API routes, workflows, and vendor portal drawers.",
       "dependencies": [
         "multer",
-        "@types/multer",
-        "@medusajs/core-flows"
+        "@types/multer"
       ],
       "registryDependencies": [],
-      "docs": "## Product Import/Export Block\n\n### Dependencies\n\nInstall dependencies in the **API workspace** (not the project root):\n\n```bash\ncd packages/api\nbun add @medusajs/core-flows multer @types/multer\n```\n\n### Configuration\n\nNo additional modules needed \u2014 uses built-in Medusa product CSV steps.\n\n### Middleware Setup\n\nAdd the import middleware to your `api/middlewares.ts`:\n\n```ts\nimport { defineMiddlewares } from '@medusajs/medusa'\nimport { productImportExportMiddlewares } from './vendor/products/middlewares'\n\nexport default defineMiddlewares({\n  routes: [...productImportExportMiddlewares],\n})\n```\n\n### Run codegen\n\nAfter installing the block, regenerate SDK types:\n\n```bash\nnpx @mercurjs/cli@latest codegen\n```\n\n### Vendor Navigation\n\nThe block includes a `products/page.tsx` that overrides the default product list page, adding Import and Export buttons in the header. The buttons open drawer routes at `/products/import` and `/products/export`.",
+      "docs": "## Product Import/Export Block\n\n### Dependencies\n\nInstall dependencies in the **API workspace** (not the project root):\n\n```bash\ncd packages/api\nbun add multer @types/multer\n```\n\n### Configuration\n\nNo additional modules needed \u2014 uses built-in Medusa product CSV steps.\n\n### Middleware Setup\n\nAdd the import middleware to your `api/middlewares.ts`:\n\n```ts\nimport { defineMiddlewares } from '@medusajs/medusa'\nimport { productImportExportMiddlewares } from './vendor/products/middlewares'\n\nexport default defineMiddlewares({\n  routes: [...productImportExportMiddlewares],\n})\n```\n\n### Run codegen\n\nAfter installing the block, regenerate SDK types:\n\n```bash\nnpx @mercurjs/cli@latest codegen\n```\n\n### Vendor Navigation\n\nThe block includes a `products/page.tsx` that overrides the default product list page, adding Import and Export buttons in the header. The buttons open drawer routes at `/products/import` and `/products/export`.",
       "files": [
         {
           "path": "product-import-export/workflows/steps/get-seller-products.ts",

--- a/templates/basic/packages/api/package.json
+++ b/templates/basic/packages/api/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@medusajs/admin-sdk": "2.17.2",
     "@medusajs/cli": "2.17.2",
+    "@medusajs/core-flows": "2.17.2",
     "@medusajs/framework": "2.17.2",
     "@medusajs/dashboard": "2.17.2",
     "@medusajs/admin-shared": "2.17.2",


### PR DESCRIPTION
Fixes #1264

## Problem

Installing the `product-import-export` block breaks the API boot with:

```
Error starting server: Workflow with id "create-payment-sessions" and step definition already exists.
```

`create-payment-sessions` is a built-in Medusa core-flow, not block code.

## Root cause

`@medusajs/core-flows` self-registers all its workflows into a process-level singleton (`WorkflowManager`) on import — a given workflow id may be registered exactly once per process. Two physical copies loading in one process → double registration → crash.

The second copy appears because of bun's isolated linker:

- At scaffold time `@medusajs/core-flows` is **transitive-only** → one copy.
- The `product-import-export` block declared it as a **direct** dependency, so `bun add @medusajs/core-flows` promotes it. The isolated linker re-resolves it in a new peer-dependency context (`+<hash>`) → a **second** physical copy binding to a second `@medusajs/framework`.
- Both copies load and both register → boot fails. (Same underlying cause also surfaced as the Vite `Rollup failed to resolve "i18next"` build error.)

It is not a version mismatch — bare `@medusajs/core-flows` already resolves to `2.17.2`, same as the rest of the graph.

## Fix

- Declare `@medusajs/core-flows@2.17.2` directly in `templates/basic/packages/api/package.json`, so it is resolved once in the scaffold's peer context at install time.
- Remove `@medusajs/core-flows` from the block's `dependencies` (source `registry.json` + built `r/registry.json` and `r/product-import-export.json`) and update the docs' `bun add` command, so installing the block no longer re-forks the `@medusajs` graph.