### PR TITLE
chore(storefront): rename package to @mercurjs/storefront

### DIFF
--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "b2c-storefront",
-  "version": "1.5.4",
+  "name": "@mercurjs/storefront",
+  "version": "2.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Renames the storefront package from `b2c-storefront` to `@mercurjs/storefront` and bumps the version to `2.1.1`.