### PR TITLE
fix(admin): use built-in password reveal on login field

### DIFF
--- a/packages/admin/src/pages/login/login.tsx
+++ b/packages/admin/src/pages/login/login.tsx
@@ -1,8 +1,7 @@
-import { Children, ReactNode, useEffect, useState } from "react";
+import { Children, ReactNode, useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import i18n from "i18next";
-import { Button, Heading, IconButton, Input, Text, toast } from "@medusajs/ui";
-import { Eye, EyeSlash } from "@medusajs/icons";
+import { Button, Heading, Input, Text, toast } from "@medusajs/ui";
 import { useForm } from "react-hook-form";
 import { Trans, useTranslation } from "react-i18next";
 import {
@@ -54,7 +53,6 @@ const LoginForm = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const [showPassword, setShowPassword] = useState(false);
 
   const reason = searchParams.get("reason") || "";
   const from = location.state?.from?.pathname || "/orders";
@@ -131,28 +129,12 @@ const LoginForm = () => {
               <Form.Item>
                 <Form.Label>{t("fields.password")}</Form.Label>
                 <Form.Control>
-                  <div className="relative">
-                    <Input
-                      type={showPassword ? "text" : "password"}
-                      autoComplete="current-password"
-                      {...field}
-                      className="pr-10"
-                      data-testid="login-password-input"
-                    />
-                    <IconButton
-                      type="button"
-                      size="small"
-                      variant="transparent"
-                      className="absolute inset-y-0 right-1 my-auto"
-                      onClick={() => setShowPassword((prev) => !prev)}
-                      aria-label={t(
-                        showPassword ? "login.hidePassword" : "login.showPassword",
-                      )}
-                      data-testid="login-password-toggle"
-                    >
-                      {showPassword ? <EyeSlash /> : <Eye />}
-                    </IconButton>
-                  </div>
+                  <Input
+                    type="password"
+                    autoComplete="current-password"
+                    {...field}
+                    data-testid="login-password-input"
+                  />
                 </Form.Control>
                 <Form.ErrorMessage />
               </Form.Item>


### PR DESCRIPTION
## Problem

The admin login screen showed an oversized eye icon overflowing the password field.

## Cause

The login form re-implemented a custom show/hide password toggle, positioning its `IconButton` with `absolute inset-y-0 ... my-auto`. `inset-y-0` (top:0 + bottom:0) stretched the button to the full height of the input, so the eye icon rendered enlarged and overflowed.

## Fix

`@medusajs/ui`'s `Input` already ships a correctly-positioned password reveal toggle out of the box when given `type="password"` — this is the pattern Medusa uses in its own dashboard. We drop the custom wrapper (state, `IconButton`, `Eye`/`EyeSlash` imports) and rely on the built-in one, which keeps the icon at its natural size and correctly aligned.