### PR TITLE
fix(create-mercur-app): inject seeded publishable key into storefront env

### DIFF
--- a/packages/create-mercur-app/src/utils/create-db.ts
+++ b/packages/create-mercur-app/src/utils/create-db.ts
@@ -24,6 +24,7 @@ export interface SetupDatabaseResult {
   connectionString: string | null;
   alreadyExists?: boolean;
   inviteToken?: string | null;
+  publishableKey?: string | null;
 }
 
 export async function setupDatabase(args: {
@@ -110,13 +111,48 @@ async function runPostDbSetup(args: DbSetupArgs & {
 
   const inviteToken = await createAdminInvite({ projectDir });
 
+  const publishableKey = await getPublishableKey({ connectionString });
+
+  // Now that the storefront .env exists, inject the seeded publishable key.
+  if (publishableKey) {
+    await manageEnvFiles({
+      projectDir,
+      databaseUri: connectionString,
+      publishableKey,
+    });
+  }
+
   return {
     success: true,
     dbName,
     connectionString,
     alreadyExists,
     inviteToken,
+    publishableKey,
   };
+}
+
+async function getPublishableKey({
+  connectionString,
+}: {
+  connectionString: string;
+}): Promise<string | null> {
+  const client = new pg.Client({ connectionString });
+
+  try {
+    await client.connect();
+    const result = await client.query(
+      `SELECT token FROM api_key WHERE type = 'publishable' AND revoked_at IS NULL AND deleted_at IS NULL ORDER BY created_at ASC LIMIT 1;`
+    );
+    return result.rows[0]?.token ?? null;
+  } catch (err) {
+    logger.error(
+      `Error reading publishable API key${err instanceof Error ? `: ${err.message}` : ""}.`
+    );
+    return null;
+  } finally {
+    await client.end().catch(() => {});
+  }
 }
 
 interface DbClientResult {

--- a/packages/create-mercur-app/src/utils/manage-env-files.ts
+++ b/packages/create-mercur-app/src/utils/manage-env-files.ts
@@ -52,6 +52,17 @@ const sanitizeEnv = ({
   return updatedEnv;
 };
 
+const setEnvValue = (contents: string, key: string, value: string): string => {
+  const line = `${key}=${value}`;
+  const pattern = new RegExp(`^${key}=.*$`, "m");
+
+  if (pattern.test(contents)) {
+    return contents.replace(pattern, line);
+  }
+
+  return `${contents}${contents.endsWith("\n") || contents === "" ? "" : "\n"}${line}`;
+};
+
 const APP_PATHS = [
   { path: "packages/api" },
   { path: "apps/vendor" },
@@ -62,9 +73,11 @@ const APP_PATHS = [
 export async function manageEnvFiles({
   projectDir,
   databaseUri,
+  publishableKey,
 }: {
   projectDir: string;
   databaseUri?: string;
+  publishableKey?: string;
 }): Promise<void> {
   try {
     await Promise.all(
@@ -79,10 +92,25 @@ export async function manageEnvFiles({
         const envPath = path.join(appDir, ".env");
 
         const isApi = appPath.includes("api");
+        const isStorefront = appPath.includes("storefront");
         // if not API, just copy the .env.template file
         if (!isApi) {
           if (fs.existsSync(envTemplatePath) && !fs.existsSync(envPath)) {
             await fs.copy(envTemplatePath, envPath);
+          }
+
+          // Inject the seeded publishable key into the storefront env so the
+          // storefront can talk to the Store API out of the box.
+          if (isStorefront && publishableKey && fs.existsSync(envPath)) {
+            const contents = await fs.readFile(envPath, "utf8");
+            await fs.writeFile(
+              envPath,
+              setEnvValue(
+                contents,
+                "NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY",
+                publishableKey
+              )
+            );
           }
           return;
         }


### PR DESCRIPTION
## Problem

The `create-mercur-app` scaffolder seeds the API database — which creates a publishable API key (`apps/api/src/scripts/seed.ts`) — but nothing ever read that key back and wrote it into the storefront's `.env`. As a result `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` stayed empty (matching `.env.template`), and the generated storefront could not authenticate against the Store API out of the box.

## Fix

Mirror how Medusa's own scaffolder wires this up: seed → read the generated publishable key from the DB → inject it into the storefront env.

- **`create-db.ts`** — after seeding, `getPublishableKey()` queries the `api_key` table for the live publishable token (`type = 'publishable'`, not revoked/deleted, oldest first) reusing the existing `pg` connection, then re-runs `manageEnvFiles` with it. The key is also returned on `SetupDatabaseResult`.
- **`manage-env-files.ts`** — adds an optional `publishableKey` param and a `setEnvValue` helper that replaces (or appends) `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` in the storefront `.env`.

Publishable keys are stored in plaintext (`pk_...`) in `api_key.token`, so this is exactly the value the storefront needs.

## Notes

This populates the key on the local seed path (CLI sets up the DB). If DB setup is skipped, the storefront `.env` still ships with an empty key as before.

## Verification

- `bun run build` passes in `packages/create-mercur-app`.