### PR TITLE
feat: admin and vendor can choose currency

### DIFF
--- a/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
+++ b/packages/admin/src/pages/stores/store-edit/components/store-edit-form.tsx
@@ -28,6 +28,7 @@ import { MediaSchema } from "@pages/products/product-create/constants";
 import { InferClientOutput } from "@mercurjs/client";
 import { sdk } from "@lib/client";
 import { useUpdateSeller } from "@hooks/api/sellers";
+import { useStore } from "@hooks/api/store";
 import { currencies } from "@/lib/data/currencies";
 import { SellerStatus } from "@mercurjs/types";
 
@@ -50,6 +51,9 @@ const EditStoreSchema = zod.object({
     .email({ message: i18n.t("stores.create.validation.emailInvalid") }),
   phone: zod.string().optional().or(zod.literal("")),
   website_url: zod.string().optional().or(zod.literal("")),
+  currency_code: zod
+    .string()
+    .min(1, { message: i18n.t("stores.create.validation.currencyRequired") }),
   is_premium: zod.boolean(),
   media: zod.array(MediaSchema).optional(),
   bannerMedia: zod.array(MediaSchema).optional(),
@@ -100,6 +104,7 @@ const ensureWebsiteProtocol = (url: string): string | null => {
 export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
   const { t } = useTranslation();
   const { handleSuccess } = useRouteModal();
+  const { store: marketplaceStore } = useStore();
 
   const form = useExtendableForm({
     schema: EditStoreSchema,
@@ -114,6 +119,7 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
       email: seller.email ?? "",
       phone: seller.phone ?? "",
       website_url: stripWebsiteProtocol(seller.website_url),
+      currency_code: seller.currency_code?.toLowerCase() ?? "",
       is_premium: seller.is_premium ?? false,
       media: seller.logo
         ? [
@@ -193,6 +199,7 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
         phone: values.phone || null,
         description: values.description || null,
         website_url: ensureWebsiteProtocol(values.website_url ?? ""),
+        currency_code: values.currency_code.toLowerCase(),
         is_premium: values.is_premium,
         logo: logoUrl,
         banner: bannerUrl,
@@ -255,8 +262,7 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
     form.setValue("bannerMedia", [{ ...files[0], isThumbnail: false }]);
   };
 
-  const currencyCode = seller.currency_code?.toUpperCase() ?? "";
-  const currencyName = currencies[currencyCode]?.name ?? currencyCode;
+  const supportedCurrencies = marketplaceStore?.supported_currencies ?? [];
 
   return (
     <RouteDrawer.Form form={form}>
@@ -374,19 +380,43 @@ export const StoreEditForm = ({ seller }: StoreEditFormProps) => {
                 </Form.Item>
               )}
             />
-            <Form.Item>
-              <Form.Label>{t("fields.currency")}</Form.Label>
-              <Select value={currencyCode} disabled>
-                <Select.Trigger>
-                  <Select.Value placeholder={currencyName}>
-                    {currencyName}
-                  </Select.Value>
-                </Select.Trigger>
-                <Select.Content>
-                  <Select.Item value={currencyCode}>{currencyName}</Select.Item>
-                </Select.Content>
-              </Select>
-            </Form.Item>
+            <Form.Field
+              control={form.control}
+              name="currency_code"
+              render={({ field: { onChange, ref, value, ...field } }) => (
+                <Form.Item>
+                  <Form.Label>{t("fields.currency")}</Form.Label>
+                  <Form.Control>
+                    <Select
+                      {...field}
+                      value={value}
+                      onValueChange={onChange}
+                    >
+                      <Select.Trigger ref={ref}>
+                        <Select.Value
+                          placeholder={t("fields.selectPlaceholder")}
+                        />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {supportedCurrencies.map((sc) => {
+                          const code = sc.currency_code.toLowerCase();
+                          const label =
+                            currencies[code.toUpperCase()]?.name
+                              ? `${code.toUpperCase()} - ${currencies[code.toUpperCase()].name}`
+                              : code.toUpperCase();
+                          return (
+                            <Select.Item key={code} value={code}>
+                              {label}
+                            </Select.Item>
+                          );
+                        })}
+                      </Select.Content>
+                    </Select>
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
           </div>
           <SwitchBox
             control={form.control}

--- a/packages/core/src/api/admin/sellers/validators.ts
+++ b/packages/core/src/api/admin/sellers/validators.ts
@@ -85,6 +85,7 @@ export const UpdateSeller = z.object({
   banner: z.string().url().nullable().optional(),
   website_url: z.string().nullable().optional(),
   external_id: z.string().nullable().optional(),
+  currency_code: z.string().optional(),
   status: z.string().optional(),
   status_reason: z.string().nullable().optional(),
   is_premium: z.boolean().optional(),

--- a/packages/core/src/api/vendor/sellers/validators.ts
+++ b/packages/core/src/api/vendor/sellers/validators.ts
@@ -74,6 +74,7 @@ export const UpdateSeller = z.object({
   logo: z.string().url().nullable().optional(),
   banner: z.string().url().nullable().optional(),
   website_url: z.string().nullable().optional(),
+  currency_code: z.string().optional(),
   closed_from: z.coerce.date().nullable().optional(),
   closed_to: z.coerce.date().nullable().optional(),
   closure_note: z.string().nullable().optional(),

--- a/packages/types/src/seller/mutation.ts
+++ b/packages/types/src/seller/mutation.ts
@@ -25,6 +25,7 @@ export interface UpdateSellerDTO {
   banner?: string | null
   website_url?: string | null
   external_id?: string | null
+  currency_code?: string
   status?: string
   status_reason?: string | null
   is_premium?: boolean

--- a/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
+++ b/packages/vendor/src/pages/settings/store/edit/_components/edit-store-form.tsx
@@ -27,7 +27,7 @@ import { sdk } from "@lib/client";
 import { currencies } from "@lib/data/currencies";
 import { MediaSchema } from "@pages/products/create/constants";
 import { HttpTypes } from "@mercurjs/types";
-import { useUpdateSeller } from "@hooks/api";
+import { useStore, useUpdateSeller } from "@hooks/api";
 
 type EditStoreFormProps = HttpTypes.StoreSellerResponse;
 
@@ -43,6 +43,9 @@ const EditStoreSchema = zod.object({
   phone: zod.string().optional().or(zod.literal("")),
   description: zod.string().optional().or(zod.literal("")),
   website_url: zod.string().optional().or(zod.literal("")),
+  currency_code: zod
+    .string()
+    .min(1, { message: i18n.t("store.validation.currencyRequired") }),
   media: zod.array(MediaSchema).optional(),
   bannerMedia: zod.array(MediaSchema).optional(),
 });
@@ -92,6 +95,7 @@ const ensureWebsiteProtocol = (url: string): string | null => {
 export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
   const { t } = useTranslation();
   const { handleSuccess } = useRouteModal();
+  const { store: marketplaceStore } = useStore();
 
   const form = useExtendableForm({
     schema: EditStoreSchema,
@@ -105,6 +109,7 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
       phone: seller.phone ?? "",
       description: seller.description ?? "",
       website_url: stripWebsiteProtocol(seller.website_url),
+      currency_code: seller.currency_code?.toLowerCase() ?? "",
       media: seller.logo
         ? [
             {
@@ -182,6 +187,7 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
         phone: values.phone || null,
         description: values.description || null,
         website_url: ensureWebsiteProtocol(values.website_url),
+        currency_code: values.currency_code.toLowerCase(),
         logo: logoUrl,
         banner: bannerUrl,
         additional_data: values.additional_data,
@@ -239,8 +245,7 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
     form.setValue("bannerMedia", [{ ...files[0], isThumbnail: false }]);
   };
 
-  const currencyCode = seller.currency_code?.toUpperCase() ?? "";
-  const currencyName = currencies[currencyCode]?.name ?? currencyCode;
+  const supportedCurrencies = marketplaceStore?.supported_currencies ?? [];
 
   return (
     <RouteDrawer.Form form={form}>
@@ -330,19 +335,43 @@ export const EditStoreForm = ({ seller }: EditStoreFormProps) => {
                 </Form.Item>
               )}
             />
-            <Form.Item>
-              <Form.Label>{t("fields.currency")}</Form.Label>
-              <Select value={currencyCode} disabled>
-                <Select.Trigger>
-                  <Select.Value placeholder={currencyName}>
-                    {currencyName}
-                  </Select.Value>
-                </Select.Trigger>
-                <Select.Content>
-                  <Select.Item value={currencyCode}>{currencyName}</Select.Item>
-                </Select.Content>
-              </Select>
-            </Form.Item>
+            <Form.Field
+              control={form.control}
+              name="currency_code"
+              render={({ field: { onChange, ref, value, ...field } }) => (
+                <Form.Item>
+                  <Form.Label>{t("fields.currency")}</Form.Label>
+                  <Form.Control>
+                    <Select
+                      {...field}
+                      value={value}
+                      onValueChange={onChange}
+                    >
+                      <Select.Trigger ref={ref}>
+                        <Select.Value
+                          placeholder={t("fields.selectPlaceholder")}
+                        />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {supportedCurrencies.map((sc) => {
+                          const code = sc.currency_code.toLowerCase();
+                          const label =
+                            currencies[code.toUpperCase()]?.name
+                              ? `${code.toUpperCase()} - ${currencies[code.toUpperCase()].name}`
+                              : code.toUpperCase();
+                          return (
+                            <Select.Item key={code} value={code}>
+                              {label}
+                            </Select.Item>
+                          );
+                        })}
+                      </Select.Content>
+                    </Select>
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
           </div>
           <div className="border-ui-border-base border-t" />
           <div className="flex flex-col gap-y-4">


### PR DESCRIPTION
feat(store): enable editable currency selection in admin and vendor panels

- Add optional `currency_code` field to `UpdateSellerDTO` and backend Zod validation schemas for Admin and Vendor seller update endpoints.
- Update Admin store edit form (`StoreEditForm`) to allow admins to select and update store currency from the marketplace's supported currencies.
- Update Vendor store edit form (`EditStoreForm`) in settings to allow vendors to select and update store currency from the marketplace's supported currencies.
- Rebuild core, types, client, admin, and vendor package bundles.
