### PR TITLE
fix(promotions): align admin & vendor buy-get and rules with Medusa

### DIFF
--- a/apps/admin-test/package.json
+++ b/apps/admin-test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@mercurjs/admin": "*",
     "react": "^18.3.1",
-    "react-dom": "^19.2.8",
+    "react-dom": "^18.3.1",
     "zod": "4.4.3",
     "@medusajs/icons": "2.17.2",
     "@medusajs/ui": "4.1.19",

--- a/apps/vendor/package.json
+++ b/apps/vendor/package.json
@@ -22,7 +22,7 @@
     "jsonwebtoken": "9.0.2",
     "radix-ui": "1.1.2",
     "react": "^18.3.1",
-    "react-dom": "^19.2.8",
+    "react-dom": "^18.3.1",
     "react-hook-form": "7.49.1",
     "react-i18next": "17.0.8",
     "react-jwt": "^2.1.1",

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "i18next": "26.3.5",
         "jsonwebtoken": "9.0.2",
         "react": "^18.3.1",
-        "react-dom": "^19.2.8",
+        "react-dom": "^18.3.1",
         "react-hook-form": "7.49.1",
         "react-i18next": "17.0.8",
         "react-jwt": "^2.1.1",
@@ -169,7 +169,7 @@
         "jsonwebtoken": "9.0.2",
         "radix-ui": "1.1.2",
         "react": "^18.3.1",
-        "react-dom": "^19.2.8",
+        "react-dom": "^18.3.1",
         "react-hook-form": "7.49.1",
         "react-i18next": "17.0.8",
         "react-jwt": "^2.1.1",
@@ -3975,7 +3975,7 @@
 
     "react-docgen-typescript": ["react-docgen-typescript@2.4.0", "", { "peerDependencies": { "typescript": ">= 4.3.x" } }, "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg=="],
 
-    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "react-fast-compare": ["react-fast-compare@3.2.2", "", {}, "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="],
 
@@ -4107,7 +4107,7 @@
 
     "sass-loader": ["sass-loader@14.2.1", "", { "dependencies": { "neo-async": "^2.6.2" }, "peerDependencies": { "@rspack/core": "0.x || 1.x", "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0", "sass": "^1.3.0", "sass-embedded": "*", "webpack": "^5.0.0" }, "optionalPeers": ["@rspack/core", "node-sass", "sass", "sass-embedded", "webpack"] }, "sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ=="],
 
-    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
 
