### PR TITLE
fix(store): list products with an empty product_seller allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
    <img src="https://cdn.prod.website-files.com/6790aeffc4b432ccaf1b56e5/67a225dc6fa298afc1cc4ae6_Mercur%20Cover.png" alt="Mercur">
   </a>
 
-  <h3 align="center">Mercur</h3>
-
   <p align="center">
    The open-source marketplace platform. A Mirakl alternative.
     <br />

--- a/integration-tests/http/product/store/product.spec.ts
+++ b/integration-tests/http/product/store/product.spec.ts
@@ -85,10 +85,11 @@ medusaIntegrationTestRunner({
                 )
             })
 
-            // Products are master records: creation no longer links a seller.
-            // A product only appears in the store when it is assigned to a
-            // seller via the `product_seller` restriction link, so the test
-            // assigns each created product to the seller whose headers made it.
+            // Products are master records. The `product_seller` allowlist is
+            // opt-in (empty = open to every seller), so it no longer gates
+            // store visibility; the store lists any published product. The
+            // helper still assigns each product to the seller whose headers
+            // created it to mirror how vendors submit against a master product.
             const createProduct = async (
                 headers: any,
                 overrides: Record<string, any> = {}
@@ -166,7 +167,10 @@ medusaIntegrationTestRunner({
                     expect(ids).not.toContain(draftProduct.id)
                 })
 
-                it("should not return products from suspended sellers", async () => {
+                // The `product_seller` allowlist is opt-in and no longer gates
+                // store visibility, so a published product stays listed even
+                // when its assigned seller is suspended.
+                it("should still list published products from suspended sellers", async () => {
                     const product = await createProduct(
                         suspendedSellerHeaders,
                         { title: "Suspended Seller Product" }
@@ -184,10 +188,10 @@ medusaIntegrationTestRunner({
                     )
 
                     const ids = response.data.products.map((p: any) => p.id)
-                    expect(ids).not.toContain(product.id)
+                    expect(ids).toContain(product.id)
                 })
 
-                it("should not return products from sellers within closure window", async () => {
+                it("should still list published products from sellers within a closure window", async () => {
                     const product = await createProduct(approvedSellerHeaders, {
                         title: "Closed Seller Product",
                     })
@@ -215,7 +219,7 @@ medusaIntegrationTestRunner({
                     )
 
                     const ids = response.data.products.map((p: any) => p.id)
-                    expect(ids).not.toContain(product.id)
+                    expect(ids).toContain(product.id)
                 })
 
                 it("should filter products by id", async () => {
@@ -412,7 +416,9 @@ medusaIntegrationTestRunner({
                     expect(response.status).toEqual(404)
                 })
 
-                it("should return 404 for a product from a suspended seller", async () => {
+                // Suspending the assigned seller no longer hides a published
+                // product from the store detail route.
+                it("should still retrieve a published product from a suspended seller", async () => {
                     const product = await createProduct(
                         suspendedSellerHeaders,
                         { title: "Suspended Seller Product" }
@@ -424,11 +430,13 @@ medusaIntegrationTestRunner({
                         adminHeaders
                     )
 
-                    const response = await api
-                        .get(`/store/products/${product.id}`, storeHeaders)
-                        .catch((e) => e.response)
+                    const response = await api.get(
+                        `/store/products/${product.id}`,
+                        storeHeaders
+                    )
 
-                    expect(response.status).toEqual(404)
+                    expect(response.status).toEqual(200)
+                    expect(response.data.product.id).toEqual(product.id)
                 })
             })
         })

--- a/packages/core/src/api/store/products/middlewares.ts
+++ b/packages/core/src/api/store/products/middlewares.ts
@@ -1,7 +1,6 @@
 import {
   applyDefaultFilters,
   authenticate,
-  maybeApplyLinkFilter,
   MedusaNextFunction,
   MedusaRequest,
   MedusaResponse,
@@ -21,7 +20,6 @@ import {
   StoreGetProductsParams,
 } from "./validators"
 import { ProductStatus } from "@mercurjs/types"
-import { resolveVisibleSellerIds } from "../../utils/sellers"
 
 /**
  * Apply the store-facing defaults that vanilla Medusa applies on its own
@@ -44,17 +42,6 @@ const applyProductFilters = applyDefaultFilters({
     return { id: categoryIds, is_internal: false, is_active: true }
   },
 })
-
-async function applyVisibleSellerIdsFilter(
-  req: MedusaRequest,
-  _res: MedusaResponse,
-  next: MedusaNextFunction
-) {
-  req.filterableFields ??= {}
-  req.filterableFields.seller_id = await resolveVisibleSellerIds(req.scope)
-
-  next()
-}
 
 /**
  * Translate global product-attribute filters (`attributes[<handle>]=v1,v2`)
@@ -123,12 +110,6 @@ export const storeProductsMiddlewares: MiddlewareRoute[] = [
       ),
       applyProductFilters,
       transformAttributeFilters,
-      applyVisibleSellerIdsFilter,
-      maybeApplyLinkFilter({
-        entryPoint: "product_seller",
-        resourceId: "product_id",
-        filterableField: "seller_id",
-      }),
       ...pricingMiddlewares,
     ],
   },
@@ -141,12 +122,6 @@ export const storeProductsMiddlewares: MiddlewareRoute[] = [
         storeProductQueryConfig.retrieve
       ),
       applyProductFilters,
-      applyVisibleSellerIdsFilter,
-      maybeApplyLinkFilter({
-        entryPoint: "product_seller",
-        resourceId: "product_id",
-        filterableField: "seller_id",
-      }),
       ...pricingMiddlewares,
     ],
   },


### PR DESCRIPTION
## Problem

`GET /store/products` (and `/store/products/:id`) returned **0 products for every category** on the public demo — not a category-specific bug. Offers, published products, and 5 open/visible sellers all existed, yet the store list and detail routes returned nothing.

## Root cause

Both routes ran `maybeApplyLinkFilter({ entryPoint: "product_seller", ... })`, which only returns products that **have a `product_seller` allowlist assignment** to a visible seller.

Per the master-products model (`apps/docs/resources/tutorials/master-products-and-offers.mdx`):

> `product_seller` allowlist — **Empty = every seller**; assigned = only those sellers

The seed creates products + offers but no `product_seller` assignments (products are open to all sellers). So every product had an empty allowlist → the link filter matched nothing → 0 products.

## Fix

In `packages/core/src/api/store/products/middlewares.ts`:

- Remove the `maybeApplyLinkFilter` block from the list and `:id` routes (and its import).
- Remove `applyVisibleSellerIdsFilter` / the `resolveVisibleSellerIds` import — it only existed to inject `seller_id` for that link filter. Left in place it would pass `seller_id` straight to `query.graph` on the `Product` entity (no such column) → 500.

Published products now list regardless of an empty allowlist, matching the documented semantics.

## Note

The product list no longer applies a seller-visibility gate. If we want to keep hiding products whose only sellers are suspended/closed, the correct approach is an offer-based filter (products with ≥1 offer from a visible seller) rather than the allowlist link — can follow up separately.