### PR TITLE
fix(dashboard-shared): guard useExtendableForm against non-object base schema

### DIFF
--- a/packages/dashboard-shared/src/extensions/use-extendable-form.ts
+++ b/packages/dashboard-shared/src/extensions/use-extendable-form.ts
@@ -66,10 +66,7 @@ export const useExtendableForm = <
       .partial()
       .optional()
 
-    // `.extend` only exists on a plain ZodObject. A refined/wrapped base schema
-    // (e.g. one guarded by `.refine`/`.superRefine`) is a ZodEffects and would
-    // throw "baseSchema.extend is not a function"; compose via intersection so
-    // custom fields still validate.
+    // `.extend` is ZodObject-only; a refined base schema needs intersection.
     return typeof (baseSchema as ZodObject<Record<string, z.ZodTypeAny>>)
       .extend === "function"
       ? baseSchema.extend({ additional_data: additionalData })

--- a/packages/dashboard-shared/src/extensions/use-extendable-form.ts
+++ b/packages/dashboard-shared/src/extensions/use-extendable-form.ts
@@ -61,15 +61,20 @@ export const useExtendableForm = <
 }: UseExtendableFormProps<TSchema, TContext>) => {
   const extension = useExtension()
 
-  const schema = useMemo(
-    () =>
-      baseSchema.extend({
-        additional_data: buildAdditionalDataSchema(extension, model, zone, tab)
-          .partial()
-          .optional(),
-      }),
-    [baseSchema, extension, model, zone, tab]
-  )
+  const schema = useMemo(() => {
+    const additionalData = buildAdditionalDataSchema(extension, model, zone, tab)
+      .partial()
+      .optional()
+
+    // `.extend` only exists on a plain ZodObject. A refined/wrapped base schema
+    // (e.g. one guarded by `.refine`/`.superRefine`) is a ZodEffects and would
+    // throw "baseSchema.extend is not a function"; compose via intersection so
+    // custom fields still validate.
+    return typeof (baseSchema as ZodObject<Record<string, z.ZodTypeAny>>)
+      .extend === "function"
+      ? baseSchema.extend({ additional_data: additionalData })
+      : (baseSchema.and(z.object({ additional_data: additionalData })) as unknown as typeof baseSchema)
+  }, [baseSchema, extension, model, zone, tab])
 
   const defaultValues = useMemo(
     () => ({


### PR DESCRIPTION
Fixes #1270

## Problem

Opening a promotion to **edit** could crash with `TypeError: baseSchema.extend is not a function` ("An unexpected error occurred while rendering this page"). Creating worked; only editing crashed.

## Root cause

`useExtendableForm` (`@mercurjs/dashboard-shared`) called `baseSchema.extend({ additional_data })` **unconditionally**. `.extend` only exists on a plain `ZodObject`. Although the hook's type signature declares `TSchema extends ZodObject`, nothing enforces that at runtime — a refined/wrapped base schema (a `ZodEffects`, e.g. one guarded by `.refine`/`.superRefine`) has no `.extend`, so the call threw and the edit form failed to render.

## Fix

Guard the `.extend` call. When the base schema is a plain object, extend as before. When it isn't, compose the `additional_data` custom-field schema via intersection (`baseSchema.and(...)`) instead of dropping it — so custom fields keep validating regardless of the base schema's shape. This matches how newer `@medusajs/dashboard` handles non-object schemas.

## Verification

- `bun run build --filter=@mercurjs/dashboard-shared` passes (ESM + DTS); the guard is present in the emitted bundle.
- Change is isolated to the shared hook; all existing edit forms (category, collection, customer, price list, promotion, …) keep their current behaviour since their schemas are plain `ZodObject`.