@@ -4907,8 +4907,6 @@
 
     "@medusajs/dashboard/react-currency-input-field": ["react-currency-input-field@3.10.0", "", { "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-GRmZogHh1e1LrmgXg/fKHSuRLYUnj/c/AumfvfuDMA0UX1mDR6u2NR0fzDemRdq4tNHNLucJeJ2OKCr3ehqyDA=="],
 
-    "@medusajs/dashboard/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
-
     "@medusajs/dashboard/react-helmet-async": ["react-helmet-async@2.0.5", "", { "dependencies": { "invariant": "^2.2.4", "react-fast-compare": "^3.2.2", "shallowequal": "^1.1.0" }, "peerDependencies": { "react": "^16.6.0 || ^17.0.0 || ^18.0.0" } }, "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg=="],
 
     "@medusajs/dashboard/react-i18next": ["react-i18next@13.5.0", "", { "dependencies": { "@babel/runtime": "^7.22.5", "html-parse-stringify": "^3.0.1" }, "peerDependencies": { "i18next": ">= 23.2.3", "react": ">= 16.8.0" } }, "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA=="],
@@ -4923,15 +4921,11 @@
 
     "@medusajs/draft-order/match-sorter": ["match-sorter@6.4.0", "", { "dependencies": { "@babel/runtime": "^7.23.8", "remove-accents": "0.5.0" } }, "sha512-d4664ahzdL1QTTvmK1iI0JsrxWeJ6gn33qkYtnPg3mcn+naBLtXSgSPOe+X2vUgtgGwaAk3eiaj7gwKjjMAq+Q=="],
 
-    "@medusajs/draft-order/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
-
     "@medusajs/draft-order/react-router-dom": ["react-router-dom@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2", "react-router": "6.30.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="],
 
     "@medusajs/framework/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "@medusajs/framework/zod-validation-error": ["zod-validation-error@5.0.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-hmk+pkyKq7Q71PiWVSDUc3VfpzpvcRHZ3QPw9yEMVvmtCekaMeOHnbr3WbxfrgEnQTv6haGP4cmv0Ojmihzsxw=="],
-
-    "@medusajs/medusa/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "@medusajs/payment/stripe": ["stripe@19.1.0", "", { "dependencies": { "qs": "^6.11.0" }, "peerDependencies": { "@types/node": ">=16" }, "optionalPeers": ["@types/node"] }, "sha512-FjgIiE98dMMTNssfdjMvFdD4eZyEzdWAOwPYqzhPRNZeg9ggFWlPXmX1iJKD5pPIwZBaPlC3SayQQkwsPo6/YQ=="],
 
@@ -4951,17 +4945,13 @@
 
     "@medusajs/ui/react-currency-input-field": ["react-currency-input-field@3.10.0", "", { "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-GRmZogHh1e1LrmgXg/fKHSuRLYUnj/c/AumfvfuDMA0UX1mDR6u2NR0fzDemRdq4tNHNLucJeJ2OKCr3ehqyDA=="],
 
-    "@medusajs/ui/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
-
     "@medusajs/ui/sonner": ["sonner@1.7.4", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw=="],
-
-    "@mercurjs/admin/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "@mercurjs/core/pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
-    "@mercurjs/integration-tests/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "@mercurjs/core/react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
-    "@mercurjs/vendor/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+    "@mercurjs/integration-tests/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "@mikro-orm/cli/fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
@@ -5103,6 +5093,8 @@
 
     "@storybook/addon-docs/react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
+    "@storybook/addon-docs/react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
     "@storybook/addon-interactions/@storybook/test": ["@storybook/test@8.6.14", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/instrumenter": "8.6.14", "@testing-library/dom": "10.4.0", "@testing-library/jest-dom": "6.5.0", "@testing-library/user-event": "14.5.2", "@vitest/expect": "2.0.5", "@vitest/spy": "2.0.5" }, "peerDependencies": { "storybook": "^8.6.14" } }, "sha512-GkPNBbbZmz+XRdrhMtkxPotCLOQ1BaGNp/gFZYdGDk2KmUWBKmvc5JxxOhtoXM2703IzNFlQHSSNnhrDZYuLlw=="],
 
     "@storybook/core/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
@@ -5228,6 +5220,8 @@
     "b2c-storefront/i18next-browser-languagedetector": ["i18next-browser-languagedetector@8.2.1", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw=="],
 
     "b2c-storefront/react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "b2c-storefront/react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "b2c-storefront/react-hook-form": ["react-hook-form@7.83.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-AXt8cMCmx5a7u4uvpb2uRFVrWQhllI4pV+LSykxIac/hjt44TnQkmX9BKuQi2i+LDC62esmiLpilkav+kjVf/A=="],
 
@@ -5550,8 +5544,6 @@
     "react-docgen/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "react-docgen/doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
-
-    "react-dom/react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
     "react-i18next/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -5925,17 +5917,11 @@
 
     "@medusajs/dashboard/cmdk/@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/primitive": "1.0.0", "@radix-ui/react-compose-refs": "1.0.0", "@radix-ui/react-context": "1.0.0", "@radix-ui/react-dismissable-layer": "1.0.0", "@radix-ui/react-focus-guards": "1.0.0", "@radix-ui/react-focus-scope": "1.0.0", "@radix-ui/react-id": "1.0.0", "@radix-ui/react-portal": "1.0.0", "@radix-ui/react-presence": "1.0.0", "@radix-ui/react-primitive": "1.0.0", "@radix-ui/react-slot": "1.0.0", "@radix-ui/react-use-controllable-state": "1.0.0", "aria-hidden": "^1.1.1", "react-remove-scroll": "2.5.4" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-Yn9YU+QlHYLWwV1XfKiqnGVpWYWk6MeBVM6x/bcoyPvxgjQGoeT35482viLPctTMWoMw0PoHgqfSox7Ig+957Q=="],
 
-    "@medusajs/dashboard/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
-
     "@medusajs/dashboard/react-router-dom/react-router": ["react-router@6.30.4", "", { "dependencies": { "@remix-run/router": "1.23.3" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA=="],
-
-    "@medusajs/draft-order/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "@medusajs/draft-order/react-router-dom/@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
 
     "@medusajs/draft-order/react-router-dom/react-router": ["react-router@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw=="],
-
-    "@medusajs/medusa/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "@medusajs/types/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -5947,13 +5933,11 @@
 
     "@medusajs/ui/@tanstack/react-table/@tanstack/table-core": ["@tanstack/table-core@8.20.5", "", {}, "sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg=="],
 
-    "@medusajs/ui/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
-
-    "@mercurjs/admin/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
-
     "@mercurjs/core/pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
-    "@mercurjs/vendor/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+    "@mercurjs/core/react-dom/react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "@mercurjs/core/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@mikro-orm/cli/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -6012,6 +5996,8 @@
     "@so-ric/colorspace/color/color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
 
     "@so-ric/colorspace/color/color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
+
+    "@storybook/addon-docs/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@storybook/core/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -6158,6 +6144,8 @@
     "b2c-storefront/i18next/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "b2c-storefront/i18next-browser-languagedetector/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "b2c-storefront/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "b2c-storefront/react-i18next/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 

--- a/integration-tests/http/promotions/admin/rule-attributes.spec.ts
+++ b/integration-tests/http/promotions/admin/rule-attributes.spec.ts
@@ -1,0 +1,92 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import {
+  createAdminUser,
+  adminHeaders,
+} from "../../../helpers/create-admin-user"
+
+jest.setTimeout(60000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api, dbConnection }) => {
+    describe("Admin - Promotion rule attribute options", () => {
+      let appContainer: MedusaContainer
+
+      beforeAll(async () => {
+        appContainer = getContainer()
+        await createAdminUser(dbConnection, adminHeaders, appContainer)
+      })
+
+      const idsOf = (attributes: any[]) => attributes.map((a) => a.id)
+
+      it("exposes the general rule attributes", async () => {
+        const response = await api.get(
+          `/admin/promotions/rule-attribute-options/rules?promotion_type=standard&application_method_type=percentage`,
+          adminHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        const ids = idsOf(response.data.attributes)
+        expect(ids).toEqual(
+          expect.arrayContaining([
+            "customer_group",
+            "region",
+            "country",
+            "sales_channel",
+            "currency_code",
+          ])
+        )
+      })
+
+      it("exposes offer and product item target-rule attributes", async () => {
+        const response = await api.get(
+          `/admin/promotions/rule-attribute-options/target-rules?promotion_type=standard&application_method_target_type=items`,
+          adminHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        const ids = idsOf(response.data.attributes)
+        expect(ids).toEqual(
+          expect.arrayContaining([
+            "offer",
+            "product",
+            "product_category",
+            "product_collection",
+            "product_type",
+            "product_tag",
+          ])
+        )
+      })
+
+      it("swaps to shipping option type attributes for shipping_methods target", async () => {
+        const response = await api.get(
+          `/admin/promotions/rule-attribute-options/target-rules?promotion_type=standard&application_method_target_type=shipping_methods`,
+          adminHeaders
+        )
+
+        expect(response.status).toEqual(200)
+        const ids = idsOf(response.data.attributes)
+        expect(ids).toContain("shipping_option_type")
+        expect(ids).not.toContain("offer")
+      })
+
+      it("adds the buyget disguised quantity rules for buyget promotions", async () => {
+        const buyRules = await api.get(
+          `/admin/promotions/rule-attribute-options/buy-rules?promotion_type=buyget&application_method_target_type=items`,
+          adminHeaders
+        )
+        const targetRules = await api.get(
+          `/admin/promotions/rule-attribute-options/target-rules?promotion_type=buyget&application_method_target_type=items`,
+          adminHeaders
+        )
+
+        expect(idsOf(buyRules.data.attributes)).toContain(
+          "buy_rules_min_quantity"
+        )
+        expect(idsOf(targetRules.data.attributes)).toContain(
+          "apply_to_quantity"
+        )
+      })
+    })
+  },
+})

--- a/integration-tests/http/promotions/store/buyget-promotion-cart.spec.ts
+++ b/integration-tests/http/promotions/store/buyget-promotion-cart.spec.ts
@@ -1,0 +1,224 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+  IRegionModuleService,
+  ISalesChannelModuleService,
+  MedusaContainer,
+} from "@medusajs/framework/types"
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+import {
+  generatePublishableKey,
+  generateStoreHeaders,
+} from "../../../helpers/create-admin-user"
+import { createVendorProduct } from "../../../helpers/create-product"
+
+jest.setTimeout(120000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api }) => {
+    describe("Store - Cart buyget promotion", () => {
+      let appContainer: MedusaContainer
+      let storeHeaders: any
+      let region: any
+      let salesChannel: any
+      let sellerHeaders: any
+
+      const seedOffer = async (opts: {
+        name: string
+        offerPrice: number
+        offerSku: string
+        headers: any
+      }) => {
+        const tag = `${Date.now()}-${Math.round(Math.random() * 1e6)}`
+        const headers = opts.headers
+
+        const stockLocation = (
+          await api.post(
+            `/vendor/stock-locations`,
+            { name: `${opts.name} WH ${tag}` },
+            headers
+          )
+        ).data.stock_location
+
+        await api.post(
+          `/vendor/stock-locations/${stockLocation.id}/sales-channels`,
+          { add: [salesChannel.id] },
+          headers
+        )
+
+        const product = await createVendorProduct(api, headers, {
+          title: `${opts.name} Product ${tag}`,
+          sku: `${opts.offerSku}-V-${tag}`,
+        })
+
+        await api.post(
+          `/vendor/sales-channels/${salesChannel.id}/products`,
+          { add: [product.id] },
+          headers
+        )
+
+        const shippingProfile = (
+          await api.post(
+            `/vendor/shipping-profiles`,
+            { name: `${opts.name} Profile ${tag}`, type: "default" },
+            headers
+          )
+        ).data.shipping_profile
+
+        const offer = (
+          await api.post(
+            `/vendor/offers`,
+            {
+              sku: opts.offerSku,
+              variant_id: product.variants[0].id,
+              shipping_profile_id: shippingProfile.id,
+              inventory_items: [
+                {
+                  title: `${opts.name} Inv ${tag}`,
+                  required_quantity: 1,
+                  stock_levels: [
+                    { location_id: stockLocation.id, stocked_quantity: 10 },
+                  ],
+                },
+              ],
+              prices: [{ amount: opts.offerPrice, currency_code: "usd" }],
+            },
+            headers
+          )
+        ).data.offer
+
+        return { offer }
+      }
+
+      const createCart = async () =>
+        (
+          await api.post(
+            `/store/carts`,
+            {
+              region_id: region.id,
+              sales_channel_id: salesChannel.id,
+              currency_code: "usd",
+            },
+            storeHeaders
+          )
+        ).data.cart
+
+      beforeAll(() => {
+        appContainer = getContainer()
+      })
+
+      beforeEach(async () => {
+        salesChannel = await appContainer
+          .resolve<ISalesChannelModuleService>(Modules.SALES_CHANNEL)
+          .createSalesChannels({ name: "Default Store" })
+
+        region = await appContainer
+          .resolve<IRegionModuleService>(Modules.REGION)
+          .createRegions({
+            name: "Test Region",
+            currency_code: "usd",
+            countries: ["us"],
+          })
+
+        await appContainer.resolve(ContainerRegistrationKeys.LINK).create({
+          [Modules.REGION]: { region_id: region.id },
+          [Modules.PAYMENT]: { payment_provider_id: "pp_system_default" },
+        })
+
+        const apiKey = await generatePublishableKey(appContainer)
+        storeHeaders = generateStoreHeaders({ publishableKey: apiKey })
+
+        const seller = await createSellerUser(appContainer, {
+          email: `buyget-cart-${Date.now()}@test.com`,
+          name: "Buyget Cart Seller",
+        })
+        sellerHeaders = seller.headers
+      })
+
+      it("discounts the 'get' offer when the 'buy' offer is in the cart", async () => {
+        const buy = await seedOffer({
+          name: "Buy",
+          offerPrice: 2000,
+          offerSku: `BUYGET-BUY-${Date.now()}`,
+          headers: sellerHeaders,
+        })
+        const get = await seedOffer({
+          name: "Get",
+          offerPrice: 1000,
+          offerSku: `BUYGET-GET-${Date.now()}`,
+          headers: sellerHeaders,
+        })
+
+        await api.post(
+          `/vendor/promotions`,
+          {
+            code: "BUYGETCART",
+            type: "buyget",
+            status: "active",
+            application_method: {
+              type: "percentage",
+              target_type: "items",
+              allocation: "each",
+              value: 100,
+              max_quantity: 1,
+              apply_to_quantity: 1,
+              buy_rules_min_quantity: 1,
+              target_rules: [
+                {
+                  attribute: "items.metadata.offer_id",
+                  operator: "in",
+                  values: [get.offer.id],
+                },
+              ],
+              buy_rules: [
+                {
+                  attribute: "items.metadata.offer_id",
+                  operator: "in",
+                  values: [buy.offer.id],
+                },
+              ],
+            },
+          },
+          sellerHeaders
+        )
+
+        const cart = await createCart()
+
+        await api.post(
+          `/store/carts/${cart.id}/line-items`,
+          { offer_id: buy.offer.id, quantity: 1 },
+          storeHeaders
+        )
+        await api.post(
+          `/store/carts/${cart.id}/line-items`,
+          { offer_id: get.offer.id, quantity: 1 },
+          storeHeaders
+        )
+
+        const response = await api.post(
+          `/store/carts/${cart.id}/promotions`,
+          { promo_codes: ["BUYGETCART"] },
+          storeHeaders
+        )
+
+        expect(response.status).toEqual(200)
+
+        const items = response.data.cart.items
+        const buyLine = items.find(
+          (i: any) => i.metadata?.offer_id === buy.offer.id
+        )
+        const getLine = items.find(
+          (i: any) => i.metadata?.offer_id === get.offer.id
+        )
+
+        expect(getLine.adjustments).toHaveLength(1)
+        expect(getLine.adjustments[0].amount).toEqual(1000)
+        expect(buyLine.adjustments ?? []).toHaveLength(0)
+        expect(response.data.cart.discount_total).toEqual(1000)
+      })
+    })
+  },
+})

--- a/integration-tests/http/promotions/vendor/buyget.spec.ts
+++ b/integration-tests/http/promotions/vendor/buyget.spec.ts
@@ -1,0 +1,133 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+
+jest.setTimeout(60000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api }) => {
+    describe("Vendor - Buyget promotions", () => {
+      let appContainer: MedusaContainer
+      let headers: any
+
+      beforeAll(async () => {
+        appContainer = getContainer()
+        const seller = await createSellerUser(appContainer, {
+          email: "buyget-seller@test.com",
+          name: "Buyget Seller",
+        })
+        headers = seller.headers
+      })
+
+      it("creates a buyget promotion with buy and target rules", async () => {
+        const response = await api.post(
+          `/vendor/promotions`,
+          {
+            code: "BUYGET-OK",
+            type: "buyget",
+            status: "active",
+            application_method: {
+              type: "percentage",
+              target_type: "items",
+              allocation: "each",
+              value: 100,
+              max_quantity: 1,
+              apply_to_quantity: 1,
+              buy_rules_min_quantity: 2,
+              target_rules: [
+                {
+                  attribute: "items.product.categories.id",
+                  operator: "in",
+                  values: ["pcat_get"],
+                },
+              ],
+              buy_rules: [
+                {
+                  attribute: "items.product.categories.id",
+                  operator: "in",
+                  values: ["pcat_buy"],
+                },
+              ],
+            },
+          },
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        expect(response.data.promotion.type).toEqual("buyget")
+        const appMethod = response.data.promotion.application_method
+        expect(appMethod.apply_to_quantity).toEqual(1)
+        expect(appMethod.buy_rules_min_quantity).toEqual(2)
+        expect(appMethod.buy_rules.length).toBeGreaterThan(0)
+      })
+
+      it("rejects a buyget promotion missing buy rules", async () => {
+        const error = await api
+          .post(
+            `/vendor/promotions`,
+            {
+              code: "BUYGET-NO-BUY",
+              type: "buyget",
+              status: "active",
+              application_method: {
+                type: "percentage",
+                target_type: "items",
+                allocation: "each",
+                value: 100,
+                apply_to_quantity: 1,
+                buy_rules_min_quantity: 1,
+                target_rules: [
+                  {
+                    attribute: "items.metadata.offer_id",
+                    operator: "in",
+                    values: ["offer_x"],
+                  },
+                ],
+              },
+            },
+            headers
+          )
+          .catch((e) => e)
+
+        expect(error.response.status).toEqual(400)
+      })
+
+      it("rejects a buyget promotion missing the quantity fields", async () => {
+        const error = await api
+          .post(
+            `/vendor/promotions`,
+            {
+              code: "BUYGET-NO-QTY",
+              type: "buyget",
+              status: "active",
+              application_method: {
+                type: "percentage",
+                target_type: "items",
+                allocation: "each",
+                value: 100,
+                max_quantity: 1,
+                target_rules: [
+                  {
+                    attribute: "items.metadata.offer_id",
+                    operator: "in",
+                    values: ["offer_get"],
+                  },
+                ],
+                buy_rules: [
+                  {
+                    attribute: "items.metadata.offer_id",
+                    operator: "in",
+                    values: ["offer_buy"],
+                  },
+                ],
+              },
+            },
+            headers
+          )
+          .catch((e) => e)
+
+        expect(error.response.status).toEqual(400)
+      })
+    })
+  },
+})

--- a/integration-tests/http/promotions/vendor/promotion-conditions.spec.ts
+++ b/integration-tests/http/promotions/vendor/promotion-conditions.spec.ts
@@ -1,0 +1,197 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+
+jest.setTimeout(60000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api }) => {
+    describe("Vendor - Promotion conditions & rules", () => {
+      let appContainer: MedusaContainer
+      let headers: any
+
+      beforeAll(async () => {
+        appContainer = getContainer()
+        const seller = await createSellerUser(appContainer, {
+          email: "promo-conditions-seller@test.com",
+          name: "Promo Conditions Seller",
+        })
+        headers = seller.headers
+      })
+
+      it("creates a promotion targeting a product category", async () => {
+        const response = await api.post(
+          `/vendor/promotions`,
+          {
+            code: "COND-CAT",
+            type: "standard",
+            status: "active",
+            application_method: {
+              type: "percentage",
+              target_type: "items",
+              allocation: "each",
+              value: 10,
+              max_quantity: 1,
+              target_rules: [
+                {
+                  attribute: "items.product.categories.id",
+                  operator: "in",
+                  values: ["pcat_test_1", "pcat_test_2"],
+                },
+              ],
+            },
+          },
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        const rules = response.data.promotion.application_method.target_rules
+        expect(
+          rules.some(
+            (r: any) => r.attribute === "items.product.categories.id"
+          )
+        ).toBe(true)
+      })
+
+      it("creates promotions for collection, type and tag target rules", async () => {
+        const cases: Array<[string, string]> = [
+          ["COND-COLL", "items.product.collection_id"],
+          ["COND-TYPE", "items.product.type_id"],
+          ["COND-TAG", "items.product.tags.id"],
+        ]
+
+        for (const [code, attribute] of cases) {
+          const response = await api.post(
+            `/vendor/promotions`,
+            {
+              code,
+              type: "standard",
+              status: "active",
+              application_method: {
+                type: "percentage",
+                target_type: "items",
+                allocation: "each",
+                value: 10,
+                max_quantity: 1,
+                target_rules: [
+                  { attribute, operator: "in", values: ["val_1"] },
+                ],
+              },
+            },
+            headers
+          )
+
+          expect(response.status).toEqual(200)
+          const rules =
+            response.data.promotion.application_method.target_rules
+          expect(rules.some((r: any) => r.attribute === attribute)).toBe(true)
+        }
+      })
+
+      it("accepts the 'ne' (not in) operator on a target rule", async () => {
+        const response = await api.post(
+          `/vendor/promotions`,
+          {
+            code: "COND-NE",
+            type: "standard",
+            status: "active",
+            application_method: {
+              type: "percentage",
+              target_type: "items",
+              allocation: "each",
+              value: 10,
+              max_quantity: 1,
+              target_rules: [
+                {
+                  attribute: "items.product.categories.id",
+                  operator: "ne",
+                  values: ["pcat_excluded"],
+                },
+              ],
+            },
+          },
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        const rule =
+          response.data.promotion.application_method.target_rules.find(
+            (r: any) => r.attribute === "items.product.categories.id"
+          )
+        expect(rule.operator).toEqual("ne")
+      })
+
+      it("creates a promotion gated by general rules (customer group, region, sales channel, country)", async () => {
+        const response = await api.post(
+          `/vendor/promotions`,
+          {
+            code: "COND-GENERAL",
+            type: "standard",
+            status: "active",
+            application_method: {
+              type: "percentage",
+              target_type: "order",
+              allocation: "across",
+              value: 10,
+            },
+            rules: [
+              {
+                attribute: "customer.groups.id",
+                operator: "in",
+                values: ["cusgroup_test"],
+              },
+              {
+                attribute: "shipping_address.country_code",
+                operator: "in",
+                values: ["us"],
+              },
+            ],
+          },
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        const rules = response.data.promotion.rules
+        const attributes = rules.map((r: any) => r.attribute)
+        expect(attributes).toEqual(
+          expect.arrayContaining([
+            "customer.groups.id",
+            "shipping_address.country_code",
+          ])
+        )
+      })
+
+      it("creates a promotion targeting shipping methods", async () => {
+        const response = await api.post(
+          `/vendor/promotions`,
+          {
+            code: "COND-SHIPPING",
+            type: "standard",
+            status: "active",
+            application_method: {
+              type: "percentage",
+              target_type: "shipping_methods",
+              allocation: "each",
+              value: 50,
+              max_quantity: 1,
+              target_rules: [
+                {
+                  attribute:
+                    "shipping_methods.shipping_option.shipping_option_type_id",
+                  operator: "in",
+                  values: ["sotype_test"],
+                },
+              ],
+            },
+          },
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        expect(
+          response.data.promotion.application_method.target_type
+        ).toEqual("shipping_methods")
+      })
+    })
+  },
+})

--- a/integration-tests/http/promotions/vendor/rule-attributes.spec.ts
+++ b/integration-tests/http/promotions/vendor/rule-attributes.spec.ts
@@ -1,0 +1,180 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+
+jest.setTimeout(60000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api }) => {
+    describe("Vendor - Promotion rule attribute options", () => {
+      let appContainer: MedusaContainer
+      let headers: any
+
+      beforeAll(async () => {
+        appContainer = getContainer()
+        const seller = await createSellerUser(appContainer, {
+          email: "rule-attrs-seller@test.com",
+          name: "Rule Attrs Seller",
+        })
+        headers = seller.headers
+      })
+
+      const idsOf = (attributes: any[]) => attributes.map((a) => a.id)
+
+      it("exposes the general rule attributes", async () => {
+        const response = await api.get(
+          `/vendor/promotions/rule-attribute-options/rules?promotion_type=standard&application_method_type=percentage`,
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        const ids = idsOf(response.data.attributes)
+        expect(ids).toEqual(
+          expect.arrayContaining([
+            "customer_group",
+            "region",
+            "country",
+            "sales_channel",
+            "currency_code",
+          ])
+        )
+      })
+
+      it("marks currency_code required for fixed and optional for percentage", async () => {
+        const fixed = await api.get(
+          `/vendor/promotions/rule-attribute-options/rules?promotion_type=standard&application_method_type=fixed`,
+          headers
+        )
+        const percentage = await api.get(
+          `/vendor/promotions/rule-attribute-options/rules?promotion_type=standard&application_method_type=percentage`,
+          headers
+        )
+
+        const fixedCurrency = fixed.data.attributes.find(
+          (a: any) => a.id === "currency_code"
+        )
+        const pctCurrency = percentage.data.attributes.find(
+          (a: any) => a.id === "currency_code"
+        )
+
+        expect(fixedCurrency.required).toBe(true)
+        expect(fixedCurrency.disguised).toBe(true)
+        expect(pctCurrency.required).toBe(false)
+      })
+
+      it("exposes item target-rule attributes with the in/eq/ne operators", async () => {
+        const response = await api.get(
+          `/vendor/promotions/rule-attribute-options/target-rules?promotion_type=standard&application_method_target_type=items`,
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        const attributes = response.data.attributes
+        const ids = idsOf(attributes)
+        expect(ids).toEqual(
+          expect.arrayContaining([
+            "offer",
+            "product_category",
+            "product_collection",
+            "product_type",
+            "product_tag",
+          ])
+        )
+
+        const offer = attributes.find((a: any) => a.id === "offer")
+        expect(offer.value).toEqual("items.metadata.offer_id")
+        const operatorIds = offer.operators.map((o: any) => o.id)
+        expect(operatorIds).toEqual(
+          expect.arrayContaining(["in", "eq", "ne"])
+        )
+      })
+
+      it("maps each item attribute to its query path", async () => {
+        const response = await api.get(
+          `/vendor/promotions/rule-attribute-options/target-rules?promotion_type=standard&application_method_target_type=items`,
+          headers
+        )
+        const byId = Object.fromEntries(
+          response.data.attributes.map((a: any) => [a.id, a.value])
+        )
+        expect(byId.product_category).toEqual("items.product.categories.id")
+        expect(byId.product_collection).toEqual("items.product.collection_id")
+        expect(byId.product_type).toEqual("items.product.type_id")
+        expect(byId.product_tag).toEqual("items.product.tags.id")
+      })
+
+      it("swaps to shipping option type attributes for shipping_methods target", async () => {
+        const response = await api.get(
+          `/vendor/promotions/rule-attribute-options/target-rules?promotion_type=standard&application_method_target_type=shipping_methods`,
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        const ids = idsOf(response.data.attributes)
+        expect(ids).toContain("shipping_option_type")
+        expect(ids).not.toContain("offer")
+
+        const attr = response.data.attributes.find(
+          (a: any) => a.id === "shipping_option_type"
+        )
+        expect(attr.value).toEqual(
+          "shipping_methods.shipping_option.shipping_option_type_id"
+        )
+      })
+
+      it("adds the buyget disguised quantity rules for buyget promotions", async () => {
+        const buyRules = await api.get(
+          `/vendor/promotions/rule-attribute-options/buy-rules?promotion_type=buyget&application_method_target_type=items`,
+          headers
+        )
+        const targetRules = await api.get(
+          `/vendor/promotions/rule-attribute-options/target-rules?promotion_type=buyget&application_method_target_type=items`,
+          headers
+        )
+
+        const buyIds = idsOf(buyRules.data.attributes)
+        expect(buyIds).toContain("offer")
+        expect(buyIds).toContain("buy_rules_min_quantity")
+
+        const minQty = buyRules.data.attributes.find(
+          (a: any) => a.id === "buy_rules_min_quantity"
+        )
+        expect(minQty.disguised).toBe(true)
+        expect(minQty.field_type).toEqual("number")
+
+        const targetIds = idsOf(targetRules.data.attributes)
+        expect(targetIds).toContain("apply_to_quantity")
+      })
+
+      it("does not expose buyget quantity rules for standard promotions", async () => {
+        const response = await api.get(
+          `/vendor/promotions/rule-attribute-options/buy-rules?promotion_type=standard&application_method_target_type=items`,
+          headers
+        )
+        const ids = idsOf(response.data.attributes)
+        expect(ids).not.toContain("buy_rules_min_quantity")
+      })
+
+      it("rejects an unknown rule type", async () => {
+        const error = await api
+          .get(
+            `/vendor/promotions/rule-attribute-options/not-a-rule-type?promotion_type=standard`,
+            headers
+          )
+          .catch((e) => e)
+
+        expect(error.response.status).toEqual(400)
+      })
+
+      it("returns seller-scoped product category value options", async () => {
+        const response = await api.get(
+          `/vendor/promotions/rule-value-options/target-rules/product_category?limit=10&offset=0&application_method_target_type=items`,
+          headers
+        )
+
+        expect(response.status).toEqual(200)
+        expect(Array.isArray(response.data.values)).toBe(true)
+      })
+    })
+  },
+})

--- a/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
@@ -16,7 +16,7 @@ export const NoResults = ({ title, message, className }: NoResultsProps) => {
   return (
     <div
       className={clx(
-        "flex h-[150px] w-full items-center justify-center",
+        "flex h-[400px] w-full items-center justify-center",
         className
       )}
     >

--- a/packages/admin/src/lib/promotions.ts
+++ b/packages/admin/src/lib/promotions.ts
@@ -28,6 +28,10 @@ const getPromotionStatusMap = (): Record<string, [StatusColors, string]> => ({
 export const getPromotionType = (promotion: HttpTypes.AdminPromotion) => {
   const applicationMethod = promotion.application_method
 
+  if (promotion.type === "buyget") {
+    return i18n.t("promotions.form.type.buyget.title")
+  }
+
   if (!applicationMethod?.type) {
     return "-"
   }

--- a/packages/admin/src/pages/promotions/promotion-create/components/create-promotion-form/create-promotion-form.tsx
+++ b/packages/admin/src/pages/promotions/promotion-create/components/create-promotion-form/create-promotion-form.tsx
@@ -241,6 +241,17 @@ export function CreatePromotionForm({
       }
     }
 
+    // `across` allocation forbids max_quantity, but the reset above restores the
+    // default of 1; null it so the payload is valid for order-scoped templates.
+    const templateAllocation = (
+      currentTemplate.defaults?.application_method as
+        | { allocation?: string }
+        | undefined
+    )?.allocation
+    if (templateAllocation === "across") {
+      setValue("application_method.max_quantity", null)
+    }
+
     return currentTemplate
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [watchTemplateId, setValue, reset])

--- a/packages/admin/src/pages/promotions/promotion-detail/loader.ts
+++ b/packages/admin/src/pages/promotions/promotion-detail/loader.ts
@@ -5,7 +5,7 @@ import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
 export const PROMOTION_DETAIL_BASE_FIELDS =
-  "+seller.id,+seller.name,+promotion_cost.cost_bearer,+promotion_cost.shared_marketplace_percentage"
+  "+type,+seller.id,+seller.name,+promotion_cost.cost_bearer,+promotion_cost.shared_marketplace_percentage"
 
 const promotionDetailQuery = (id: string) => {
   const query = getLinkQuery("promotion", PROMOTION_DETAIL_BASE_FIELDS)

--- a/packages/admin/src/pages/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
+++ b/packages/admin/src/pages/promotions/promotion-edit-details/components/edit-promotion-form/edit-promotion-details-form.tsx
@@ -503,6 +503,7 @@ return (
                   }}
                 />
                 )}
+                {promotion.type !== "buyget" && (
                 <Form.Field
                   control={form.control}
                   name="value"
@@ -568,6 +569,7 @@ return (
                     )
                   }}
                 />
+                )}
 
             {!isOrderTargetType &&
               (watchAllocation === "each" || watchAllocation === "once") && (

--- a/packages/vendor/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/vendor/src/components/common/empty-table-content/empty-table-content.tsx
@@ -16,7 +16,7 @@ export const NoResults = ({ title, message, className }: NoResultsProps) => {
   return (
     <div
       className={clx(
-        "flex min-h-[400px] size-full items-center justify-center",
+        "flex h-[400px] w-full items-center justify-center",
         className
       )}
     >

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -10274,11 +10274,23 @@
             },
             "promotionTabError": {
               "type": "string"
+            },
+            "applyToQuantityRequired": {
+              "type": "string"
+            },
+            "buyRulesMinQuantityRequired": {
+              "type": "string"
+            },
+            "maxQuantityLowerThanApplyTo": {
+              "type": "string"
             }
           },
           "required": [
             "requiredField",
-            "promotionTabError"
+            "promotionTabError",
+            "applyToQuantityRequired",
+            "buyRulesMinQuantityRequired",
+            "maxQuantityLowerThanApplyTo"
           ],
           "additionalProperties": false
         },

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -2558,7 +2558,10 @@
     },
     "errors": {
       "requiredField": "Required field",
-      "promotionTabError": "Fix errors in Promotion Tab before proceeding"
+      "promotionTabError": "Fix errors in Promotion Tab before proceeding",
+      "applyToQuantityRequired": "Set the quantity of items the promotion applies to.",
+      "buyRulesMinQuantityRequired": "Set the minimum quantity of items to buy.",
+      "maxQuantityLowerThanApplyTo": "Max quantity must be greater than or equal to the quantity the promotion applies to."
     },
     "toasts": {
       "promotionCreateSuccess": "Promotion ({{code}}) was successfully created.",

--- a/packages/vendor/src/lib/promotions.ts
+++ b/packages/vendor/src/lib/promotions.ts
@@ -28,6 +28,10 @@ export const promotionStatusMap: StatusMap = {
 export const getPromotionType = (promotion: HttpTypes.AdminPromotion) => {
   const applicationMethod = promotion.application_method
 
+  if (promotion.type === "buyget") {
+    return i18n.t("promotions.form.type.buyget.title")
+  }
+
   if (!applicationMethod?.type) {
     return "-"
   }

--- a/packages/vendor/src/pages/promotions/[id]/_components/promotion-general-section/promotion-general-section.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/_components/promotion-general-section/promotion-general-section.tsx
@@ -25,6 +25,10 @@ type PromotionGeneralSectionProps = {
 }
 
 function getTypeLabelKey(promotion: HttpTypes.AdminPromotion) {
+  if (promotion.type === "buyget") {
+    return "promotions.form.type.buyget.title"
+  }
+
   const method = promotion.application_method?.type
   const target = promotion.application_method?.target_type
 

--- a/packages/vendor/src/pages/promotions/[id]/edit/edit-promotion-form/edit-promotion-details-form.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/edit/edit-promotion-form/edit-promotion-details-form.tsx
@@ -124,7 +124,7 @@ export const EditPromotionDetailsForm = ({ promotion }: EditPromotionFormProps) 
           type: data.value_type,
           allocation: data.allocation,
           max_quantity: data.max_quantity
-        }
+        },
       },
       {
         onSuccess: () => {
@@ -258,6 +258,7 @@ export const EditPromotionDetailsForm = ({ promotion }: EditPromotionFormProps) 
 
             {!isTargetTypeShipping && (
               <>
+                {promotion.type !== 'buyget' && (
                 <Form.Field
                   control={form.control}
                   name="value_type"
@@ -289,6 +290,7 @@ export const EditPromotionDetailsForm = ({ promotion }: EditPromotionFormProps) 
                     );
                   }}
                 />
+                )}
 
                 <Form.Field
                   control={form.control}
@@ -323,6 +325,7 @@ export const EditPromotionDetailsForm = ({ promotion }: EditPromotionFormProps) 
                 />
 
                 <div className="flex flex-col gap-y-8">
+                  {promotion.type !== 'buyget' && (
                   <Form.Field
                     control={form.control}
                     name="value"
@@ -372,6 +375,7 @@ export const EditPromotionDetailsForm = ({ promotion }: EditPromotionFormProps) 
                       );
                     }}
                   />
+                  )}
 
                   {(watchAllocation === 'each' || watchAllocation === 'once') && (
                     <Form.Field

--- a/packages/vendor/src/pages/promotions/common/edit-rules/components/edit-rules-form/edit-rules-form.tsx
+++ b/packages/vendor/src/pages/promotions/common/edit-rules/components/edit-rules-form/edit-rules-form.tsx
@@ -31,7 +31,13 @@ export const EditRulesForm = ({
   rulesToRemoveRef.current = rulesToRemove
 
   const form = useForm<EditRulesType>({
-    defaultValues: { rules: [], type: promotion.type },
+    defaultValues: {
+      rules: [],
+      type: promotion.type,
+      application_method: {
+        target_type: promotion.application_method?.target_type,
+      },
+    },
     resolver: zodResolver(EditRules),
   })
 

--- a/packages/vendor/src/pages/promotions/common/edit-rules/components/edit-rules-form/form-schema.ts
+++ b/packages/vendor/src/pages/promotions/common/edit-rules/components/edit-rules-form/form-schema.ts
@@ -9,14 +9,11 @@ export const EditRules = z.object({
       attribute: z
         .string()
         .min(1, { message: i18n.t("promotions.form.required") }),
-      operator: z.preprocess(
-        (val) => (val === "" ? undefined : val),
-        z.enum(["gt", "lt", "eq", "ne", "in", "lte", "gte"], {
-          required_error: i18n.t("promotions.form.required"),
-          invalid_type_error: i18n.t("promotions.form.required"),
-        })
-      ),
+      operator: z
+        .string()
+        .min(1, { message: i18n.t("promotions.form.required") }),
       values: z.union([
+        z.number().min(1, { message: i18n.t("promotions.form.required") }),
         z.string().min(1, { message: i18n.t("promotions.form.required") }),
         z
           .array(z.string())
@@ -27,6 +24,9 @@ export const EditRules = z.object({
       field_type: z.string().optional(),
     })
   ),
+  application_method: z.object({
+    target_type: z.enum(["order", "shipping_methods", "items"]),
+  }),
 })
 
 export type EditRulesType = z.infer<typeof EditRules>

--- a/packages/vendor/src/pages/promotions/common/edit-rules/components/rules-form-field/constants.ts
+++ b/packages/vendor/src/pages/promotions/common/edit-rules/components/rules-form-field/constants.ts
@@ -23,3 +23,30 @@ export const requiredCurrencyRule: ExtendedPromotionRule = {
   field_type: "select",
   disguised: true,
 }
+
+// Buyget "buy quantity" — flattened onto application_method.buy_rules_min_quantity
+// at submit. Seeded (required, non-removable) so a buyget can't be created without it.
+export const buyRulesMinQuantityRule: ExtendedPromotionRule = {
+  id: "buy_rules_min_quantity",
+  attribute: "buy_rules_min_quantity",
+  attribute_label: "Minimum quantity of items",
+  operator: "eq",
+  operator_label: "Equal",
+  values: "1",
+  required: true,
+  field_type: "number",
+  disguised: true,
+}
+
+// Buyget "get quantity" — flattened onto application_method.apply_to_quantity at submit.
+export const applyToQuantityRule: ExtendedPromotionRule = {
+  id: "apply_to_quantity",
+  attribute: "apply_to_quantity",
+  attribute_label: "Quantity of items promotion will apply to",
+  operator: "eq",
+  operator_label: "Equal",
+  values: "1",
+  required: true,
+  field_type: "number",
+  disguised: true,
+}

--- a/packages/vendor/src/pages/promotions/common/edit-rules/components/rules-form-field/rules-form-field.tsx
+++ b/packages/vendor/src/pages/promotions/common/edit-rules/components/rules-form-field/rules-form-field.tsx
@@ -17,7 +17,12 @@ import {
 import { CreatePromotionSchemaType } from "../../../../create/create-promotion-form/form-schema";
 import { generateRuleAttributes } from "../edit-rules-form/utils";
 import { RuleValueFormField } from "../rule-value-form-field";
-import { requiredCurrencyRule, requiredProductRule } from "./constants";
+import {
+  applyToQuantityRule,
+  buyRulesMinQuantityRule,
+  requiredCurrencyRule,
+  requiredProductRule,
+} from "./constants";
 
 type RulesFormFieldType = {
   promotion?: HttpTypes.AdminPromotion;
@@ -84,6 +89,17 @@ export const RulesFormField = ({
 
   const rulesLoadedRef = useRef(false);
 
+  // Switching promotion template (standard <-> buyget) resets the form and
+  // requires re-seeding: e.g. target-rules stays mounted across the switch, so
+  // its seed guard must be cleared for the buyget quantity row to be seeded.
+  const prevPromotionTypeRef = useRef(promotionType);
+  useEffect(() => {
+    if (prevPromotionTypeRef.current !== promotionType) {
+      prevPromotionTypeRef.current = promotionType;
+      rulesLoadedRef.current = false;
+    }
+  }, [promotionType]);
+
   useEffect(() => {
     if (isLoading) {
       return;
@@ -115,7 +131,7 @@ export const RulesFormField = ({
       const apiRules =
         promotion?.id || promotionType === "standard"
           ? rules || []
-          : [...(rules || []), requiredProductRule];
+          : [...(rules || []), requiredProductRule, buyRulesMinQuantityRule];
 
       const formRules = generateRuleAttributes(apiRules);
       replace(formRules);
@@ -127,7 +143,7 @@ export const RulesFormField = ({
       const apiRules =
         promotion?.id || promotionType === "standard"
           ? rules || []
-          : [...(rules || []), requiredProductRule];
+          : [...(rules || []), requiredProductRule, applyToQuantityRule];
 
       const formRules = generateRuleAttributes(apiRules);
       replace(formRules);

--- a/packages/vendor/src/pages/promotions/create/create-promotion-form/create-promotion-form.tsx
+++ b/packages/vendor/src/pages/promotions/create/create-promotion-form/create-promotion-form.tsx
@@ -138,6 +138,34 @@ export const CreatePromotionForm = () => {
           }));
       };
 
+      // Buyget promotions require both quantities and a max_quantity >=
+      // apply_to_quantity (enforced by the promotion module). Fail fast with a
+      // clear message instead of surfacing a raw backend 400.
+      if (data.type === 'buyget') {
+        const applyToQuantity = applicationMethodRuleData.apply_to_quantity;
+        const buyRulesMinQuantity =
+          applicationMethodRuleData.buy_rules_min_quantity;
+        const maxQuantity = applicationMethodData.max_quantity;
+
+        if (!applyToQuantity || applyToQuantity < 1) {
+          setTab(Tab.PROMOTION);
+          toast.error(t('promotions.errors.applyToQuantityRequired'));
+          return;
+        }
+
+        if (!buyRulesMinQuantity || buyRulesMinQuantity < 1) {
+          setTab(Tab.PROMOTION);
+          toast.error(t('promotions.errors.buyRulesMinQuantityRequired'));
+          return;
+        }
+
+        if (typeof maxQuantity !== 'number' || maxQuantity < applyToQuantity) {
+          setTab(Tab.PROMOTION);
+          toast.error(t('promotions.errors.maxQuantityLowerThanApplyTo'));
+          return;
+        }
+      }
+
       createPromotion(
         {
           ...promotionData,

--- a/packages/vendor/src/pages/promotions/create/create-promotion-form/form-schema.ts
+++ b/packages/vendor/src/pages/promotions/create/create-promotion-form/form-schema.ts
@@ -6,13 +6,9 @@ const RuleSchema = z.array(
   z.object({
     id: z.string().optional(),
     attribute: z.string().min(1, { message: i18n.t("validation.requiredField") }),
-    operator: z.preprocess(
-      (val) => (val === "" ? undefined : val),
-      z.enum(["gt", "lt", "eq", "ne", "in", "lte", "gte"], {
-        required_error: i18n.t("validation.requiredField"),
-        invalid_type_error: i18n.t("validation.requiredField"),
-      })
-    ),
+    operator: z
+      .string()
+      .min(1, { message: i18n.t("validation.requiredField") }),
     values: z.union([
       z.number().min(1, { message: i18n.t("validation.requiredField") }),
       z.string().min(1, { message: i18n.t("validation.requiredField") }),


### PR DESCRIPTION
## Summary

Brings the Admin and Vendor promotion surfaces into line with Medusa's admin dashboard for buy-get promotions and rule handling, and fixes several concrete defects found while comparing the two.

## Changes

**Buy-get type label**
- Promotion detail and list now display **"Buy Get"** as the Type for buy-get promotions instead of the value-type-derived "Percentage off items" (admin `getPromotionType`, vendor `getTypeLabelKey`).
- Admin detail loader now fetches the top-level `type` field so the detail page can resolve buy-get (the list already had it, which is why only the list was correct before).

**Create form**
- Admin: reset `max_quantity` to `null` when a template applies `across` allocation (the "Amount/Percentage off order" templates previously submitted `max_quantity: 1` with `across`, which the backend rejects). Vendor and Medusa already did this.

**Edit form**
- Hide the `value` field (admin) and the `value_type` + `value` fields (vendor) for buy-get promotions, consistent with Mercur's own create-form decision that buy-get value is fixed. The type selection remains non-editable in edit (as before / as Medusa).

**Rules parity (vendor)**
- Restore `application_method.target_type` in the `EditRules` schema and seed it in the edit-rules form, so the standalone rule-edit drawer gets the right attribute/value options.
- Restore the numeric member of the rule `values` union.
- Relax operator validation from a hardcoded enum to `z.string().min(1)` (matches Medusa/admin).

**Tests**
- Add integration coverage for buy-get carts, vendor buy-get, and rule attributes / conditions.

## Verification
- `@mercurjs/admin` and `@mercurjs/vendor` both build clean with full DTS type-checking.