### PR TITLE
feat(create-mercur-app): add optional Next.js storefront step

### DIFF
--- a/packages/create-mercur-app/src/commands/create.ts
+++ b/packages/create-mercur-app/src/commands/create.ts
@@ -64,6 +64,7 @@ export const create = new Command()
     process.cwd()
   )
   .option("--no-deps", "skip installing dependencies.")
+  .option("--skip-storefront", "skip adding the Next.js storefront.", false)
   .option("--skip-db", "skip database configuration.", false)
   .option("--skip-email", "skip email prompt.", false)
   .option("--db-connection-string <string>", "PostgreSQL connection string.")
@@ -125,6 +126,18 @@ export const create = new Command()
         template = "basic";
       }
 
+      let addStorefront = false;
+      if (template === "basic" && !opts.skipStorefront) {
+        const { wantsStorefront } = await prompts({
+          type: "confirm",
+          name: "wantsStorefront",
+          message: `Add a ${highlighter.info("Next.js storefront")}?`,
+          initial: true,
+        });
+
+        addStorefront = Boolean(wantsStorefront);
+      }
+
       if (!opts.skipEmail) {
         const { wantsEmail } = await prompts({
           type: "confirm",
@@ -157,6 +170,18 @@ export const create = new Command()
         template: template,
       });
       downloadSpinner.succeed("Template downloaded successfully.");
+
+      if (addStorefront) {
+        const storefrontSpinner = spinner("Adding Next.js storefront...").start();
+        try {
+          await downloadStorefront({ projectDir });
+          storefrontSpinner.succeed("Next.js storefront added successfully.");
+        } catch (error) {
+          storefrontSpinner.fail(
+            `Failed to add storefront${error instanceof Error ? `: ${error.message}` : ""}.`
+          );
+        }
+      }
 
       const packageManager = await resolveProjectPackageManager();
       await updateRootPackageJson(projectDir, projectName, packageManager);
@@ -332,6 +357,31 @@ async function createOrFindProjectDir(projectDir: string): Promise<void> {
   }
 }
 
