### PR TITLE
fix(core): declare zod as a runtime dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,6 @@
     "typescript": "5.9.3",
     "yalc": "^1.0.0-pre.53",
     "@medusajs/types": "2.17.2",
-    "zod": "4.4.3",
     "multer": "^2.0.2",
     "http-proxy-middleware": "^3.0.3",
     "jsonwebtoken": "^9.0.2",
@@ -97,6 +96,7 @@
   "dependencies": {
     "@orama/orama": "^3.1.18",
     "pkg-dir": "4",
-    "resolve-cwd": "^3.0.0"
+    "resolve-cwd": "^3.0.0",
+    "zod": "4.4.3"
   }
 }


### PR DESCRIPTION
## Summary

`@mercurjs/core` ships route validators that `import { z } from "zod"` at module scope, but `zod` was declared only in `devDependencies`. At runtime it therefore resolved to whatever `zod` the host workspace happened to hoist.

Medusa builds its validators (`createFindParams`, etc.) against the zod it bundles internally (`@medusajs/framework/zod`, zod 4 from Medusa 2.14.0 onward). Those schemas meet Mercur's own schemas inside `.merge(...)` calls in our validators. When a host pins a different major of zod (e.g. `zod@3`), `ZodObject.prototype.merge` in Medusa's zod 4 reads `b._zod.def.catchall` off Mercur's argument — a zod 3 object has `_def`, not `_zod`, so the read throws and the app dies during route registration, before serving a request:

```
An error occurred while registering API Routes.
Error: Cannot read properties of undefined (reading 'def')
```

The stack (once restored) points at `@mercurjs/core/src/api/admin/order-groups/validators.ts` `.merge(...)`, but the error names neither package, making it expensive to diagnose.

## Root cause

`packages/core/package.json` (2.1.6 through 2.2.1) listed `zod` under `devDependencies` only — no `dependencies` or `peerDependencies` entry — even though 64 shipped source files import it at runtime. Notably, **every other Mercur package that imports zod already declares it in `dependencies` at `4.4.3`** (`@mercurjs/admin`, `@mercurjs/vendor`, `@mercurjs/cli`, `@mercurjs/dashboard-shared`, `@mercurjs/registry`). Only `core` was inconsistent.

## Fix

Move `zod` from `devDependencies` to `dependencies`, pinned to `4.4.3` to match the sibling packages. `core` now always resolves a compatible zod 4 (which has the `_zod` shape Medusa's zod-4 `.merge()` expects) regardless of what the host workspace hoists, so the boot crash no longer happens on hosts that pin zod 3.

```diff
   "devDependencies": {
-    "zod": "4.4.3",
     ...
   },
   "dependencies": {
     "@orama/orama": "^3.1.18",
     "pkg-dir": "4",
-    "resolve-cwd": "^3.0.0"
+    "resolve-cwd": "^3.0.0",
+    "zod": "4.4.3"
   }
```

## Testing

- Metadata-only change; no source code touched, so type-checking / compilation behaviour is unchanged (`dependencies` are available at build time just as `devDependencies` were).
- Verified `packages/core/package.json` remains valid JSON and that `zod` now appears under `dependencies` and no longer under `devDependencies`.

Fixes #1302