### PR TITLE
chore(seed): multi-vendor footwear catalog in basic template seed

### DIFF
--- a/templates/basic/packages/api/src/scripts/seed.ts
+++ b/templates/basic/packages/api/src/scripts/seed.ts
@@ -2,8 +2,9 @@ import { ExecArgs } from "@medusajs/framework/types";
 import {
   ContainerRegistrationKeys,
   Modules,
+  toHandle,
 } from "@medusajs/framework/utils";
-import { ProductStatus } from "@mercurjs/types";
+import { ProductStatus, type CreateOfferDTO } from "@mercurjs/types";
 import {
   approveSellerWorkflow,
   createOffersWorkflow,
@@ -240,390 +241,441 @@ export default async function seedDemoData({ container }: ExecArgs) {
 
   logger.info("Seeding product categories...");
   const productModule = container.resolve(Modules.PRODUCT);
-  const categoryNames = ["Shirts", "Sweatshirts", "Pants", "Merch"];
-  const existingCategories = await productModule.listProductCategories({
-    name: categoryNames,
-  });
 
-  let categoryResult;
-  if (existingCategories.length === categoryNames.length) {
-    categoryResult = existingCategories;
-    logger.info("Product categories already exist, skipping.");
-  } else {
-    const categoriesToCreate = categoryNames.filter(
-      (name) => !existingCategories.find((c) => c.name === name)
-    );
-    const { result: newCategories } = await createProductCategoriesWorkflow(
-      container
-    ).run({
+  // Departments (roots) and their sub-categories; array order sets nav `rank`.
+  const CATEGORY_TREE: Record<string, string[]> = {
+    Sandals: ["Slides", "Flip Flops", "Clogs"],
+    Sneakers: ["Low Top", "High Top", "Retro"],
+    Boots: ["Chelsea Boots", "Winter Boots", "Work Boots"],
+    Sport: ["Football", "Running", "Basketball"],
+    Accessories: ["Bags", "Headwear", "Wallets"],
+  };
+  const parentNames = Object.keys(CATEGORY_TREE);
+  const childNames = Object.values(CATEGORY_TREE).flat();
+
+  const existingCats = await productModule.listProductCategories({
+    name: [...parentNames, ...childNames],
+  });
+  type SeededCategory = { id: string; name: string };
+  const catByName = new Map<string, SeededCategory>(
+    existingCats.map((c) => [c.name, { id: c.id, name: c.name }])
+  );
+
+  const missingParents = parentNames.filter((name) => !catByName.has(name));
+  if (missingParents.length) {
+    const { result } = await createProductCategoriesWorkflow(container).run({
       input: {
-        product_categories: categoriesToCreate.map((name) => ({
+        product_categories: missingParents.map((name) => ({
           name,
           is_active: true,
+          rank: parentNames.indexOf(name),
         })),
       },
     });
-    categoryResult = [...existingCategories, ...newCategories];
+    result.forEach((c: SeededCategory) => catByName.set(c.name, c));
+  }
+
+  const childInputs: {
+    name: string;
+    is_active: boolean;
+    rank: number;
+    parent_category_id: string;
+  }[] = [];
+  for (const parent of parentNames) {
+    CATEGORY_TREE[parent].forEach((childName, rank) => {
+      if (!catByName.has(childName)) {
+        childInputs.push({
+          name: childName,
+          is_active: true,
+          rank,
+          parent_category_id: catByName.get(parent)!.id,
+        });
+      }
+    });
+  }
+  if (childInputs.length) {
+    const { result } = await createProductCategoriesWorkflow(container).run({
+      input: { product_categories: childInputs },
+    });
+    result.forEach((c: SeededCategory) => catByName.set(c.name, c));
   }
   logger.info("Finished seeding product categories.");
 
-  const SELLER_EMAIL = "seller@mercur.dev";
   const SELLER_PASSWORD = "supersecret";
+  const SELLER_CONFIGS = [
+    { name: "Sole Society", email: "seller@mercur.dev", first_name: "Demo", last_name: "Seller", city: "Berlin", country_code: "DE", address_1: "Alexanderplatz 1" },
+    { name: "Kickz Corner", email: "kickz@mercur.dev", first_name: "Kai", last_name: "Corner", city: "Amsterdam", country_code: "NL", address_1: "Damrak 12" },
+    { name: "Trailhead Outfitters", email: "trailhead@mercur.dev", first_name: "Tara", last_name: "Head", city: "Munich", country_code: "DE", address_1: "Marienplatz 3" },
+  ];
+  const PRIMARY_SELLER_EMAIL = SELLER_CONFIGS[0].email;
 
   const { data: existingSellers } = await query.graph({
     entity: "seller",
     fields: ["id"],
-    filters: { email: SELLER_EMAIL },
+    filters: { email: PRIMARY_SELLER_EMAIL },
   });
 
   if (existingSellers[0]) {
     logger.info(
-      "Demo seller already exists, skipping seller, product and offer seeding."
+      "Demo sellers already exist, skipping seller, product and offer seeding."
     );
     logger.info("Finished seeding.");
     return;
   }
 
-  logger.info("Seeding demo seller...");
   const authModuleService = container.resolve(Modules.AUTH);
 
-  let authIdentityId: string;
-  const registerResponse = await authModuleService.register("emailpass", {
-    body: { email: SELLER_EMAIL, password: SELLER_PASSWORD },
-  });
+  type SeededSeller = {
+    id: string;
+    name: string;
+    memberId: string;
+    stockLocationId: string;
+    shippingProfileId: string;
+  };
+  const sellers: SeededSeller[] = [];
 
-  if (registerResponse.success && registerResponse.authIdentity) {
-    authIdentityId = registerResponse.authIdentity.id;
-  } else {
-    const [providerIdentity] = await authModuleService.listProviderIdentities({
-      entity_id: SELLER_EMAIL,
-      provider: "emailpass",
+  for (const [index, sellerConfig] of SELLER_CONFIGS.entries()) {
+    logger.info(`Seeding seller "${sellerConfig.name}"...`);
+
+    let authIdentityId: string;
+    const registerResponse = await authModuleService.register("emailpass", {
+      body: { email: sellerConfig.email, password: SELLER_PASSWORD },
     });
-    authIdentityId = providerIdentity.auth_identity_id!;
-  }
 
-  const { result: demoSeller } = await createSellerAccountWorkflow(
-    container
-  ).run({
-    input: {
-      auth_identity_id: authIdentityId,
-      member_email: SELLER_EMAIL,
-      first_name: "Demo",
-      last_name: "Seller",
-      seller: {
-        name: "Demo Store",
-        email: SELLER_EMAIL,
-        currency_code: "eur",
-        description:
-          "A demo marketplace seller with a full catalog of offers.",
-      },
-    },
-  });
+    if (registerResponse.success && registerResponse.authIdentity) {
+      authIdentityId = registerResponse.authIdentity.id;
+    } else {
+      const [providerIdentity] =
+        await authModuleService.listProviderIdentities({
+          entity_id: sellerConfig.email,
+          provider: "emailpass",
+        });
+      authIdentityId = providerIdentity.auth_identity_id!;
+    }
 
-  await approveSellerWorkflow(container).run({
-    input: { seller_id: demoSeller.id },
-  });
-
-  const { data: members } = await query.graph({
-    entity: "member",
-    fields: ["id"],
-    filters: { email: SELLER_EMAIL },
-  });
-  const demoSellerMemberId = members[0].id;
-
-  const { result: sellerStockLocations } =
-    await createSellerStockLocationsWorkflow(container).run({
+    const { result: seller } = await createSellerAccountWorkflow(
+      container
+    ).run({
       input: {
-        seller_id: demoSeller.id,
-        locations: [
-          {
-            name: "Demo Store Warehouse",
-            address: {
-              city: "Berlin",
-              country_code: "DE",
-              address_1: "Alexanderplatz 1",
+        auth_identity_id: authIdentityId,
+        member_email: sellerConfig.email,
+        first_name: sellerConfig.first_name,
+        last_name: sellerConfig.last_name,
+        seller: {
+          name: sellerConfig.name,
+          email: sellerConfig.email,
+          currency_code: "eur",
+          description: `${sellerConfig.name} — a demo marketplace seller.`,
+        },
+      },
+    });
+
+    await approveSellerWorkflow(container).run({
+      input: { seller_id: seller.id },
+    });
+
+    const { data: members } = await query.graph({
+      entity: "member",
+      fields: ["id"],
+      filters: { email: sellerConfig.email },
+    });
+    const memberId = members[0].id;
+
+    const { result: stockLocations } =
+      await createSellerStockLocationsWorkflow(container).run({
+        input: {
+          seller_id: seller.id,
+          locations: [
+            {
+              name: `${sellerConfig.name} Warehouse`,
+              address: {
+                city: sellerConfig.city,
+                country_code: sellerConfig.country_code,
+                address_1: sellerConfig.address_1,
+              },
             },
+          ],
+        },
+      });
+    const stockLocation = stockLocations[0];
+
+    await link.create({
+      [Modules.STOCK_LOCATION]: { stock_location_id: stockLocation.id },
+      [Modules.FULFILLMENT]: { fulfillment_provider_id: "manual_manual" },
+    });
+
+    await linkSalesChannelsToStockLocationWorkflow(container).run({
+      input: {
+        id: stockLocation.id,
+        add: [defaultSalesChannel[0].id],
+      },
+    });
+
+    if (index === 0) {
+      await updateStoresWorkflow(container).run({
+        input: {
+          selector: { id: store.id },
+          update: {
+            default_location_id: stockLocation.id,
+          },
+        },
+      });
+    }
+
+    await createLocationFulfillmentSetWorkflow(container).run({
+      input: {
+        location_id: stockLocation.id,
+        fulfillment_set_data: {
+          name: `${sellerConfig.name} delivery`,
+          type: "shipping",
+        },
+      },
+    });
+
+    const {
+      data: [locationWithSet],
+    } = await query.graph({
+      entity: "stock_location",
+      fields: ["id", "fulfillment_sets.id"],
+      filters: { id: stockLocation.id },
+    });
+    const fulfillmentSetId = locationWithSet?.fulfillment_sets?.[0]?.id;
+    if (!fulfillmentSetId) {
+      throw new Error(
+        `Fulfillment set was not created for seller "${sellerConfig.name}"`
+      );
+    }
+
+    const { result: serviceZones } = await createServiceZonesWorkflow(
+      container
+    ).run({
+      input: {
+        data: [
+          {
+            fulfillment_set_id: fulfillmentSetId,
+            name: `${sellerConfig.name} Europe`,
+            geo_zones: countries.map((country_code) => ({
+              country_code,
+              type: "country" as const,
+            })),
           },
         ],
       },
     });
-  const sellerStockLocation = sellerStockLocations[0];
+    const serviceZoneId = serviceZones[0].id;
 
-  await link.create({
-    [Modules.STOCK_LOCATION]: { stock_location_id: sellerStockLocation.id },
-    [Modules.FULFILLMENT]: { fulfillment_provider_id: "manual_manual" },
-  });
-
-  await linkSalesChannelsToStockLocationWorkflow(container).run({
-    input: {
-      id: sellerStockLocation.id,
-      add: [defaultSalesChannel[0].id],
-    },
-  });
-
-  await updateStoresWorkflow(container).run({
-    input: {
-      selector: { id: store.id },
-      update: {
-        default_location_id: sellerStockLocation.id,
-      },
-    },
-  });
-
-  await createLocationFulfillmentSetWorkflow(container).run({
-    input: {
-      location_id: sellerStockLocation.id,
-      fulfillment_set_data: {
-        name: "Demo Store delivery",
-        type: "shipping",
-      },
-    },
-  });
-
-  const {
-    data: [locationWithSet],
-  } = await query.graph({
-    entity: "stock_location",
-    fields: ["id", "fulfillment_sets.id"],
-    filters: { id: sellerStockLocation.id },
-  });
-  const sellerFulfillmentSetId = locationWithSet?.fulfillment_sets?.[0]?.id;
-  if (!sellerFulfillmentSetId) {
-    throw new Error("Seller fulfillment set was not created");
-  }
-
-  const { result: sellerServiceZones } = await createServiceZonesWorkflow(
-    container
-  ).run({
-    input: {
-      data: [
-        {
-          fulfillment_set_id: sellerFulfillmentSetId,
-          name: "Europe",
-          geo_zones: countries.map((country_code) => ({
-            country_code,
-            type: "country" as const,
-          })),
+    const { result: shippingProfiles } =
+      await createSellerShippingProfilesWorkflow(container).run({
+        input: {
+          seller_id: seller.id,
+          shipping_profiles: [
+            { name: `${sellerConfig.name} Shipping`, type: "default" },
+          ],
         },
-      ],
-    },
-  });
-  const sellerServiceZoneId = sellerServiceZones[0].id;
+      });
+    const shippingProfileId = shippingProfiles[0].id;
 
-  const { result: sellerShippingProfiles } =
-    await createSellerShippingProfilesWorkflow(container).run({
+    await createSellerShippingOptionsWorkflow(container).run({
       input: {
-        seller_id: demoSeller.id,
-        shipping_profiles: [{ name: "Demo Store Shipping", type: "default" }],
+        seller_id: seller.id,
+        shipping_options: [
+          {
+            name: "Standard Shipping",
+            price_type: "flat",
+            provider_id: "manual_manual",
+            service_zone_id: serviceZoneId,
+            shipping_profile_id: shippingProfileId,
+            type: {
+              label: "Standard",
+              description: "Ship in 2-3 days.",
+              code: "standard",
+            },
+            prices: [
+              { currency_code: "usd", amount: 10 },
+              { currency_code: "eur", amount: 10 },
+              { region_id: region.id, amount: 10 },
+            ],
+            rules: [
+              { attribute: "enabled_in_store", value: "true", operator: "eq" },
+              { attribute: "is_return", value: "false", operator: "eq" },
+            ],
+          },
+          {
+            name: "Express Shipping",
+            price_type: "flat",
+            provider_id: "manual_manual",
+            service_zone_id: serviceZoneId,
+            shipping_profile_id: shippingProfileId,
+            type: {
+              label: "Express",
+              description: "Ship in 24 hours.",
+              code: "express",
+            },
+            prices: [
+              { currency_code: "usd", amount: 10 },
+              { currency_code: "eur", amount: 10 },
+              { region_id: region.id, amount: 10 },
+            ],
+            rules: [
+              { attribute: "enabled_in_store", value: "true", operator: "eq" },
+              { attribute: "is_return", value: "false", operator: "eq" },
+            ],
+          },
+        ],
       },
     });
-  const sellerShippingProfileId = sellerShippingProfiles[0].id;
 
-  await createSellerShippingOptionsWorkflow(container).run({
-    input: {
-      seller_id: demoSeller.id,
-      shipping_options: [
-        {
-          name: "Standard Shipping",
-          price_type: "flat",
-          provider_id: "manual_manual",
-          service_zone_id: sellerServiceZoneId,
-          shipping_profile_id: sellerShippingProfileId,
-          type: {
-            label: "Standard",
-            description: "Ship in 2-3 days.",
-            code: "standard",
-          },
-          prices: [
-            { currency_code: "usd", amount: 10 },
-            { currency_code: "eur", amount: 10 },
-            { region_id: region.id, amount: 10 },
-          ],
-          rules: [
-            { attribute: "enabled_in_store", value: "true", operator: "eq" },
-            { attribute: "is_return", value: "false", operator: "eq" },
-          ],
-        },
-        {
-          name: "Express Shipping",
-          price_type: "flat",
-          provider_id: "manual_manual",
-          service_zone_id: sellerServiceZoneId,
-          shipping_profile_id: sellerShippingProfileId,
-          type: {
-            label: "Express",
-            description: "Ship in 24 hours.",
-            code: "express",
-          },
-          prices: [
-            { currency_code: "usd", amount: 10 },
-            { currency_code: "eur", amount: 10 },
-            { region_id: region.id, amount: 10 },
-          ],
-          rules: [
-            { attribute: "enabled_in_store", value: "true", operator: "eq" },
-            { attribute: "is_return", value: "false", operator: "eq" },
-          ],
-        },
-      ],
-    },
-  });
-  logger.info("Finished seeding demo seller.");
+    sellers.push({
+      id: seller.id,
+      name: sellerConfig.name,
+      memberId,
+      stockLocationId: stockLocation.id,
+      shippingProfileId,
+    });
+    logger.info(`Finished seeding seller "${sellerConfig.name}".`);
+  }
+
+  const primarySeller = sellers[0];
+  logger.info(`Finished seeding ${sellers.length} sellers.`);
 
   logger.info("Seeding product data...");
 
-  await createProductsWorkflow(container).run({
-    input: {
-      created_by: demoSellerMemberId,
-      products: [
-        {
-          title: "Basic T-Shirt",
-          category_ids: [
-            categoryResult.find((cat: { name: string }) => cat.name === "Shirts")!.id,
-          ],
-          description:
-            "Reimagine the feeling of a classic T-shirt. With our cotton T-shirts, everyday essentials no longer have to be ordinary.",
-          handle: "t-shirt",
-          weight: 400,
-          status: ProductStatus.PUBLISHED,
-          seller_ids: [demoSeller.id],
-          images: [
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/tee-black-front.png" },
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/tee-black-back.png" },
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/tee-white-front.png" },
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/tee-white-back.png" },
-          ],
-          attributes: [
-            { title: "Size", values: ["S", "M", "L", "XL"], is_variant_axis: true },
-            { title: "Color", values: ["Black", "White"], is_variant_axis: true },
-          ],
-          variants: [
-            { title: "S / Black", sku: "SHIRT-S-BLACK", options: { Size: "S", Color: "Black" } },
-            { title: "S / White", sku: "SHIRT-S-WHITE", options: { Size: "S", Color: "White" } },
-            { title: "M / Black", sku: "SHIRT-M-BLACK", options: { Size: "M", Color: "Black" } },
-            { title: "M / White", sku: "SHIRT-M-WHITE", options: { Size: "M", Color: "White" } },
-            { title: "L / Black", sku: "SHIRT-L-BLACK", options: { Size: "L", Color: "Black" } },
-            { title: "L / White", sku: "SHIRT-L-WHITE", options: { Size: "L", Color: "White" } },
-            { title: "XL / Black", sku: "SHIRT-XL-BLACK", options: { Size: "XL", Color: "Black" } },
-            { title: "XL / White", sku: "SHIRT-XL-WHITE", options: { Size: "XL", Color: "White" } },
-          ],
-        },
-        {
-          title: "Basic Sweatshirt",
-          category_ids: [
-            categoryResult.find((cat: { name: string }) => cat.name === "Sweatshirts")!.id,
-          ],
-          description:
-            "Reimagine the feeling of a classic sweatshirt. With our cotton sweatshirt, everyday essentials no longer have to be ordinary.",
-          handle: "sweatshirt",
-          weight: 400,
-          status: ProductStatus.PUBLISHED,
-          seller_ids: [demoSeller.id],
-          images: [
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/sweatshirt-vintage-front.png" },
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/sweatshirt-vintage-back.png" },
-          ],
-          attributes: [
-            { title: "Size", values: ["S", "M", "L", "XL"], is_variant_axis: true },
-          ],
-          variants: [
-            { title: "S", sku: "SWEATSHIRT-S", options: { Size: "S" } },
-            { title: "M", sku: "SWEATSHIRT-M", options: { Size: "M" } },
-            { title: "L", sku: "SWEATSHIRT-L", options: { Size: "L" } },
-            { title: "XL", sku: "SWEATSHIRT-XL", options: { Size: "XL" } },
-          ],
-        },
-        {
-          title: "Basic Sweatpants",
-          category_ids: [
-            categoryResult.find((cat: { name: string }) => cat.name === "Pants")!.id,
-          ],
-          description:
-            "Reimagine the feeling of classic sweatpants. With our cotton sweatpants, everyday essentials no longer have to be ordinary.",
-          handle: "sweatpants",
-          weight: 400,
-          status: ProductStatus.PUBLISHED,
-          seller_ids: [demoSeller.id],
-          images: [
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/sweatpants-gray-front.png" },
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/sweatpants-gray-back.png" },
-          ],
-          attributes: [
-            { title: "Size", values: ["S", "M", "L", "XL"], is_variant_axis: true },
-          ],
-          variants: [
-            { title: "S", sku: "SWEATPANTS-S", options: { Size: "S" } },
-            { title: "M", sku: "SWEATPANTS-M", options: { Size: "M" } },
-            { title: "L", sku: "SWEATPANTS-L", options: { Size: "L" } },
-            { title: "XL", sku: "SWEATPANTS-XL", options: { Size: "XL" } },
-          ],
-        },
-        {
-          title: "Basic Shorts",
-          category_ids: [
-            categoryResult.find((cat: { name: string }) => cat.name === "Merch")!.id,
-          ],
-          description:
-            "Reimagine the feeling of classic shorts. With our cotton shorts, everyday essentials no longer have to be ordinary.",
-          handle: "shorts",
-          weight: 400,
-          status: ProductStatus.PUBLISHED,
-          seller_ids: [demoSeller.id],
-          images: [
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/shorts-vintage-front.png" },
-            { url: "https://medusa-public-images.s3.eu-west-1.amazonaws.com/shorts-vintage-back.png" },
-          ],
-          attributes: [
-            { title: "Size", values: ["S", "M", "L", "XL"], is_variant_axis: true },
-          ],
-          variants: [
-            { title: "S", sku: "SHORTS-S", options: { Size: "S" } },
-            { title: "M", sku: "SHORTS-M", options: { Size: "M" } },
-            { title: "L", sku: "SHORTS-L", options: { Size: "L" } },
-            { title: "XL", sku: "SHORTS-XL", options: { Size: "XL" } },
-          ],
-        },
-      ],
-    },
-  });
-  logger.info("Finished seeding product data.");
+  // Trademark-safe demo catalog. Images are generic AI-generated renders hosted
+  // from /static via the jsDelivr GitHub CDN.
+  const FOOTWEAR_SIZES = ["41", "42", "43"];
 
-  logger.info("Creating offers for the demo seller...");
+  type SeedProduct = {
+    title: string;
+    category: string;
+    price: number;
+    description: string;
+    image: string;
+  };
+  const SEED_PRODUCTS: SeedProduct[] = [
+    { title: "Cityline Canvas High Top", category: "Sneakers", price: 82, description: "Cityline Canvas High Top in Black Denim.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/cityline-canvas-high-top-1.png" },
+    { title: "Vantage 204 Runner", category: "Sneakers", price: 95, description: "Vantage 204 Runner in Beige Brown.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/vantage-204-runner-1.png" },
+    { title: "Halcyon Sherpa Runner", category: "Sneakers", price: 279, description: "Halcyon Sherpa Runner in Cream.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/halcyon-sherpa-runner-1.png" },
+    { title: "Strive Pro Mid-Cut Firm Ground Cleats", category: "Boots", price: 250, description: "Strive Pro Mid-Cut Firm Ground Cleats in Aurora Blue Solar Yellow.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/strive-pro-mid-cut-firm-ground-cleats-1.png" },
+    { title: "Cloudpeak Classic Mini Boot", category: "Boots", price: 155, description: "Cloudpeak Classic Mini Boot in Black.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/cloudpeak-classic-mini-boot-1.png" },
+    { title: "Cloudpeak Ultra Mini Boot", category: "Boots", price: 160, description: "Cloudpeak Ultra Mini Boot in Hickory.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/cloudpeak-ultra-mini-boot-1.png" },
+    { title: "Meridian Twin-Strap Buckle Sandal", category: "Sandals", price: 155, description: "Meridian Twin-Strap Buckle Sandal in Black - Regular/Wide.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/meridian-twin-strap-buckle-sandal-1.png" },
+    { title: "Meridian Twin-Strap Sandal", category: "Sandals", price: 125, description: "Meridian Twin-Strap Sandal in Pearl White - Narrow.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/meridian-twin-strap-sandal-1.png" },
+    { title: "Meridian Clog Slide", category: "Sandals", price: 232, description: "Meridian Clog Slide in Anthracite.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/meridian-clog-slide-1.png" },
+    { title: "Strive Pro FG Cleats", category: "Sport", price: 131, description: "Strive Pro FG Cleats in Aurora Black Platinum.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/strive-pro-fg-cleats-1.png" },
+    { title: "Strive Talon Pro FG Cleats", category: "Sport", price: 155, description: "Strive Talon Pro FG Cleats in Midnight Navy.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/strive-talon-pro-fg-cleats-1.png" },
+    { title: "Strive Taekwondo Trainers", category: "Sport", price: 119, description: "Strive Taekwondo Trainers in Silver Lilac.", image: "https://cdn.jsdelivr.net/gh/mercurjs/mercur@main/static/strive-taekwondo-trainers-1.png" },
+  ];
+
+  // Round-robin each product into one of its department's sub-categories.
+  const childCursor: Record<string, number> = {};
+  const nextChildId = (parent: string) => {
+    const children = CATEGORY_TREE[parent];
+    const i = (childCursor[parent] ?? 0) % children.length;
+    childCursor[parent] = i + 1;
+    return catByName.get(children[i])!.id;
+  };
+
+  const priceByHandle = new Map<string, number>();
+  const products = SEED_PRODUCTS.map((item) => {
+    const handle = toHandle(item.title);
+    const skuBase = handle.toUpperCase().replace(/-/g, "");
+    priceByHandle.set(handle, item.price);
+    return {
+      title: item.title,
+      category_ids: [nextChildId(item.category)],
+      description: item.description,
+      handle,
+      weight: 1200,
+      status: ProductStatus.PUBLISHED,
+      thumbnail: item.image,
+      images: [{ url: item.image }],
+      attributes: [
+        { title: "Size", values: FOOTWEAR_SIZES, is_variant_axis: true },
+      ],
+      variants: FOOTWEAR_SIZES.map((size) => ({
+        title: `EU ${size}`,
+        sku: `${skuBase}-EU${size}`,
+        options: { Size: size },
+      })),
+    };
+  });
+
+  await createProductsWorkflow(container).run({
+    input: { created_by: primarySeller.memberId, products },
+  });
+  logger.info(`Finished seeding ${products.length} products.`);
+
+  logger.info("Creating randomized offers across sellers...");
+
+  // Deterministic PRNG (mulberry32) so re-seeding produces the same spread.
+  let rngState = 0x9e3779b9;
+  const rand = () => {
+    rngState = (rngState + 0x6d2b79f5) | 0;
+    let t = rngState;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const randInt = (min: number, max: number) =>
+    min + Math.floor(rand() * (max - min + 1));
+
   const { data: seededProducts } = await query.graph({
     entity: "product",
-    fields: ["id", "variants.id", "variants.sku"],
+    fields: ["id", "handle", "variants.id", "variants.sku"],
     filters: {
-      handle: ["t-shirt", "sweatshirt", "sweatpants", "shorts"],
+      handle: products.map((product) => product.handle),
     },
   });
 
-  const offers = seededProducts.flatMap((product) =>
-    product.variants.map((variant: { id: string; sku: string | null }) => ({
-      seller_id: demoSeller.id,
-      created_by: demoSellerMemberId,
-      sku: `OFFER-${variant.sku}`,
-      variant_id: variant.id,
-      shipping_profile_id: sellerShippingProfileId,
-      inventory_items: [
-        {
-          sku: `OFFER-${variant.sku}`,
-          stock_levels: [
+  const offers: CreateOfferDTO[] = [];
+
+  for (const product of seededProducts) {
+    const basePrice = priceByHandle.get(product.handle) ?? 50;
+
+    // At least one seller always carries the product; the rest are random.
+    const shuffledSellers = [...sellers].sort(() => rand() - 0.5);
+    const participantCount = randInt(1, sellers.length);
+    const participants = shuffledSellers.slice(0, participantCount);
+
+    for (const seller of participants) {
+      for (const variant of product.variants as {
+        id: string;
+        sku: string | null;
+      }[]) {
+        const jitter = 1 + (rand() * 0.3 - 0.15); // ±15%
+        const eur = Math.max(1, Math.round(basePrice * jitter));
+        const usd = Math.round(eur * 1.08);
+        const sku = `OFFER-${seller.id.slice(-4)}-${variant.sku}`;
+        offers.push({
+          seller_id: seller.id,
+          created_by: seller.memberId,
+          sku,
+          variant_id: variant.id,
+          shipping_profile_id: seller.shippingProfileId,
+          inventory_items: [
             {
-              location_id: sellerStockLocation.id,
-              stocked_quantity: 1000000,
+              sku,
+              stock_levels: [
+                {
+                  location_id: seller.stockLocationId,
+                  stocked_quantity: 1000000,
+                },
+              ],
             },
           ],
-        },
-      ],
-      prices: [
-        { amount: 10, currency_code: "eur" },
-        { amount: 15, currency_code: "usd" },
-      ],
-    }))
-  );
+          prices: [
+            { amount: eur, currency_code: "eur" },
+            { amount: usd, currency_code: "usd" },
+          ],
+        });
+      }
+    }
+  }
 
   await createOffersWorkflow(container).run({ input: { offers } });
-  logger.info("Finished creating offers for the demo seller.");
+  logger.info(
+    `Finished creating ${offers.length} offers across ${sellers.length} sellers.`
+  );
 
   logger.info("Finished seeding.");
 }


### PR DESCRIPTION
Reworks the `templates/basic` seed script into a lighter, more representative multi-vendor demo.

## Changes
- **Category tree** now mirrors the `apps/api` seed: 5 departments × 3 sub-categories (Sandals, Sneakers, Boots, Sport, Accessories), created parents-then-children with nav `rank`.
- **3 sellers** (was 1): Sole Society (`seller@mercur.dev` kept as primary so existing logins/skip-check still work), Kickz Corner, Trailhead Outfitters — each with its own warehouse, fulfillment set, service zone, shipping profile + standard/express options.
- **12 products** (was 4) using trademark-safe catalog names/descriptions/images ported from the `apps/api` catalog, 3 per department, round-robined into sub-categories. Each has a Size variant axis (EU 41–43).
- **Randomized offers** across sellers (deterministic PRNG): each product carried by 1–3 sellers, one offer per (seller, variant) with ±15% EUR/USD price jitter — ~60–70 offers instead of the source seed's 400+.
- Handles generated via `toHandle` from `@medusajs/framework/utils`.

Scope is limited to the template seed; the catalog is inlined so the template stays self-contained.