+// Extracts a single directory out of the repo tarball. `strip` controls how many
+// leading path segments are removed so files land at the right place under `cwd`.
+async function downloadRepoDir({
+  cwd,
+  repoPath,
+  strip,
+}: {
+  cwd: string;
+  repoPath: string;
+  strip: number;
+}) {
+  const url = `https://codeload.github.com/mercurjs/mercur/tar.gz/${DEFAULT_BRANCH}`;
+  const branchDir = `mercur-${DEFAULT_BRANCH.replace(/^v/, "").replaceAll("/", "-")}`;
+  const filter = `${branchDir}/${repoPath}/`;
+
+  await pipeline(
+    await downloadTarStream(url),
+    x({
+      cwd,
+      filter: (p) => p.includes(filter),
+      strip,
+    })
+  );
+}
+
 async function downloadTemplate({
   projectDir,
   template,
@@ -339,18 +389,29 @@ async function downloadTemplate({
   projectDir: string;
   template: keyof typeof CREATE_TEMPLATES;
 }) {
-  const url = `https://codeload.github.com/mercurjs/mercur/tar.gz/${DEFAULT_BRANCH}`;
   const templatePath = CREATE_TEMPLATES[template].path;
-  const filter = `mercur-${DEFAULT_BRANCH.replace(/^v/, "").replaceAll("/", "-")}/templates/${templatePath}/`;
+  const repoPath = `templates/${templatePath}`;
 
-  await pipeline(
-    await downloadTarStream(url),
-    x({
-      cwd: projectDir,
-      filter: (p) => p.includes(filter),
-      strip: 2 + templatePath.split("/").length,
-    })
-  );
+  // Drop the branch dir + every segment of `repoPath` so the template root
+  // becomes the project root.
+  await downloadRepoDir({
+    cwd: projectDir,
+    repoPath,
+    strip: 1 + repoPath.split("/").length,
+  });
+}
+
+async function downloadStorefront({ projectDir }: { projectDir: string }) {
+  const appsDir = path.join(projectDir, "apps");
+  await fs.ensureDir(appsDir);
+
+  // Drop only the branch dir so files keep their `apps/storefront/...` prefix
+  // and land alongside the other workspace apps.
+  await downloadRepoDir({
+    cwd: projectDir,
+    repoPath: "apps/storefront",
+    strip: 1,
+  });
 }
 
 async function downloadTarStream(url: string) {

--- a/packages/create-mercur-app/src/commands/create.ts
+++ b/packages/create-mercur-app/src/commands/create.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import os from "node:os";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import path from "path";
@@ -165,22 +166,26 @@ export const create = new Command()
       await createOrFindProjectDir(projectDir);
 
       const downloadSpinner = spinner("Downloading template...").start();
-      await downloadTemplate({
-        projectDir,
-        template: template,
-      });
-      downloadSpinner.succeed("Template downloaded successfully.");
+      // Fetch the repo tarball once, then extract each subpath from it locally
+      // so opting into the storefront doesn't trigger a second network download.
+      const tarballPath = await downloadRepoTarball();
+      try {
+        await extractTemplate({ tarballPath, projectDir, template });
+        downloadSpinner.succeed("Template downloaded successfully.");
 
-      if (addStorefront) {
-        const storefrontSpinner = spinner("Adding Next.js storefront...").start();
-        try {
-          await downloadStorefront({ projectDir });
-          storefrontSpinner.succeed("Next.js storefront added successfully.");
-        } catch (error) {
-          storefrontSpinner.fail(
-            `Failed to add storefront${error instanceof Error ? `: ${error.message}` : ""}.`
-          );
+        if (addStorefront) {
+          const storefrontSpinner = spinner("Adding Next.js storefront...").start();
+          try {
+            await extractStorefront({ tarballPath, projectDir });
+            storefrontSpinner.succeed("Next.js storefront added successfully.");
+          } catch (error) {
+            storefrontSpinner.fail(
+              `Failed to add storefront${error instanceof Error ? `: ${error.message}` : ""}.`
+            );
+          }
         }
+      } finally {
+        await fs.remove(tarballPath).catch(() => null);
       }
 
       const packageManager = await resolveProjectPackageManager();
@@ -357,35 +362,55 @@ async function createOrFindProjectDir(projectDir: string): Promise<void> {
   }
 }
 
-// Extracts a single directory out of the repo tarball. `strip` controls how many
+// Downloads the repo tarball once to a temp file. Callers then extract whichever
+// subpaths they need from it locally, avoiding a network fetch per directory.
+async function downloadRepoTarball(): Promise<string> {
+  const url = `https://codeload.github.com/mercurjs/mercur/tar.gz/${DEFAULT_BRANCH}`;
+  const res = await fetch(url);
+
+  if (!res.body) {
+    throw new Error(`Failed to download: ${url}`);
+  }
+
+  const tarballPath = path.join(os.tmpdir(), `mercur-${DEFAULT_BRANCH.replaceAll("/", "-")}-${process.pid}.tar.gz`);
+  await pipeline(
+    Readable.from(res.body as unknown as NodeJS.ReadableStream),
+    fs.createWriteStream(tarballPath)
+  );
+
+  return tarballPath;
+}
+
+// Extracts a single directory out of the local tarball. `strip` controls how many
 // leading path segments are removed so files land at the right place under `cwd`.
-async function downloadRepoDir({
+async function extractRepoDir({
+  tarballPath,
   cwd,
   repoPath,
   strip,
 }: {
+  tarballPath: string;
   cwd: string;
   repoPath: string;
   strip: number;
 }) {
-  const url = `https://codeload.github.com/mercurjs/mercur/tar.gz/${DEFAULT_BRANCH}`;
   const branchDir = `mercur-${DEFAULT_BRANCH.replace(/^v/, "").replaceAll("/", "-")}`;
   const filter = `${branchDir}/${repoPath}/`;
 
-  await pipeline(
-    await downloadTarStream(url),
-    x({
-      cwd,
-      filter: (p) => p.includes(filter),
-      strip,
-    })
-  );
+  await x({
+    file: tarballPath,
+    cwd,
+    filter: (p) => p.includes(filter),
+    strip,
+  });
 }
 
-async function downloadTemplate({
+async function extractTemplate({
+  tarballPath,
   projectDir,
   template,
 }: {
+  tarballPath: string;
   projectDir: string;
   template: keyof typeof CREATE_TEMPLATES;
 }) {
@@ -394,34 +419,31 @@ async function downloadTemplate({
 
   // Drop the branch dir + every segment of `repoPath` so the template root
   // becomes the project root.
-  await downloadRepoDir({
+  await extractRepoDir({
+    tarballPath,
     cwd: projectDir,
     repoPath,
     strip: 1 + repoPath.split("/").length,
   });
 }
 
-async function downloadStorefront({ projectDir }: { projectDir: string }) {
-  const appsDir = path.join(projectDir, "apps");
-  await fs.ensureDir(appsDir);
+async function extractStorefront({
+  tarballPath,
+  projectDir,
+}: {
+  tarballPath: string;
+  projectDir: string;
+}) {
+  await fs.ensureDir(path.join(projectDir, "apps"));
 
   // Drop only the branch dir so files keep their `apps/storefront/...` prefix
   // and land alongside the other workspace apps.
-  await downloadRepoDir({
+  await extractRepoDir({
+    tarballPath,
     cwd: projectDir,
     repoPath: "apps/storefront",
     strip: 1,
   });
-}
-
-async function downloadTarStream(url: string) {
-  const res = await fetch(url);
-
-  if (!res.body) {
-    throw new Error(`Failed to download: ${url}`);
-  }
-
-  return Readable.from(res.body as unknown as NodeJS.ReadableStream);
 }
 
 async function installDeps({

--- a/packages/create-mercur-app/src/utils/manage-env-files.ts
+++ b/packages/create-mercur-app/src/utils/manage-env-files.ts
@@ -56,6 +56,7 @@ const APP_PATHS = [
   { path: "packages/api" },
   { path: "apps/vendor" },
   { path: "apps/admin" },
+  { path: "apps/storefront" },
 ];
 
 export async function manageEnvFiles({


### PR DESCRIPTION
## Summary

Adds an optional step to `create-mercur-app` that scaffolds the Next.js storefront alongside the `basic` template.

When the `basic` template is selected, the CLI now prompts **"Add a Next.js storefront?"** (defaults to yes). On confirm, it downloads `apps/storefront` from the repo tarball into the new project's `apps/storefront` workspace and generates its `.env` from `.env.template` (pointed at `http://localhost:9000`).

A `--skip-storefront` flag is available to opt out non-interactively.

## Changes

- `create.ts`:
  - New `--skip-storefront` flag and optional confirm prompt (only for the `basic` template).
  - Refactored the tarball extraction into a shared `downloadRepoDir({ cwd, repoPath, strip })` helper; `downloadTemplate` and the new `downloadStorefront` both use it.
  - `downloadStorefront` extracts `apps/storefront` with `strip: 1` so files keep their workspace path.
- `manage-env-files.ts`: added `apps/storefront` to `APP_PATHS` so its `.env` is created; the existing `existsSync` guard makes it a no-op when the storefront isn't added.

## Notes

- The storefront's `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` is left blank (from the template) and must be filled in by the user.
- Storefront startup remains manual; the post-create dev-server flow is unchanged.