### PR TITLE
fix(admin): default campaigns list to created_at order

### DIFF
--- a/packages/admin/src/hooks/table/query/use-campaign-table-query.tsx
+++ b/packages/admin/src/hooks/table/query/use-campaign-table-query.tsx
@@ -37,7 +37,7 @@ export const useCampaignTableQuery = ({
   const searchParams = {
     limit: pageSize,
     offset: offset ? Number(offset) : 0,
-    order,
+    order: order || "-created_at",
     fields: "+seller.id,+seller.name,+budget.type",
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,

--- a/packages/admin/src/pages/campaigns/campaign-list/components/campaign-list-table.tsx
+++ b/packages/admin/src/pages/campaigns/campaign-list/components/campaign-list-table.tsx
@@ -112,6 +112,7 @@ export const CampaignListDataTable = () => {
       navigateTo={(row) => row.id}
       isLoading={isLoading}
       queryObject={raw}
+      defaultOrder="-created_at"
       orderBy={[
         { key: "name", label: t("fields.name") },
         { key: "created_at", label: t("fields.createdAt") },


### PR DESCRIPTION
## Summary

The admin campaigns list had no default sort, so the order-by control showed nothing selected and results came back unsorted.

This change defaults the list to **Created At (descending)**:

- `use-campaign-table-query.tsx` — request now sends `order: order || "-created_at"` so data is sorted newest-first by default.
- `campaign-list-table.tsx` — passes `defaultOrder="-created_at"` to the data table so "Created At" shows as the selected option in the order-by menu without requiring a URL param.

Users can still change the sort key/direction; explicit `order` params take precedence.

## Testing
- `bun run build`