### PR TITLE
fix(vendor): paginate products list past the first page

### DIFF
--- a/packages/vendor/src/pages/products/_components/product-list-table/product-list-data-table.tsx
+++ b/packages/vendor/src/pages/products/_components/product-list-table/product-list-data-table.tsx
@@ -30,9 +30,6 @@ export const ProductListDataTable = () => {
     | Awaited<ReturnType<typeof productListLoader>>
     | undefined;
 
-  // The loader only prefetches the first page, so seeding it as `initialData`
-  // on later pages would make TanStack Query serve stale first-page rows for
-  // the whole `staleTime` window instead of fetching the requested offset.
   const initialData = searchParams.offset ? undefined : loaderData;
 
   const { products, count, isLoading, isError, error } = useProducts(

--- a/packages/vendor/src/pages/products/_components/product-list-table/product-list-data-table.tsx
+++ b/packages/vendor/src/pages/products/_components/product-list-table/product-list-data-table.tsx
@@ -26,9 +26,14 @@ export const ProductListDataTable = () => {
     pageSize: PAGE_SIZE,
   });
 
-  const initialData = useLoaderData() as
+  const loaderData = useLoaderData() as
     | Awaited<ReturnType<typeof productListLoader>>
     | undefined;
+
+  // The loader only prefetches the first page, so seeding it as `initialData`
+  // on later pages would make TanStack Query serve stale first-page rows for
+  // the whole `staleTime` window instead of fetching the requested offset.
+  const initialData = searchParams.offset ? undefined : loaderData;
 
   const { products, count, isLoading, isError, error } = useProducts(
     searchParams,


### PR DESCRIPTION
## Problem

Pagination on the vendor portal products list doesn't work — clicking to a later page updates the URL offset but the table keeps showing the first page's rows.

Closes #1297

## Root cause

The list runs a route loader that prefetches **only the first page** and passes that result to `useProducts` as TanStack Query `initialData` on **every** page. With the dashboard query client's `staleTime: 90000` (`packages/vendor/src/lib/query-client.ts`), navigating to a new offset (a fresh query key with no cache) seeds it with the first-page `initialData`, marks it fresh, and skips the refetch. The `offset` was being sent correctly and the backend paginated fine — but the UI never advanced past the seeded first-page data.

## Fix

Only seed `initialData` when the requested offset is the first page:

```ts
const initialData = searchParams.offset ? undefined : loaderData;
```

Later pages fetch their own offset normally; `keepPreviousData` still smooths the transition.

## Verification

- `bun run --filter @mercurjs/vendor build` — green.

## Note

`packages/admin` uses the same loader + `initialData` pattern and shares the same latent bug. This PR is scoped to the reported vendor surface; the admin guard can follow up if desired.