### PR TITLE
feat(inventory): align vendor inventory panel with Figma (MER-141)

### DIFF
--- a/integration-tests/http/inventory/vendor/inventory.spec.ts
+++ b/integration-tests/http/inventory/vendor/inventory.spec.ts
@@ -1,0 +1,254 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+  ISalesChannelModuleService,
+  MedusaContainer,
+} from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
+import { MercurModules, SellerStatus } from "@mercurjs/types"
+
+import {
+  adminHeaders,
+  createAdminUser,
+} from "../../../helpers/create-admin-user"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
+
+jest.setTimeout(60000)
+
+/**
+ * Vendor Inventory (MER-141, spec-3-vendor-inventory).
+ *
+ * The vendor inventory list adds a **Product** column (the master-product
+ * title) — the vendor is seller-scoped, so there is NO Store column. The
+ * product title is requested off `GET /vendor/inventory-items` via
+ * `fields=+offers.product_variant.product.title` (item → offer → variant →
+ * product; alias `offers`, memory `offer-inventory-not-on-variant`).
+ *
+ * These tests guard ground-rule #15: the offers/product join must resolve
+ * NON-EMPTY at runtime, and the vendor list must stay seller-scoped (a vendor
+ * never sees another store's items).
+ */
+const approveSeller = async (container: MedusaContainer, sellerId: string) => {
+  const sellerModule = container.resolve(MercurModules.SELLER) as {
+    updateSellers: (data: {
+      id: string
+      status: SellerStatus
+    }) => Promise<unknown>
+  }
+  await sellerModule.updateSellers({ id: sellerId, status: SellerStatus.OPEN })
+}
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api, dbConnection }) => {
+    describe("Vendor - Inventory (Product column + seller scoping)", () => {
+      let container: MedusaContainer
+      let counter = 0
+
+      beforeEach(async () => {
+        container = getContainer()
+        await createAdminUser(dbConnection, adminHeaders, container)
+      })
+
+      /**
+       * Seed a seller that owns one offer-backed inventory item, mirroring the
+       * production chain: seller → stock location + fulfillment + shipping
+       * profile → product → offer (with an inventory item + stock level).
+       * Returns the seller's id, name, headers, and the offer's sku.
+       */
+      const seedSellerInventory = async (opts: {
+        email: string
+        name: string
+        productTitle: string
+        offerSku: string
+        stocked?: number
+      }) => {
+        const { seller, headers } = await createSellerUser(container, {
+          email: opts.email,
+          name: opts.name,
+        })
+        const sellerId = (seller as { id: string }).id
+        await approveSeller(container, sellerId)
+
+        const tag = `_${++counter}_${Date.now()}`
+
+        const salesChannel = await container
+          .resolve<ISalesChannelModuleService>(Modules.SALES_CHANNEL)
+          .createSalesChannels({ name: `SC${tag}` })
+
+        const stockLocation = (
+          await api.post(
+            `/vendor/stock-locations`,
+            { name: `WH${tag}` },
+            headers
+          )
+        ).data.stock_location
+
+        await api.post(
+          `/vendor/stock-locations/${stockLocation.id}/fulfillment-sets`,
+          { name: `FS${tag}`, type: "shipping" },
+          headers
+        )
+        const fulfillmentSet = (
+          await api.get(
+            `/vendor/stock-locations/${stockLocation.id}?fields=*fulfillment_sets`,
+            headers
+          )
+        ).data.stock_location.fulfillment_sets[0]
+
+        const serviceZone = (
+          await api.post(
+            `/vendor/fulfillment-sets/${fulfillmentSet.id}/service-zones`,
+            {
+              name: `SZ${tag}`,
+              geo_zones: [{ type: "country", country_code: "us" }],
+            },
+            headers
+          )
+        ).data.fulfillment_set.service_zones.find(
+          (z: { name: string }) => z.name === `SZ${tag}`
+        )
+
+        const shippingProfile = (
+          await api.post(
+            `/vendor/shipping-profiles`,
+            { name: `SP${tag}`, type: "default" },
+            headers
+          )
+        ).data.shipping_profile
+
+        await api.post(
+          `/vendor/stock-locations/${stockLocation.id}/fulfillment-providers`,
+          { add: ["manual_manual"] },
+          headers
+        )
+        await api.post(
+          `/vendor/stock-locations/${stockLocation.id}/sales-channels`,
+          { add: [salesChannel.id] },
+          headers
+        )
+        await api.post(
+          `/vendor/shipping-options`,
+          {
+            name: `Ship${tag}`,
+            service_zone_id: serviceZone.id,
+            shipping_profile_id: shippingProfile.id,
+            provider_id: "manual_manual",
+            price_type: "flat",
+            type: {
+              label: "Standard",
+              description: "Standard",
+              code: "standard",
+            },
+            prices: [{ currency_code: "usd", amount: 500 }],
+            rules: [
+              { attribute: "enabled_in_store", value: "true", operator: "eq" },
+            ],
+          },
+          headers
+        )
+
+        const product = await createVendorProduct(api, headers, {
+          title: opts.productTitle,
+          sku: `V${tag}`,
+        })
+        await api.post(
+          `/vendor/sales-channels/${salesChannel.id}/products`,
+          { add: [product.id] },
+          headers
+        )
+
+        await api.post(
+          `/vendor/offers`,
+          {
+            sku: opts.offerSku,
+            variant_id: product.variants[0].id,
+            shipping_profile_id: shippingProfile.id,
+            inventory_items: [
+              {
+                title: opts.productTitle,
+                required_quantity: 1,
+                stock_levels: [
+                  {
+                    location_id: stockLocation.id,
+                    stocked_quantity: opts.stocked ?? 100,
+                  },
+                ],
+              },
+            ],
+            prices: [{ amount: 1000, currency_code: "usd" }],
+          },
+          headers
+        )
+
+        return { sellerId, sellerName: opts.name, headers, offerSku: opts.offerSku }
+      }
+
+      it("resolves the Product column via the offer's variant product, plus stock quantities", async () => {
+        const { headers, offerSku } = await seedSellerInventory({
+          email: "vinv-product@medusa.js",
+          name: "Vendor Store One",
+          productTitle: "A-Line Dress",
+          offerSku: "V-OF-1",
+          stocked: 100,
+        })
+
+        const res = await api.get(
+          `/vendor/inventory-items?fields=id,sku,stocked_quantity,reserved_quantity,+offers.product_variant.product.title`,
+          headers
+        )
+        expect(res.status).toEqual(200)
+
+        const item = (
+          res.data.inventory_items as Array<{
+            sku?: string
+            stocked_quantity?: number
+            reserved_quantity?: number
+            offers?: Array<{
+              product_variant?: { product?: { title?: string } }
+            }>
+          }>
+        ).find((i) => i.sku === offerSku)
+
+        expect(item).toBeDefined()
+        // Product column reads offers[0].product_variant.product.title
+        expect(item!.offers?.[0]?.product_variant?.product?.title).toEqual(
+          "A-Line Dress"
+        )
+        // In stock / Reserved columns read the server accessors
+        expect(item!.stocked_quantity).toEqual(100)
+        expect(item!.reserved_quantity).toEqual(0)
+      })
+
+      it("scopes the vendor list to the caller's own store", async () => {
+        const a = await seedSellerInventory({
+          email: "vinv-a@medusa.js",
+          name: "Vendor Store A",
+          productTitle: "Prod A",
+          offerSku: "V-OF-A",
+        })
+        const b = await seedSellerInventory({
+          email: "vinv-b@medusa.js",
+          name: "Vendor Store B",
+          productTitle: "Prod B",
+          offerSku: "V-OF-B",
+        })
+
+        const res = await api.get(
+          `/vendor/inventory-items?fields=id,sku`,
+          a.headers
+        )
+        expect(res.status).toEqual(200)
+
+        const skus = new Set(
+          (res.data.inventory_items as Array<{ sku?: string }>).map(
+            (i) => i.sku
+          )
+        )
+        // Seller A sees its own item...
+        expect(skus.has(a.offerSku)).toBe(true)
+        // ...but never seller B's.
+        expect(skus.has(b.offerSku)).toBe(false)
+      })
+    })
+  },
+})

--- a/integration-tests/http/inventory/vendor/inventory.spec.ts
+++ b/integration-tests/http/inventory/vendor/inventory.spec.ts
@@ -165,6 +165,7 @@ medusaIntegrationTestRunner({
             shipping_profile_id: shippingProfile.id,
             inventory_items: [
               {
+                sku: opts.offerSku,
                 title: opts.productTitle,
                 required_quantity: 1,
                 stock_levels: [

--- a/integration-tests/http/reservations/vendor/reservations.spec.ts
+++ b/integration-tests/http/reservations/vendor/reservations.spec.ts
@@ -1,0 +1,268 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+  ISalesChannelModuleService,
+  MedusaContainer,
+} from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
+import { MercurModules, SellerStatus } from "@mercurjs/types"
+
+import {
+  adminHeaders,
+  createAdminUser,
+} from "../../../helpers/create-admin-user"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
+
+jest.setTimeout(60000)
+
+/**
+ * Vendor Reservations — seller scoping (MER-141).
+ *
+ * Reservations have no direct reservation↔seller link; a reservation belongs to
+ * a seller only through its inventory item (`inventory_item_seller`). The vendor
+ * reservation middlewares scope every route to the caller's own inventory items.
+ * These tests guard that a vendor can never see, delete, or create a reservation
+ * against another store's inventory.
+ */
+const approveSeller = async (container: MedusaContainer, sellerId: string) => {
+  const sellerModule = container.resolve(MercurModules.SELLER) as {
+    updateSellers: (data: {
+      id: string
+      status: SellerStatus
+    }) => Promise<unknown>
+  }
+  await sellerModule.updateSellers({ id: sellerId, status: SellerStatus.OPEN })
+}
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api, dbConnection }) => {
+    describe("Vendor - Reservations (seller scoping)", () => {
+      let container: MedusaContainer
+      let counter = 0
+
+      beforeEach(async () => {
+        container = getContainer()
+        await createAdminUser(dbConnection, adminHeaders, container)
+      })
+
+      // Seed a seller that owns one offer-backed inventory item with stock, then
+      // return everything needed to create/inspect its reservations.
+      const seedSellerWithReservation = async (opts: {
+        email: string
+        name: string
+        offerSku: string
+      }) => {
+        const { seller, headers } = await createSellerUser(container, {
+          email: opts.email,
+          name: opts.name,
+        })
+        const sellerId = (seller as { id: string }).id
+        await approveSeller(container, sellerId)
+
+        const tag = `_${++counter}_${Date.now()}`
+
+        const salesChannel = await container
+          .resolve<ISalesChannelModuleService>(Modules.SALES_CHANNEL)
+          .createSalesChannels({ name: `SC${tag}` })
+
+        const stockLocation = (
+          await api.post(`/vendor/stock-locations`, { name: `WH${tag}` }, headers)
+        ).data.stock_location
+
+        await api.post(
+          `/vendor/stock-locations/${stockLocation.id}/fulfillment-sets`,
+          { name: `FS${tag}`, type: "shipping" },
+          headers
+        )
+        const fulfillmentSet = (
+          await api.get(
+            `/vendor/stock-locations/${stockLocation.id}?fields=*fulfillment_sets`,
+            headers
+          )
+        ).data.stock_location.fulfillment_sets[0]
+
+        const serviceZone = (
+          await api.post(
+            `/vendor/fulfillment-sets/${fulfillmentSet.id}/service-zones`,
+            {
+              name: `SZ${tag}`,
+              geo_zones: [{ type: "country", country_code: "us" }],
+            },
+            headers
+          )
+        ).data.fulfillment_set.service_zones.find(
+          (z: { name: string }) => z.name === `SZ${tag}`
+        )
+
+        const shippingProfile = (
+          await api.post(
+            `/vendor/shipping-profiles`,
+            { name: `SP${tag}`, type: "default" },
+            headers
+          )
+        ).data.shipping_profile
+
+        await api.post(
+          `/vendor/stock-locations/${stockLocation.id}/fulfillment-providers`,
+          { add: ["manual_manual"] },
+          headers
+        )
+        await api.post(
+          `/vendor/stock-locations/${stockLocation.id}/sales-channels`,
+          { add: [salesChannel.id] },
+          headers
+        )
+        await api.post(
+          `/vendor/shipping-options`,
+          {
+            name: `Ship${tag}`,
+            service_zone_id: serviceZone.id,
+            shipping_profile_id: shippingProfile.id,
+            provider_id: "manual_manual",
+            price_type: "flat",
+            type: { label: "Standard", description: "Standard", code: "standard" },
+            prices: [{ currency_code: "usd", amount: 500 }],
+            rules: [
+              { attribute: "enabled_in_store", value: "true", operator: "eq" },
+            ],
+          },
+          headers
+        )
+
+        const product = await createVendorProduct(api, headers, {
+          title: `Prod${tag}`,
+          sku: `V${tag}`,
+        })
+        await api.post(
+          `/vendor/sales-channels/${salesChannel.id}/products`,
+          { add: [product.id] },
+          headers
+        )
+
+        await api.post(
+          `/vendor/offers`,
+          {
+            sku: opts.offerSku,
+            variant_id: product.variants[0].id,
+            shipping_profile_id: shippingProfile.id,
+            inventory_items: [
+              {
+                title: `Item${tag}`,
+                required_quantity: 1,
+                stock_levels: [
+                  { location_id: stockLocation.id, stocked_quantity: 100 },
+                ],
+              },
+            ],
+            prices: [{ amount: 1000, currency_code: "usd" }],
+          },
+          headers
+        )
+
+        // Resolve the seller's own inventory item + create a reservation on it.
+        const item = (
+          await api.get(`/vendor/inventory-items?sku=${opts.offerSku}`, headers)
+        ).data.inventory_items[0]
+
+        const reservation = (
+          await api.post(
+            `/vendor/reservations`,
+            {
+              inventory_item_id: item.id,
+              location_id: stockLocation.id,
+              quantity: 2,
+            },
+            headers
+          )
+        ).data.reservation
+
+        return { sellerId, headers, itemId: item.id, reservationId: reservation.id }
+      }
+
+      it("lists only the caller's own reservations", async () => {
+        const a = await seedSellerWithReservation({
+          email: "resv-a@medusa.js",
+          name: "Resv Store A",
+          offerSku: "RESV-OF-A",
+        })
+        await seedSellerWithReservation({
+          email: "resv-b@medusa.js",
+          name: "Resv Store B",
+          offerSku: "RESV-OF-B",
+        })
+
+        const res = await api.get(`/vendor/reservations`, a.headers)
+        expect(res.status).toEqual(200)
+
+        const itemIds = new Set(
+          (res.data.reservations as Array<{ inventory_item_id: string }>).map(
+            (r) => r.inventory_item_id
+          )
+        )
+        // Seller A sees only its own item's reservation, nothing from B.
+        expect(itemIds.has(a.itemId)).toBe(true)
+        expect(itemIds.size).toBe(1)
+        expect(res.data.count).toBe(1)
+      })
+
+      it("returns empty when filtering by another seller's inventory item", async () => {
+        const a = await seedSellerWithReservation({
+          email: "resv-c@medusa.js",
+          name: "Resv Store C",
+          offerSku: "RESV-OF-C",
+        })
+        const b = await seedSellerWithReservation({
+          email: "resv-d@medusa.js",
+          name: "Resv Store D",
+          offerSku: "RESV-OF-D",
+        })
+
+        const res = await api.get(
+          `/vendor/reservations?inventory_item_id=${b.itemId}`,
+          a.headers
+        )
+        expect(res.status).toEqual(200)
+        expect(res.data.count).toBe(0)
+      })
+
+      it("blocks reading, deleting, and creating against another seller's reservation/item", async () => {
+        const a = await seedSellerWithReservation({
+          email: "resv-e@medusa.js",
+          name: "Resv Store E",
+          offerSku: "RESV-OF-E",
+        })
+        const b = await seedSellerWithReservation({
+          email: "resv-f@medusa.js",
+          name: "Resv Store F",
+          offerSku: "RESV-OF-F",
+        })
+
+        // A cannot read B's reservation by id.
+        await expect(
+          api.get(`/vendor/reservations/${b.reservationId}`, a.headers)
+        ).rejects.toMatchObject({ response: { status: 404 } })
+
+        // A cannot delete B's reservation.
+        await expect(
+          api.delete(`/vendor/reservations/${b.reservationId}`, a.headers)
+        ).rejects.toMatchObject({ response: { status: 404 } })
+
+        // A cannot create a reservation against B's inventory item.
+        await expect(
+          api.post(
+            `/vendor/reservations`,
+            { inventory_item_id: b.itemId, location_id: b.itemId, quantity: 1 },
+            a.headers
+          )
+        ).rejects.toMatchObject({ response: { status: expect.any(Number) } })
+
+        // B's reservation still exists (A's failed calls didn't touch it).
+        const stillThere = await api.get(
+          `/vendor/reservations/${b.reservationId}`,
+          b.headers
+        )
+        expect(stillThere.status).toEqual(200)
+      })
+    })
+  },
+})

--- a/integration-tests/http/reservations/vendor/reservations.spec.ts
+++ b/integration-tests/http/reservations/vendor/reservations.spec.ts
@@ -147,6 +147,7 @@ medusaIntegrationTestRunner({
             shipping_profile_id: shippingProfile.id,
             inventory_items: [
               {
+                sku: opts.offerSku,
                 title: `Item${tag}`,
                 required_quantity: 1,
                 stock_levels: [

--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -4775,6 +4775,54 @@
             "editQuantityWarning"
           ],
           "additionalProperties": false
+        },
+        "list": {
+          "type": "object",
+          "properties": {
+            "noRecordsTitle": {
+              "type": "string"
+            },
+            "noRecordsMessage": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "noRecordsTitle",
+            "noRecordsMessage"
+          ],
+          "additionalProperties": false
+        },
+        "locations": {
+          "type": "object",
+          "properties": {
+            "noRecordsTitle": {
+              "type": "string"
+            },
+            "noRecordsMessage": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "noRecordsTitle",
+            "noRecordsMessage"
+          ],
+          "additionalProperties": false
+        },
+        "reservations": {
+          "type": "object",
+          "properties": {
+            "noRecordsTitle": {
+              "type": "string"
+            },
+            "noRecordsMessage": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "noRecordsTitle",
+            "noRecordsMessage"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
@@ -4799,7 +4847,10 @@
         "reservation",
         "adjustInventory",
         "toast",
-        "stock"
+        "stock",
+        "list",
+        "locations",
+        "reservations"
       ],
       "additionalProperties": false
     },

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -1174,6 +1174,18 @@
       "confirmTitle": "Edit stock levels",
       "confirmDescription": "You are about to edit stock levels in Stores locations. Before making changes to stock levels, please confirm them with the Vendors to avoid data inconsistencies or misunderstandings.",
       "editQuantityWarning": "You are editing Store location quantity. Before making changes to stock levels, please confirm them with the Vendor to avoid data inconsistencies or misunderstandings."
+    },
+    "list": {
+      "noRecordsTitle": "No inventory items yet",
+      "noRecordsMessage": "Inventory items from your stores appear here."
+    },
+    "locations": {
+      "noRecordsTitle": "No locations yet",
+      "noRecordsMessage": "Add a location to start managing stock levels"
+    },
+    "reservations": {
+      "noRecordsTitle": "No reservations yet",
+      "noRecordsMessage": "There are no reservations to show"
     }
   },
   "giftCards": {

--- a/packages/admin/src/pages/inventory/inventory-detail/components/location-levels-table/location-list-table.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/components/location-levels-table/location-list-table.tsx
@@ -7,6 +7,7 @@ import { useDataTable } from "@hooks/use-data-table";
 
 import { useLocationListTableColumns } from "./use-location-list-table-columns";
 import { useLocationLevelTableQuery } from "./use-location-list-table-query";
+import { useTranslation } from "react-i18next";
 
 const PAGE_SIZE = 20;
 const PREFIX = "invlvl";
@@ -16,6 +17,7 @@ export const ItemLocationListTable = ({
 }: {
   inventory_item_id: string;
 }) => {
+  const { t } = useTranslation();
   const { searchParams, raw } = useLocationLevelTableQuery({
     pageSize: PAGE_SIZE,
     prefix: PREFIX,
@@ -57,6 +59,10 @@ export const ItemLocationListTable = ({
         isLoading={isLoading}
         pagination
         queryObject={raw}
+        noRecords={{
+          title: t("inventory.locations.noRecordsTitle"),
+          message: t("inventory.locations.noRecordsMessage"),
+        }}
       />
     </div>
   );

--- a/packages/admin/src/pages/inventory/inventory-detail/components/reservations-table/reservation-list-table.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/components/reservations-table/reservation-list-table.tsx
@@ -1,5 +1,6 @@
 import type { HttpTypes } from "@medusajs/types"
 import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
 
 import { _DataTable } from "../../../../../components/table/data-table"
 import { useStockLocations } from "../../../../../hooks/api"
@@ -18,6 +19,7 @@ export const ReservationItemTable = ({
 }: {
   inventoryItem: HttpTypes.AdminInventoryItemResponse["inventory_item"]
 }) => {
+  const { t } = useTranslation()
   const { searchParams, raw } = useReservationsTableQuery({
     pageSize: PAGE_SIZE,
   })
@@ -66,6 +68,10 @@ export const ReservationItemTable = ({
         isLoading={isPending}
         pagination
         queryObject={raw}
+        noRecords={{
+          title: t("inventory.reservations.noRecordsTitle"),
+          message: t("inventory.reservations.noRecordsMessage"),
+        }}
       />
     </div>
   )

--- a/packages/admin/src/pages/inventory/inventory-list/components/inventory-list-table.tsx
+++ b/packages/admin/src/pages/inventory/inventory-list/components/inventory-list-table.tsx
@@ -1,4 +1,5 @@
 import { InventoryTypes, ProductVariantDTO } from "@medusajs/types"
+import { Buildings } from "@medusajs/icons"
 import { Container, Heading, Text } from "@medusajs/ui"
 
 import { ColumnDef, RowSelectionState } from "@tanstack/react-table"
@@ -145,6 +146,11 @@ export const InventoryListDataTable = () => {
           { key: "reserved_quantity", label: t("inventory.reserved") },
         ]}
         defaultOrder="title"
+        noRecords={{
+          icon: <Buildings className="text-ui-fg-subtle" />,
+          title: t("inventory.list.noRecordsTitle"),
+          message: t("inventory.list.noRecordsMessage"),
+        }}
         navigateTo={(row) => `${row.id}`}
         commands={[
           {

--- a/packages/core/src/api/vendor/reservations/middlewares.ts
+++ b/packages/core/src/api/vendor/reservations/middlewares.ts
@@ -1,20 +1,147 @@
 import {
+  AuthenticatedMedusaRequest,
+  MedusaNextFunction,
+  MedusaResponse,
   MiddlewareRoute,
 } from "@medusajs/framework/http"
 import {
   validateAndTransformBody,
   validateAndTransformQuery,
 } from "@medusajs/framework"
-
 import {
-  vendorReservationQueryConfig,
-} from "./query-config"
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+
+import { vendorReservationQueryConfig } from "./query-config"
 import {
   VendorCreateReservation,
   VendorGetReservationParams,
   VendorGetReservationsParams,
   VendorUpdateReservation,
 } from "./validators"
+
+/**
+ * Reservations have no direct reservation↔seller link — they belong to a seller
+ * only through their inventory item (`inventory_item_seller`). These middlewares
+ * scope the vendor reservation routes to the caller's own inventory items so a
+ * vendor can never read, list, edit, delete, or create a reservation against
+ * another store's inventory.
+ */
+const getSellerInventoryItemIds = async (
+  req: AuthenticatedMedusaRequest,
+  restrictTo?: string[]
+): Promise<string[]> => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const filters: Record<string, unknown> = {
+    seller_id: req.seller_context!.seller_id,
+  }
+  if (restrictTo?.length) {
+    filters.inventory_item_id = restrictTo
+  }
+
+  const { data } = await query.graph({
+    entity: "inventory_item_seller",
+    fields: ["inventory_item_id"],
+    filters,
+    pagination: {
+      take: restrictTo?.length ? restrictTo.length : 100000,
+      skip: 0,
+    },
+  })
+
+  return (data as Array<{ inventory_item_id: string }>).map(
+    (row) => row.inventory_item_id
+  )
+}
+
+const applySellerReservationsFilter = async (
+  req: AuthenticatedMedusaRequest,
+  _res: MedusaResponse,
+  next: MedusaNextFunction
+) => {
+  try {
+    const requested = req.filterableFields.inventory_item_id as
+      | string
+      | string[]
+      | undefined
+
+    let allowedIds: string[]
+    if (requested !== undefined && requested !== null) {
+      const requestedIds = Array.isArray(requested) ? requested : [requested]
+      // Keep only the requested items the seller actually owns.
+      allowedIds = await getSellerInventoryItemIds(req, requestedIds)
+    } else {
+      allowedIds = await getSellerInventoryItemIds(req)
+    }
+
+    // Sentinel that matches nothing, so an empty set never widens the query.
+    req.filterableFields.inventory_item_id = allowedIds.length
+      ? allowedIds
+      : ["__none__"]
+
+    return next()
+  } catch (error) {
+    return next(error)
+  }
+}
+
+const assertReservationOwnership = async (
+  req: AuthenticatedMedusaRequest,
+  _res: MedusaResponse,
+  next: MedusaNextFunction
+) => {
+  try {
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "reservation",
+      fields: ["id", "inventory_item_id"],
+      filters: { id: req.params.id },
+    })
+
+    const reservation = data[0] as
+      | { id: string; inventory_item_id: string }
+      | undefined
+
+    const owned = reservation
+      ? await getSellerInventoryItemIds(req, [reservation.inventory_item_id])
+      : []
+
+    if (!reservation || !owned.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Reservation with id: ${req.params.id} was not found`
+      )
+    }
+
+    return next()
+  } catch (error) {
+    return next(error)
+  }
+}
+
+const assertCreateReservationOwnership = async (
+  req: AuthenticatedMedusaRequest,
+  _res: MedusaResponse,
+  next: MedusaNextFunction
+) => {
+  try {
+    const itemId = (req.validatedBody as { inventory_item_id?: string })
+      ?.inventory_item_id
+    const owned = itemId ? await getSellerInventoryItemIds(req, [itemId]) : []
+
+    if (!owned.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "You are not allowed to create a reservation for this inventory item"
+      )
+    }
+
+    return next()
+  } catch (error) {
+    return next(error)
+  }
+}
 
 export const vendorReservationsMiddlewares: MiddlewareRoute[] = [
   {
@@ -25,6 +152,7 @@ export const vendorReservationsMiddlewares: MiddlewareRoute[] = [
         VendorGetReservationsParams,
         vendorReservationQueryConfig.list
       ),
+      applySellerReservationsFilter,
     ],
   },
   {
@@ -35,6 +163,7 @@ export const vendorReservationsMiddlewares: MiddlewareRoute[] = [
         VendorGetReservationParams,
         vendorReservationQueryConfig.retrieve
       ),
+      assertReservationOwnership,
     ],
   },
   {
@@ -42,6 +171,7 @@ export const vendorReservationsMiddlewares: MiddlewareRoute[] = [
     matcher: "/vendor/reservations",
     middlewares: [
       validateAndTransformBody(VendorCreateReservation),
+      assertCreateReservationOwnership,
       validateAndTransformQuery(
         VendorGetReservationParams,
         vendorReservationQueryConfig.retrieve
@@ -53,6 +183,7 @@ export const vendorReservationsMiddlewares: MiddlewareRoute[] = [
     matcher: "/vendor/reservations/:id",
     middlewares: [
       validateAndTransformBody(VendorUpdateReservation),
+      assertReservationOwnership,
       validateAndTransformQuery(
         VendorGetReservationParams,
         vendorReservationQueryConfig.retrieve
@@ -62,6 +193,6 @@ export const vendorReservationsMiddlewares: MiddlewareRoute[] = [
   {
     method: ["DELETE"],
     matcher: "/vendor/reservations/:id",
-    middlewares: [],
+    middlewares: [assertReservationOwnership],
   },
 ]

--- a/packages/vendor/src/extension-targets.d.ts
+++ b/packages/vendor/src/extension-targets.d.ts
@@ -189,7 +189,7 @@ declare module "@mercurjs/dashboard-sdk" {
     "inventory_item": {
       formZones: "edit"
       formTabs: Record<string, string>
-      displayZones: "attributes" | "general" | "locations" | "variants"
+      displayZones: "attributes" | "general" | "locations" | "reservations" | "variants"
       displayFieldIds: "available" | "in_stock" | "reserved" | "sku" | "title"
     }
     "member": {

--- a/packages/vendor/src/get-route-map.tsx
+++ b/packages/vendor/src/get-route-map.tsx
@@ -1087,9 +1087,6 @@ export function getRouteMap({
               },
 
               // RESERVATIONS
-              // Detail (`:id`) is intentionally not registered yet — that page
-              // imports a non-existent `@/extensions` module and would break the
-              // build; enable it once that pre-existing code is fixed.
               {
                 path: "/reservations",
                 errorElement: <ErrorBoundary />,
@@ -1102,6 +1099,42 @@ export function getRouteMap({
                       {
                         path: "create",
                         lazy: () => import("./pages/reservations/create"),
+                      },
+                    ],
+                  },
+                  {
+                    path: ":id",
+                    lazy: async () => {
+                      const { Breadcrumb } = await import(
+                        "./pages/reservations/[id]"
+                      );
+                      return {
+                        Component: Outlet,
+                        handle: {
+                          breadcrumb: (match: UIMatch<any>) => (
+                            <Breadcrumb {...match} />
+                          ),
+                        },
+                      };
+                    },
+                    children: [
+                      {
+                        path: "",
+                        lazy: () => import("./pages/reservations/[id]"),
+                        children: [
+                          {
+                            path: "edit",
+                            lazy: () =>
+                              import(
+                                "./pages/reservations/[id]/_components/edit-reservation"
+                              ),
+                          },
+                          {
+                            path: "metadata/edit",
+                            lazy: () =>
+                              import("./pages/reservations/[id]/metadata"),
+                          },
+                        ],
                       },
                     ],
                   },

--- a/packages/vendor/src/get-route-map.tsx
+++ b/packages/vendor/src/get-route-map.tsx
@@ -1086,11 +1086,27 @@ export function getRouteMap({
                 ],
               },
 
-              // RESERVATIONS - disabled
-              // {
-              //   path: "/reservations",
-              //   ...
-              // },
+              // RESERVATIONS
+              // Detail (`:id`) is intentionally not registered yet — that page
+              // imports a non-existent `@/extensions` module and would break the
+              // build; enable it once that pre-existing code is fixed.
+              {
+                path: "/reservations",
+                errorElement: <ErrorBoundary />,
+                handle: { breadcrumb: () => t("reservations.domain") },
+                children: [
+                  {
+                    path: "",
+                    lazy: () => import("./pages/reservations"),
+                    children: [
+                      {
+                        path: "create",
+                        lazy: () => import("./pages/reservations/create"),
+                      },
+                    ],
+                  },
+                ],
+              },
             ],
             customMainRoutes,
           ),

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -4355,6 +4355,21 @@
             },
             "successToast": {
               "type": "string"
+            },
+            "errors": {
+              "type": "object",
+              "properties": {
+                "titleRequired": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "titleRequired"
+              ],
+              "additionalProperties": false
+            },
+            "attributesHint": {
+              "type": "string"
             }
           },
           "required": [
@@ -4366,7 +4381,9 @@
             "requiresShipping",
             "requiresShippingHint",
             "descriptionPlaceholder",
-            "successToast"
+            "successToast",
+            "errors",
+            "attributesHint"
           ],
           "additionalProperties": false
         },
@@ -4626,6 +4643,54 @@
             "deleteDescription"
           ],
           "additionalProperties": false
+        },
+        "list": {
+          "type": "object",
+          "properties": {
+            "noRecordsTitle": {
+              "type": "string"
+            },
+            "noRecordsMessage": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "noRecordsTitle",
+            "noRecordsMessage"
+          ],
+          "additionalProperties": false
+        },
+        "locations": {
+          "type": "object",
+          "properties": {
+            "noRecordsTitle": {
+              "type": "string"
+            },
+            "noRecordsMessage": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "noRecordsTitle",
+            "noRecordsMessage"
+          ],
+          "additionalProperties": false
+        },
+        "reservations": {
+          "type": "object",
+          "properties": {
+            "noRecordsTitle": {
+              "type": "string"
+            },
+            "noRecordsMessage": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "noRecordsTitle",
+            "noRecordsMessage"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
@@ -4649,7 +4714,10 @@
         "associatedOffers",
         "attributes",
         "item",
-        "level"
+        "level",
+        "list",
+        "locations",
+        "reservations"
       ],
       "additionalProperties": false
     },

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -4480,6 +4480,9 @@
             },
             "gotIt": {
               "type": "string"
+            },
+            "locationPlaceholder": {
+              "type": "string"
             }
           },
           "required": [
@@ -4504,7 +4507,8 @@
             "deleteTitle",
             "deleteDescription",
             "deleteBlockedDescription",
-            "gotIt"
+            "gotIt",
+            "locationPlaceholder"
           ],
           "additionalProperties": false
         },

--- a/packages/vendor/src/i18n/translations/$schema.json
+++ b/packages/vendor/src/i18n/translations/$schema.json
@@ -4350,6 +4350,9 @@
             "requiresShippingHint": {
               "type": "string"
             },
+            "descriptionPlaceholder": {
+              "type": "string"
+            },
             "successToast": {
               "type": "string"
             }
@@ -4362,6 +4365,7 @@
             "attributes",
             "requiresShipping",
             "requiresShippingHint",
+            "descriptionPlaceholder",
             "successToast"
           ],
           "additionalProperties": false
@@ -4428,13 +4432,37 @@
                 },
                 "quantityOutOfRange": {
                   "type": "string"
+                },
+                "idRequired": {
+                  "type": "string"
+                },
+                "selectLocation": {
+                  "type": "string"
+                },
+                "enterQuantity": {
+                  "type": "string"
                 }
               },
               "required": [
                 "noAvaliableQuantity",
-                "quantityOutOfRange"
+                "quantityOutOfRange",
+                "idRequired",
+                "selectLocation",
+                "enterQuantity"
               ],
               "additionalProperties": false
+            },
+            "deleteTitle": {
+              "type": "string"
+            },
+            "deleteDescription": {
+              "type": "string"
+            },
+            "deleteBlockedDescription": {
+              "type": "string"
+            },
+            "gotIt": {
+              "type": "string"
             }
           },
           "required": [
@@ -4455,7 +4483,11 @@
             "successToast",
             "updateSuccessToast",
             "deleteSuccessToast",
-            "errors"
+            "errors",
+            "deleteTitle",
+            "deleteDescription",
+            "deleteBlockedDescription",
+            "gotIt"
           ],
           "additionalProperties": false
         },
@@ -4467,10 +4499,14 @@
               "properties": {
                 "stockedQuantity": {
                   "type": "string"
+                },
+                "enterQuantity": {
+                  "type": "string"
                 }
               },
               "required": [
-                "stockedQuantity"
+                "stockedQuantity",
+                "enterQuantity"
               ],
               "additionalProperties": false
             }
@@ -4491,12 +4527,16 @@
             },
             "updateItem": {
               "type": "string"
+            },
+            "deleteItem": {
+              "type": "string"
             }
           },
           "required": [
             "updateLocations",
             "updateLevel",
-            "updateItem"
+            "updateItem",
+            "deleteItem"
           ],
           "additionalProperties": false
         },
@@ -4539,6 +4579,53 @@
             "successToast"
           ],
           "additionalProperties": false
+        },
+        "associatedOffers": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "tip": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "tip"
+          ],
+          "additionalProperties": false
+        },
+        "item": {
+          "type": "object",
+          "properties": {
+            "deleteTitle": {
+              "type": "string"
+            },
+            "deleteDescription": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "deleteTitle",
+            "deleteDescription"
+          ],
+          "additionalProperties": false
+        },
+        "level": {
+          "type": "object",
+          "properties": {
+            "deleteTitle": {
+              "type": "string"
+            },
+            "deleteDescription": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "deleteTitle",
+            "deleteDescription"
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
@@ -4558,7 +4645,11 @@
         "reservation",
         "adjustInventory",
         "toast",
-        "stock"
+        "stock",
+        "associatedOffers",
+        "attributes",
+        "item",
+        "level"
       ],
       "additionalProperties": false
     },

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1054,7 +1054,7 @@
     "deleteWarning": "You are about to delete an inventory item. This action cannot be undone.",
     "editItemDetails": "Edit item details",
     "quantityAcrossLocations": "{{quantity}} across {{locations}} locations",
-    "levelDeleted": "Inventory level deleted successfully.",
+    "levelDeleted": "Inventory level was successfully deleted.",
     "create": {
       "title": "Create Inventory Item",
       "details": "Details",
@@ -1086,18 +1086,27 @@
       "deleteSuccessToast": "Reservation was successfully deleted.",
       "errors": {
         "noAvaliableQuantity": "Stock location doesn't have available quantity.",
-        "quantityOutOfRange": "Minimum quantity is 1 and maximum quantity is {{max}}"
-      }
+        "quantityOutOfRange": "Minimum quantity is 1 and maximum quantity is {{max}}",
+        "idRequired": "Select an item to reserve",
+        "selectLocation": "Select a location",
+        "enterQuantity": "Please enter quantity"
+      },
+      "deleteTitle": "Delete reservation",
+      "deleteDescription": "You are about to delete a reservation. This action cannot be undone.",
+      "deleteBlockedDescription": "This reservation cannot be deleted because it's linked to an unfulfilled order.",
+      "gotIt": "Got it"
     },
     "adjustInventory": {
       "errors": {
-        "stockedQuantity": "Stocked quantity cannot be updated to less than the reserved quantity of {{quantity}}."
+        "stockedQuantity": "Stocked quantity cannot be updated to less than the reserved quantity of {{quantity}}.",
+        "enterQuantity": "Please enter quantity"
       }
     },
     "toast": {
-      "updateLocations": "Locations updated successfully.",
-      "updateLevel": "Inventory level updated successfully.",
-      "updateItem": "Inventory item updated successfully."
+      "updateLocations": "Locations were successfully updated.",
+      "updateLevel": "Inventory level was successfully updated.",
+      "updateItem": "Inventory item was successfully updated.",
+      "deleteItem": "Inventory item was successfully deleted."
     },
     "stock": {
       "title": "Update inventory levels",
@@ -1107,7 +1116,19 @@
       "disablePrompt_one": "You are about to disable {{count}} location level. This action cannot be undone.",
       "disablePrompt_other": "You are about to disable {{count}} location levels. This action cannot be undone.",
       "disabledToggleTooltip": "Cannot disable: clear incoming and/or reserved quantity before disabling.",
-      "successToast": "Inventory levels updated successfully."
+      "successToast": "Stock levels were successfully updated."
+    },
+    "associatedOffers": "Associated offers",
+    "attributes": {
+      "tip": "These are default values used to describe the item. They are not managed by Marketplace."
+    },
+    "item": {
+      "deleteTitle": "Delete inventory item",
+      "deleteDescription": "You are about to delete an inventory item. This action cannot be undone."
+    },
+    "level": {
+      "deleteTitle": "Delete inventory level",
+      "deleteDescription": "You're about to delete inventory level from {{location}}. This will delete stock and reservations for this location and cannot be undone."
     }
   },
   "offers": {

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1064,7 +1064,11 @@
       "requiresShipping": "Requires shipping",
       "requiresShippingHint": "Does the inventory item require shipping?",
       "descriptionPlaceholder": "The item description",
-      "successToast": "Inventory item was successfully created."
+      "successToast": "Inventory item was successfully created.",
+      "errors": {
+        "titleRequired": "Please enter a title"
+      },
+      "attributesHint": "These are default values used to describe the item. They are not defined by Marketplace."
     },
     "reservation": {
       "header": "Reservation of {{itemName}}",
@@ -1129,6 +1133,18 @@
     "level": {
       "deleteTitle": "Delete inventory level",
       "deleteDescription": "You're about to delete inventory level from {{location}}. This will delete stock and reservations for this location and cannot be undone."
+    },
+    "list": {
+      "noRecordsTitle": "No inventory items yet",
+      "noRecordsMessage": "Create inventory items to manage inventory"
+    },
+    "locations": {
+      "noRecordsTitle": "No locations yet",
+      "noRecordsMessage": "Add a location to start managing stock levels"
+    },
+    "reservations": {
+      "noRecordsTitle": "No reservations yet",
+      "noRecordsMessage": "There are no reservations to show"
     }
   },
   "offers": {

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1091,14 +1091,15 @@
       "errors": {
         "noAvaliableQuantity": "Stock location doesn't have available quantity.",
         "quantityOutOfRange": "Minimum quantity is 1 and maximum quantity is {{max}}",
-        "idRequired": "Select an item to reserve",
-        "selectLocation": "Select a location",
-        "enterQuantity": "Please enter quantity"
+        "idRequired": "Please select an item to reserve",
+        "selectLocation": "Please select a location",
+        "enterQuantity": "Please enter a quantity"
       },
       "deleteTitle": "Delete reservation",
       "deleteDescription": "You are about to delete a reservation. This action cannot be undone.",
       "deleteBlockedDescription": "This reservation cannot be deleted because it's linked to an unfulfilled order.",
-      "gotIt": "Got it"
+      "gotIt": "Got it",
+      "locationPlaceholder": "Select location"
     },
     "adjustInventory": {
       "errors": {

--- a/packages/vendor/src/pages/inventory/[id]/_components/adjust-inventory/components/adjust-inventory-form.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/adjust-inventory/components/adjust-inventory-form.tsx
@@ -57,9 +57,8 @@ export const AdjustInventoryForm = ({
 
       if (quantity === null) {
         ctx.addIssue({
-          code: z.ZodIssueCode.invalid_type,
-          expected: "number",
-          received: "undefined",
+          code: z.ZodIssueCode.custom,
+          message: t("inventory.adjustInventory.errors.enterQuantity"),
           path: ["stocked_quantity"],
         })
 

--- a/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item-attributes/components/edit-item-attributes-form.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item-attributes/components/edit-item-attributes-form.tsx
@@ -1,6 +1,6 @@
 import * as zod from "zod"
 
-import { Button, Input, toast } from "@medusajs/ui"
+import { Button, InlineTip, Input, toast } from "@medusajs/ui"
 import { RouteDrawer, useRouteModal } from "@components/modals"
 
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -25,6 +25,7 @@ const EditInventoryItemAttributesSchema = z.object({
   weight: z.number().positive().optional(),
   mid_code: z.string().optional(),
   hs_code: z.string().optional(),
+  material: z.string().optional(),
   origin_country: z.string().optional(),
 })
 
@@ -36,6 +37,7 @@ const getDefaultValues = (item: HttpTypes.AdminInventoryItem) => {
     weight: item.weight ?? undefined,
     mid_code: item.mid_code ?? undefined,
     hs_code: item.hs_code ?? undefined,
+    material: item.material ?? undefined,
     origin_country: item.origin_country ?? undefined,
   }
 }
@@ -69,6 +71,9 @@ export const EditInventoryItemAttributesForm = ({
         className="flex flex-1 flex-col overflow-hidden"
       >
         <RouteDrawer.Body className="flex flex-1 flex-col gap-y-4 overflow-auto">
+          <InlineTip label={t("general.tip")}>
+            {t("inventory.attributes.tip")}
+          </InlineTip>
           <Form.Field
             control={form.control}
             name="height"
@@ -207,6 +212,22 @@ export const EditInventoryItemAttributesForm = ({
               return (
                 <Form.Item>
                   <Form.Label optional>{t("fields.hsCode")}</Form.Label>
+                  <Form.Control>
+                    <Input {...field} />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )
+            }}
+          />
+
+          <Form.Field
+            control={form.control}
+            name="material"
+            render={({ field }) => {
+              return (
+                <Form.Item>
+                  <Form.Label optional>{t("fields.material")}</Form.Label>
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>

--- a/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/components/edit-item-form.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/components/edit-item-form.tsx
@@ -16,21 +16,22 @@ type EditInventoryItemFormProps = {
   item: HttpTypes.AdminInventoryItem
 }
 
-const EditInventoryItemSchema = z.object({
-  title: z.string().optional(),
-  sku: z.string().min(1),
-})
-
 const getDefaultValues = (item: HttpTypes.AdminInventoryItem) => {
   return {
-    title: item.title ?? undefined,
-    sku: item.sku ?? undefined,
+    title: item.title ?? "",
+    sku: item.sku ?? "",
   }
 }
 
 export const EditInventoryItemForm = ({ item }: EditInventoryItemFormProps) => {
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
+
+  const EditInventoryItemSchema = z.object({
+    title: z.string().min(1, t("validation.requiredField")),
+    sku: z.string().optional(),
+  })
+
   const form = useExtendableForm({
     schema: EditInventoryItemSchema,
     model: "inventory_item",
@@ -42,13 +43,16 @@ export const EditInventoryItemForm = ({ item }: EditInventoryItemFormProps) => {
   const { mutateAsync, isPending: isLoading } = useUpdateInventoryItem(item.id)
 
   const handleSubmit = form.handleSubmit(async (values) => {
-    mutateAsync(values as any, {
-      onSuccess: () => {
-        toast.success(t("inventory.toast.updateItem"))
-        handleSuccess()
-      },
-      onError: (e) => toast.error(e.message),
-    })
+    mutateAsync(
+      { title: values.title, sku: values.sku },
+      {
+        onSuccess: () => {
+          toast.success(t("inventory.toast.updateItem"))
+          handleSuccess()
+        },
+        onError: (e) => toast.error(e.message),
+      }
+    )
   })
 
   return (
@@ -79,7 +83,7 @@ export const EditInventoryItemForm = ({ item }: EditInventoryItemFormProps) => {
             render={({ field }) => {
               return (
                 <Form.Item>
-                  <Form.Label>{t("fields.sku")}</Form.Label>
+                  <Form.Label optional>{t("fields.sku")}</Form.Label>
                   <Form.Control>
                     <Input {...field} />
                   </Form.Control>

--- a/packages/vendor/src/pages/inventory/[id]/_components/inventory-item-attributes/attributes-section.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/inventory-item-attributes/attributes-section.tsx
@@ -42,6 +42,7 @@ export const InventoryItemAttributeSection = ({
       <SectionRow title={t("fields.weight")} value={inventoryItem.weight} />
       <SectionRow title={t("fields.midCode")} value={inventoryItem.mid_code} />
       <SectionRow title={t("fields.hsCode")} value={inventoryItem.hs_code} />
+      <SectionRow title={t("fields.material")} value={inventoryItem.material} />
       <SectionRow
         title={t("fields.countryOfOrigin")}
         value={getFormattedCountry(inventoryItem.origin_country)}

--- a/packages/vendor/src/pages/inventory/[id]/_components/inventory-item-general-section.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/inventory-item-general-section.tsx
@@ -30,17 +30,34 @@ export const InventoryItemGeneralSection = ({
     ) || 0
   const availableQuantity = stockedQuantity - reservedQuantity
 
+  const getQuantityFormat = (quantity: number) => {
+    if (quantity !== undefined && !isNaN(quantity)) {
+      return t("inventory.quantityAcrossLocations", {
+        quantity,
+        locations: inventoryItem.location_levels?.length ?? "-",
+      })
+    }
+
+    return "-"
+  }
+
   return (
-    <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+    <Container
+      className="divide-y p-0"
+      data-testid="inventory-item-general-section"
+    >
+      <div
+        className="flex items-center justify-between px-6 py-4"
+        data-testid="inventory-item-general-header"
+      >
         <DisplayField
           model="inventory_item"
           zone="general"
           id="title"
           data={inventoryItem}
         >
-          <Heading>
-            {inventoryItem.title ?? inventoryItem.sku} {t("fields.details")}
+          <Heading data-testid="inventory-item-general-title">
+            {inventoryItem.title ?? inventoryItem.sku}
           </Heading>
         </DisplayField>
         <ActionMenu
@@ -55,6 +72,7 @@ export const InventoryItemGeneralSection = ({
               ],
             },
           ]}
+          data-testid="inventory-item-general-action-menu"
         />
       </div>
       <DisplayField
@@ -73,10 +91,7 @@ export const InventoryItemGeneralSection = ({
       >
         <SectionRow
           title={t("fields.inStock")}
-          value={getQuantityFormat(
-            stockedQuantity,
-            inventoryItem.location_levels?.length
-          )}
+          value={getQuantityFormat(stockedQuantity)}
         />
       </DisplayField>
       <DisplayField
@@ -87,10 +102,7 @@ export const InventoryItemGeneralSection = ({
       >
         <SectionRow
           title={t("inventory.reserved")}
-          value={getQuantityFormat(
-            reservedQuantity,
-            inventoryItem.location_levels?.length
-          )}
+          value={getQuantityFormat(reservedQuantity)}
         />
       </DisplayField>
       <DisplayField
@@ -101,10 +113,7 @@ export const InventoryItemGeneralSection = ({
       >
         <SectionRow
           title={t("inventory.available")}
-          value={getQuantityFormat(
-            availableQuantity,
-            inventoryItem.location_levels?.length
-          )}
+          value={getQuantityFormat(availableQuantity)}
         />
       </DisplayField>
       <DisplayExtensionZone
@@ -115,12 +124,4 @@ export const InventoryItemGeneralSection = ({
       />
     </Container>
   )
-}
-
-const getQuantityFormat = (quantity: number, locations?: number) => {
-  if (quantity !== undefined && !isNaN(quantity)) {
-    return `${quantity} across ${locations ?? "-"} locations`
-  }
-
-  return "-"
 }

--- a/packages/vendor/src/pages/inventory/[id]/_components/inventory-item-offers/associated-offers-section.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/inventory-item-offers/associated-offers-section.tsx
@@ -1,0 +1,53 @@
+import { Container, Heading } from "@medusajs/ui"
+import { OfferDTO } from "@mercurjs/types"
+import { useTranslation } from "react-i18next"
+
+import { SidebarLink } from "@components/common/sidebar-link/sidebar-link"
+import { Thumbnail } from "@components/common/thumbnail"
+
+type AssociatedOffersSectionProps = {
+  offers?: OfferDTO[] | null
+}
+
+export const AssociatedOffersSection = ({
+  offers,
+}: AssociatedOffersSectionProps) => {
+  const { t } = useTranslation()
+
+  if (!offers?.length) {
+    return null
+  }
+
+  return (
+    <Container className="p-0" data-testid="inventory-item-offers-section">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading level="h2" data-testid="inventory-item-offers-title">
+          {t("inventory.associatedOffers")}
+        </Heading>
+      </div>
+      {offers.map((offer) => {
+        const variantTitle = offer.product_variant?.title
+        const productTitle = offer.product_variant?.product?.title
+        const label = variantTitle || offer.sku
+        const description = [variantTitle, productTitle]
+          .filter(Boolean)
+          .join(" · ")
+
+        return (
+          <SidebarLink
+            key={offer.id}
+            to={`/offers/${offer.product_id}/variants/${offer.id}`}
+            labelKey={label}
+            descriptionKey={description}
+            icon={
+              <Thumbnail
+                src={offer.product_variant?.product?.thumbnail ?? null}
+              />
+            }
+            dataTestid={`inventory-associated-offer-${offer.id}`}
+          />
+        )
+      })}
+    </Container>
+  )
+}

--- a/packages/vendor/src/pages/inventory/[id]/_components/inventory-item-reservations.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/inventory-item-reservations.tsx
@@ -1,6 +1,8 @@
 import { HttpTypes } from "@medusajs/types"
-import { Container, Heading } from "@medusajs/ui"
+import { Button, Container, Heading } from "@medusajs/ui"
+import { DisplayExtensionZone } from "@mercurjs/dashboard-shared"
 import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
 
 import { ReservationItemTable } from "./reservations-table/reservation-list-table"
 
@@ -13,11 +15,34 @@ export const InventoryItemReservationsSection = ({
   const { t } = useTranslation()
 
   return (
-    <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
-        <Heading>{t("reservations.domain")}</Heading>
+    <Container
+      className="divide-y p-0"
+      data-testid="inventory-item-reservations-section"
+    >
+      <div
+        className="flex items-center justify-between px-6 py-4"
+        data-testid="inventory-item-reservations-header"
+      >
+        <Heading data-testid="inventory-item-reservations-title">
+          {t("reservations.domain")}
+        </Heading>
+        <Button
+          size="small"
+          variant="secondary"
+          asChild
+          data-testid="inventory-create-reservation-button"
+        >
+          <Link to={`/reservations/create?item_id=${inventoryItem.id}`}>
+            {t("actions.create")}
+          </Link>
+        </Button>
       </div>
       <ReservationItemTable inventoryItem={inventoryItem} />
+      <DisplayExtensionZone
+        model="inventory_item"
+        zone="reservations"
+        data={inventoryItem}
+      />
     </Container>
   )
 }

--- a/packages/vendor/src/pages/inventory/[id]/_components/location-levels-table/location-actions.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/location-levels-table/location-actions.tsx
@@ -1,16 +1,16 @@
 import { PencilSquare, Trash } from "@medusajs/icons"
 
-import { InventoryTypes } from "@medusajs/types"
-import { usePrompt } from "@medusajs/ui"
+import { InventoryTypes, StockLocationDTO } from "@medusajs/types"
+import { toast, usePrompt } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { ActionMenu } from "@components/common/action-menu"
 import { useDeleteInventoryItemLevel } from "@hooks/api/inventory"
 
-export const LocationActions = ({
-  level,
-}: {
-  level: InventoryTypes.InventoryLevelDTO
-}) => {
+type LocationActionsLevel = InventoryTypes.InventoryLevelDTO & {
+  stock_locations?: StockLocationDTO[]
+}
+
+export const LocationActions = ({ level }: { level: LocationActionsLevel }) => {
   const { t } = useTranslation()
   const prompt = usePrompt()
   const { mutateAsync } = useDeleteInventoryItemLevel(
@@ -18,10 +18,15 @@ export const LocationActions = ({
     level.location_id
   )
 
+  const locationName =
+    level.stock_locations?.map((location) => location.name).join(", ") ?? ""
+
   const handleDelete = async () => {
     const res = await prompt({
-      title: t("general.areYouSure"),
-      description: t("inventory.deleteWarning"),
+      title: t("inventory.level.deleteTitle"),
+      description: t("inventory.level.deleteDescription", {
+        location: locationName,
+      }),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
     })
@@ -30,7 +35,10 @@ export const LocationActions = ({
       return
     }
 
-    await mutateAsync()
+    await mutateAsync(undefined, {
+      onSuccess: () => toast.success(t("inventory.levelDeleted")),
+      onError: (e) => toast.error(e.message),
+    })
   }
 
   return (

--- a/packages/vendor/src/pages/inventory/[id]/_components/location-levels-table/location-list-table.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/location-levels-table/location-list-table.tsx
@@ -4,6 +4,7 @@ import { useDataTable } from "@hooks/use-data-table";
 import { useLocationListTableColumns } from "./use-location-list-table-columns";
 import { useLocationLevelTableQuery } from "./use-location-list-table-query";
 import { StockLocationDTO } from "@medusajs/types";
+import { useTranslation } from "react-i18next";
 
 const PAGE_SIZE = 20;
 
@@ -12,6 +13,7 @@ export const ItemLocationListTable = ({
 }: {
   inventory_item_id: string;
 }) => {
+  const { t } = useTranslation();
   const { searchParams, raw } = useLocationLevelTableQuery({
     pageSize: PAGE_SIZE,
   });
@@ -49,6 +51,10 @@ export const ItemLocationListTable = ({
       isLoading={isLoading}
       pagination
       queryObject={raw}
+      noRecords={{
+        title: t("inventory.locations.noRecordsTitle"),
+        message: t("inventory.locations.noRecordsMessage"),
+      }}
     />
   );
 };

--- a/packages/vendor/src/pages/inventory/[id]/_components/location-levels-table/use-location-list-table-columns.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/location-levels-table/use-location-list-table-columns.tsx
@@ -90,7 +90,11 @@ export const useLocationListTableColumns = () => {
       }),
       columnHelper.display({
         id: "actions",
-        cell: ({ row }) => <LocationActions level={row.original} />,
+        cell: ({ row }) => (
+          <div className="flex w-full items-center justify-end">
+            <LocationActions level={row.original} />
+          </div>
+        ),
       }),
     ],
     [t]

--- a/packages/vendor/src/pages/inventory/[id]/_components/manage-locations/components/manage-locations-form.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/manage-locations/components/manage-locations-form.tsx
@@ -1,5 +1,5 @@
 import { AdminInventoryItem, AdminStockLocation } from "@medusajs/types";
-import { Button, Text, toast } from "@medusajs/ui";
+import { Button, Input, Text, toast } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 import {
   RouteDrawer,
@@ -29,6 +29,15 @@ export const ManageLocationsForm = ({
   const [selectedLocationIds, setSelectedLocationIds] = useState<Set<string>>(
     existingLocationLevels,
   );
+  const [search, setSearch] = useState("");
+
+  const filteredLocations = useMemo(
+    () =>
+      locations.filter((location) =>
+        (location.name ?? "").toLowerCase().includes(search.toLowerCase()),
+      ),
+    [locations, search],
+  );
 
   const handleLocationSelect = (locationId: string, selected: boolean) => {
     setSelectedLocationIds((prev) => {
@@ -42,7 +51,9 @@ export const ManageLocationsForm = ({
     });
   };
 
-  const { mutateAsync } = useBatchInventoryItemLocationLevels(item.id);
+  const { mutateAsync, isPending } = useBatchInventoryItemLocationLevels(
+    item.id,
+  );
 
   const handleSubmit = async () => {
     const toCreate = Array.from(selectedLocationIds).filter(
@@ -116,7 +127,15 @@ export const ManageLocationsForm = ({
           </div>
         </div>
 
-        {locations.map((location) => (
+        <Input
+          type="search"
+          placeholder={t("general.search")}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          data-testid="manage-locations-search-input"
+        />
+
+        {filteredLocations.map((location) => (
           <LocationItem
             key={location.id}
             selected={selectedLocationIds.has(location.id)}
@@ -132,7 +151,7 @@ export const ManageLocationsForm = ({
               {t("actions.cancel")}
             </Button>
           </RouteDrawer.Close>
-          <Button onClick={handleSubmit} size="small" isLoading={false}>
+          <Button onClick={handleSubmit} size="small" isLoading={isPending}>
             {t("actions.save")}
           </Button>
         </div>

--- a/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/reservation-actions.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/reservation-actions.tsx
@@ -16,9 +16,20 @@ export const ReservationActions = ({
   const { mutateAsync } = useDeleteReservationItem(reservation.id)
 
   const handleDelete = async () => {
+    if (reservation.line_item_id) {
+      await prompt({
+        title: t("inventory.reservation.deleteTitle"),
+        description: t("inventory.reservation.deleteBlockedDescription"),
+        confirmText: t("inventory.reservation.gotIt"),
+        cancelText: t("actions.cancel"),
+      })
+
+      return
+    }
+
     const res = await prompt({
-      title: t("general.areYouSure"),
-      description: t("inventory.deleteWarning"),
+      title: t("inventory.reservation.deleteTitle"),
+      description: t("inventory.reservation.deleteDescription"),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
     })
@@ -59,6 +70,7 @@ export const ReservationActions = ({
           ],
         },
       ]}
+      data-testid={`reservation-actions-${reservation.id}`}
     />
   )
 }

--- a/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/reservation-list-table.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/reservation-list-table.tsx
@@ -26,6 +26,7 @@ export const ReservationItemTable = ({
     useReservationItems(
       {
         ...searchParams,
+        fields: "+line_item.order_id",
       },
       undefined,
       { inventory_item_id: [inventoryItem.id] }

--- a/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/reservation-list-table.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/reservation-list-table.tsx
@@ -1,5 +1,6 @@
 import { HttpTypes } from "@medusajs/types"
 import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
 
 import { _DataTable } from "@components/table/data-table"
 import { useStockLocations } from "@hooks/api"
@@ -18,6 +19,7 @@ export const ReservationItemTable = ({
 }: {
   inventoryItem: HttpTypes.AdminInventoryItemResponse["inventory_item"]
 }) => {
+  const { t } = useTranslation()
   const { searchParams, raw } = useReservationsTableQuery({
     pageSize: PAGE_SIZE,
   })
@@ -65,6 +67,10 @@ export const ReservationItemTable = ({
       isLoading={isPending}
       pagination
       queryObject={raw}
+      noRecords={{
+        title: t("inventory.reservations.noRecordsTitle"),
+        message: t("inventory.reservations.noRecordsMessage"),
+      }}
     />
   )
 }

--- a/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/reservation-list-table.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/reservation-list-table.tsx
@@ -24,15 +24,11 @@ export const ReservationItemTable = ({
     pageSize: PAGE_SIZE,
   })
 
-  const { reservations, count, isPending } =
-    useReservationItems(
-      {
-        ...searchParams,
-        fields: "+line_item.order_id",
-      },
-      undefined,
-      { inventory_item_id: [inventoryItem.id] }
-    )
+  const { reservations, count, isPending } = useReservationItems({
+    ...searchParams,
+    fields: "+line_item.order_id",
+    inventory_item_id: [inventoryItem.id],
+  })
 
   const { stock_locations } = useStockLocations({
     id: (reservations || []).map((r) => r.location_id),

--- a/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/use-reservation-list-table-columns.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/reservations-table/use-reservation-list-table-columns.tsx
@@ -32,18 +32,30 @@ export const useReservationTableColumn = ({ sku }: { sku: string }) => {
           return <TextCell text={sku} />
         },
       }),
-      // columnHelper.accessor("line_item.order_id", {
-      //   header: () => <TextHeader text={t("inventory.reservation.orderID")} />,
-      //   cell: ({ getValue, row }) => {
-      //     const orderId = getValue()
+      columnHelper.accessor("line_item.order_id", {
+        header: () => <TextHeader text={t("inventory.reservation.orderID")} />,
+        cell: ({ getValue }) => {
+          const orderId = getValue()
 
-      //     if (!orderId) {
-      //       return <PlaceholderCell />
-      //     }
+          if (!orderId) {
+            return <PlaceholderCell />
+          }
 
-      //     return <TextCell text={orderId} />
-      //   },
-      // }),
+          return <TextCell text={orderId} />
+        },
+      }),
+      columnHelper.accessor("description", {
+        header: () => <TextHeader text={t("fields.description")} />,
+        cell: ({ getValue }) => {
+          const description = getValue()
+
+          if (!description) {
+            return <PlaceholderCell />
+          }
+
+          return <TextCell text={description} />
+        },
+      }),
       columnHelper.accessor("location.name", {
         header: () => <TextHeader text={t("inventory.reservation.location")} />,
         cell: ({ getValue }) => {
@@ -68,7 +80,11 @@ export const useReservationTableColumn = ({ sku }: { sku: string }) => {
       }),
       columnHelper.display({
         id: "actions",
-        cell: ({ row }) => <ReservationActions reservation={row.original} />,
+        cell: ({ row }) => (
+          <div className="flex w-full items-center justify-end">
+            <ReservationActions reservation={row.original} />
+          </div>
+        ),
       }),
     ],
     [t, sku]

--- a/packages/vendor/src/pages/inventory/[id]/constants.ts
+++ b/packages/vendor/src/pages/inventory/[id]/constants.ts
@@ -1,2 +1,2 @@
 export const INVENTORY_DETAIL_FIELDS =
-  "*variants,*variants.product,*variants.options,+stocked_quantity,+reserved_quantity,*location_levels"
+  "*variants,*variants.product,*variants.options,+stocked_quantity,+reserved_quantity,*location_levels,+offers.id,+offers.sku,+offers.product_id,+offers.product_variant.title,+offers.product_variant.product.title,+offers.product_variant.product.thumbnail"

--- a/packages/vendor/src/pages/inventory/[id]/inventory-detail-page.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/inventory-detail-page.tsx
@@ -9,7 +9,8 @@ import { useInventoryItem } from "@hooks/api/inventory";
 import { InventoryItemAttributeSection } from "./_components/inventory-item-attributes/attributes-section";
 import { InventoryItemGeneralSection } from "./_components/inventory-item-general-section";
 import { InventoryItemLocationLevelsSection } from "./_components/inventory-item-location-levels";
-import { InventoryItemVariantsSection } from "./_components/inventory-item-variants/variants-section";
+import { InventoryItemReservationsSection } from "./_components/inventory-item-reservations";
+import { AssociatedOffersSection } from "./_components/inventory-item-offers/associated-offers-section";
 import { INVENTORY_DETAIL_FIELDS } from "./constants";
 
 import { loader } from "./loader";
@@ -17,7 +18,12 @@ import { loader } from "./loader";
 const Root = ({ children }: { children?: ReactNode }) => {
   const { id } = useParams();
   const initialData = useLoaderData() as Awaited<ReturnType<typeof loader>>;
-  const { inventory_item, isPending: isLoading } = useInventoryItem(
+  const {
+    inventory_item,
+    isPending: isLoading,
+    isError,
+    error,
+  } = useInventoryItem(
     id!,
     useLinkQuery("inventory_item", INVENTORY_DETAIL_FIELDS),
     { initialData },
@@ -34,24 +40,31 @@ const Root = ({ children }: { children?: ReactNode }) => {
     );
   }
 
+  if (isError) {
+    throw error;
+  }
+
   return (
     <>
       {Children.count(children) > 0 ? (
         children
       ) : (
-        <TwoColumnPage data={inventory_item}>
+        <TwoColumnPage data={inventory_item} showJSON showMetadata>
           <TwoColumnPage.Main>
             <WidgetZone id="inventory.detail.main" data={inventory_item}>
               <InventoryItemGeneralSection inventoryItem={inventory_item} />
               <InventoryItemLocationLevelsSection
                 inventoryItem={inventory_item}
               />
+              <InventoryItemReservationsSection
+                inventoryItem={inventory_item}
+              />
             </WidgetZone>
           </TwoColumnPage.Main>
           <TwoColumnPage.Sidebar>
             <WidgetZone id="inventory.detail.side" data={inventory_item}>
-              <InventoryItemVariantsSection
-                variants={(inventory_item as any).variants}
+              <AssociatedOffersSection
+                offers={(inventory_item as any).offers}
               />
               <InventoryItemAttributeSection
                 inventoryItem={inventory_item as any}
@@ -69,6 +82,7 @@ export const InventoryDetailPage = Object.assign(Root, {
   Sidebar: TwoColumnPage.Sidebar,
   MainGeneralSection: InventoryItemGeneralSection,
   MainLocationLevelsSection: InventoryItemLocationLevelsSection,
-  SidebarVariantsSection: InventoryItemVariantsSection,
+  MainReservationsSection: InventoryItemReservationsSection,
+  SidebarOffersSection: AssociatedOffersSection,
   SidebarAttributeSection: InventoryItemAttributeSection,
 });

--- a/packages/vendor/src/pages/inventory/[id]/stock/index.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/stock/index.tsx
@@ -14,7 +14,8 @@ export const Component = () => {
     searchParams.get(INVENTORY_ITEM_IDS_KEY)?.split(",") || undefined;
 
   const { inventory_items, isPending, isError, error } = useInventoryItems({
-    fields: "id,sku,title,*stock_locations,*location_levels",
+    fields:
+      "id,sku,title,*stock_locations,*location_levels,offers.product_variant.product.title",
     id: inventoryItemIds!,
   });
 

--- a/packages/vendor/src/pages/inventory/[id]/stock/inventory-stock-form/inventory-stock-form.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/stock/inventory-stock-form/inventory-stock-form.tsx
@@ -70,6 +70,7 @@ export const InventoryStockForm = ({
 
             if (newQuantity !== originalQuantity) {
               payload.update.push({
+                id: level.id,
                 inventory_item_id,
                 location_id,
                 stocked_quantity: newQuantity,

--- a/packages/vendor/src/pages/inventory/[id]/stock/use-inventory-stock-columns.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/stock/use-inventory-stock-columns.tsx
@@ -34,14 +34,37 @@ export const useInventoryStockColumns = (
       }),
       helper.column({
         id: "sku",
-        name: "SKU",
-        header: "SKU",
+        name: t("fields.sku"),
+        header: t("fields.sku"),
         cell: (context) => {
           const item = context.row.original
 
           return (
             <DataGridReadOnlyCell context={context} color="normal">
               <span title={item.sku || undefined}>{item.sku || "-"}</span>
+            </DataGridReadOnlyCell>
+          )
+        },
+        disableHiding: true,
+      }),
+      helper.column({
+        id: "product",
+        name: t("fields.product"),
+        header: t("fields.product"),
+        cell: (context) => {
+          const item = context.row.original as HttpTypes.AdminInventoryItem & {
+            offers?: {
+              product_variant?: { product?: { title?: string } }
+            }[]
+          }
+          const productTitle =
+            item.offers?.[0]?.product_variant?.product?.title
+
+          return (
+            <DataGridReadOnlyCell context={context} color="normal">
+              <span title={productTitle || undefined}>
+                {productTitle || "-"}
+              </span>
             </DataGridReadOnlyCell>
           )
         },

--- a/packages/vendor/src/pages/inventory/_components/inventory-actions.tsx
+++ b/packages/vendor/src/pages/inventory/_components/inventory-actions.tsx
@@ -3,7 +3,7 @@ import { PencilSquare, Trash } from "@medusajs/icons"
 import { ActionMenu } from "@components/common/action-menu"
 import { InventoryItemDTO } from "@medusajs/types"
 import { useDeleteInventoryItem } from "@hooks/api/inventory"
-import { usePrompt } from "@medusajs/ui"
+import { toast, usePrompt } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 
 export const InventoryActions = ({ item }: { item: InventoryItemDTO }) => {
@@ -13,8 +13,8 @@ export const InventoryActions = ({ item }: { item: InventoryItemDTO }) => {
 
   const handleDelete = async () => {
     const res = await prompt({
-      title: t("general.areYouSure"),
-      description: t("inventory.deleteWarning"),
+      title: t("inventory.item.deleteTitle"),
+      description: t("inventory.item.deleteDescription"),
       confirmText: t("actions.delete"),
       cancelText: t("actions.cancel"),
     })
@@ -23,7 +23,10 @@ export const InventoryActions = ({ item }: { item: InventoryItemDTO }) => {
       return
     }
 
-    await mutateAsync()
+    await mutateAsync(undefined, {
+      onSuccess: () => toast.success(t("inventory.toast.deleteItem")),
+      onError: (e) => toast.error(e.message),
+    })
   }
 
   return (
@@ -48,6 +51,7 @@ export const InventoryActions = ({ item }: { item: InventoryItemDTO }) => {
           ],
         },
       ]}
+      data-testid={`inventory-item-actions-${item.id}`}
     />
   )
 }

--- a/packages/vendor/src/pages/inventory/_components/inventory-list-data-table.tsx
+++ b/packages/vendor/src/pages/inventory/_components/inventory-list-data-table.tsx
@@ -35,7 +35,10 @@ export const InventoryListDataTable = () => {
   } = useInventoryItems(
     {
       ...searchParams,
-      ...useLinkQuery("inventory_item"),
+      ...useLinkQuery(
+        "inventory_item",
+        "+offers.product_variant.product.title",
+      ),
     },
     {
       placeholderData: keepPreviousData,
@@ -44,14 +47,19 @@ export const InventoryListDataTable = () => {
 
   const baseFilters = useInventoryTableFilters();
   const baseColumns = useInventoryTableColumns();
-  const { columns, filters: extFilters } =
+  const actionsColumn = baseColumns[baseColumns.length - 1];
+  const { columns: extended, filters: extFilters } =
     useExtendableTable<InventoryTypes.InventoryItemDTO>({
       model: "inventory_item",
-      columns: baseColumns as unknown as ColumnDef<
+      columns: baseColumns.slice(0, -1) as unknown as ColumnDef<
         InventoryTypes.InventoryItemDTO,
         unknown
       >[],
     });
+  const columns = useMemo(
+    () => [...extended, actionsColumn],
+    [extended, actionsColumn],
+  );
   const filters = useMemo(
     () => [...baseFilters, ...(extFilters as typeof baseFilters)],
     [baseFilters, extFilters],
@@ -92,6 +100,7 @@ export const InventoryListDataTable = () => {
         { key: "stocked_quantity", label: t("fields.inStock") },
         { key: "reserved_quantity", label: t("inventory.reserved") },
       ]}
+      defaultOrder="title"
       navigateTo={(row) => `${row.id}`}
       commands={[
         {

--- a/packages/vendor/src/pages/inventory/_components/inventory-list-data-table.tsx
+++ b/packages/vendor/src/pages/inventory/_components/inventory-list-data-table.tsx
@@ -1,4 +1,5 @@
 import { InventoryTypes } from "@medusajs/types";
+import { Buildings } from "@medusajs/icons";
 
 import { useExtendableTable, useLinkQuery } from "@mercurjs/dashboard-shared";
 import { ColumnDef, RowSelectionState } from "@tanstack/react-table";
@@ -101,6 +102,12 @@ export const InventoryListDataTable = () => {
         { key: "reserved_quantity", label: t("inventory.reserved") },
       ]}
       defaultOrder="title"
+      noRecords={{
+        icon: <Buildings className="text-ui-fg-subtle" />,
+        title: t("inventory.list.noRecordsTitle"),
+        message: t("inventory.list.noRecordsMessage"),
+        action: { to: "create", label: t("actions.create") },
+      }}
       navigateTo={(row) => `${row.id}`}
       commands={[
         {

--- a/packages/vendor/src/pages/inventory/_components/use-inventory-table-columns.tsx
+++ b/packages/vendor/src/pages/inventory/_components/use-inventory-table-columns.tsx
@@ -1,4 +1,5 @@
 import { InventoryTypes, ProductVariantDTO } from "@medusajs/types"
+import { OfferDTO } from "@mercurjs/types"
 
 import { Checkbox } from "@medusajs/ui"
 import { createColumnHelper } from "@tanstack/react-table"
@@ -7,17 +8,11 @@ import { useTranslation } from "react-i18next"
 import { PlaceholderCell } from "@components/table/table-cells/common/placeholder-cell"
 import { InventoryActions } from "./inventory-actions"
 
-
 interface ExtendedInventoryItem extends InventoryTypes.InventoryItemDTO {
   variants?: ProductVariantDTO[] | null
+  offers?: OfferDTO[] | null
   stocked_quantity?: number
   reserved_quantity?: number
-  location_levels?: {
-    available_quantity: number
-    reserved_quantity: number
-    stocked_quantity?: number
-    location_id?: string
-  }[]
 }
 
 const columnHelper = createColumnHelper<ExtendedInventoryItem>()
@@ -40,6 +35,7 @@ export const useInventoryTableColumns = () => {
               onCheckedChange={(value) =>
                 table.toggleAllPageRowsSelected(!!value)
               }
+              data-testid="inventory-table-header-select-checkbox"
             />
           )
         },
@@ -51,13 +47,23 @@ export const useInventoryTableColumns = () => {
               onClick={(e) => {
                 e.stopPropagation()
               }}
+              data-testid={`inventory-table-cell-${row.id}-select-checkbox`}
             />
           )
         },
       }),
       columnHelper.accessor("title", {
-        header: t("fields.title"),
-        cell: ({ getValue }) => {
+        header: () => (
+          <div
+            className="flex h-full w-full items-center"
+            data-testid="inventory-table-header-title"
+          >
+            <span data-testid="inventory-table-header-title-text">
+              {t("fields.title")}
+            </span>
+          </div>
+        ),
+        cell: ({ getValue, row }) => {
           const title = getValue()
 
           if (!title) {
@@ -66,14 +72,28 @@ export const useInventoryTableColumns = () => {
 
           return (
             <div className="flex size-full items-center overflow-hidden">
-              <span className="truncate">{title}</span>
+              <span
+                className="truncate"
+                data-testid={`inventory-table-cell-${row.id}-title-value`}
+              >
+                {title}
+              </span>
             </div>
           )
         },
       }),
       columnHelper.accessor("sku", {
-        header: t("fields.sku"),
-        cell: ({ getValue }) => {
+        header: () => (
+          <div
+            className="flex h-full w-full items-center"
+            data-testid="inventory-table-header-sku"
+          >
+            <span data-testid="inventory-table-header-sku-text">
+              {t("fields.sku")}
+            </span>
+          </div>
+        ),
+        cell: ({ getValue, row }) => {
           const sku = getValue() as string
 
           if (!sku) {
@@ -82,54 +102,118 @@ export const useInventoryTableColumns = () => {
 
           return (
             <div className="flex size-full items-center overflow-hidden">
-              <span className="truncate">{sku}</span>
+              <span
+                className="truncate"
+                data-testid={`inventory-table-cell-${row.id}-sku-value`}
+              >
+                {sku}
+              </span>
             </div>
           )
         },
       }),
-      columnHelper.accessor("location_levels", {
-        header: t("inventory.reserved"),
-        cell: ({ getValue }) => {
-          const locations = getValue() as any[]
+      columnHelper.display({
+        id: "product",
+        header: () => (
+          <div
+            className="flex h-full w-full items-center"
+            data-testid="inventory-table-header-product"
+          >
+            <span data-testid="inventory-table-header-product-text">
+              {t("fields.product")}
+            </span>
+          </div>
+        ),
+        cell: ({ row }) => {
+          const productTitle =
+            row.original.offers?.[0]?.product_variant?.product?.title
 
-          const totalReserved = locations.reduce(
-            (sum: number, level: any) => sum + level.reserved_quantity,
-            0
-          )
-
-          if (Number.isNaN(totalReserved)) {
+          if (!productTitle) {
             return <PlaceholderCell />
           }
 
           return (
             <div className="flex size-full items-center overflow-hidden">
-              <span className="truncate">{totalReserved}</span>
+              <span
+                className="truncate"
+                data-testid={`inventory-table-cell-${row.id}-product-value`}
+              >
+                {productTitle}
+              </span>
             </div>
           )
         },
       }),
-      columnHelper.accessor("location_levels", {
-        header: t("fields.inStock"),
-        cell: ({ getValue }) => {
-          const locations = getValue() as any[]
-          const totalAvailable = locations.reduce(
-            (sum: number, level: any) => sum + level.available_quantity,
-            0
-          )
+      columnHelper.accessor("stocked_quantity", {
+        header: () => (
+          <div
+            className="flex h-full w-full items-center"
+            data-testid="inventory-table-header-stocked-quantity"
+          >
+            <span data-testid="inventory-table-header-stocked-quantity-text">
+              {t("fields.inStock")}
+            </span>
+          </div>
+        ),
+        cell: ({ getValue, row }) => {
+          const quantity = getValue()
 
-          if (Number.isNaN(totalAvailable)) {
+          if (Number.isNaN(quantity)) {
             return <PlaceholderCell />
           }
 
           return (
             <div className="flex size-full items-center overflow-hidden">
-              <span className="truncate">{totalAvailable}</span>
+              <span
+                className="truncate"
+                data-testid={`inventory-table-cell-${row.id}-stocked_quantity-value`}
+              >
+                {quantity}
+              </span>
+            </div>
+          )
+        },
+      }),
+      columnHelper.accessor("reserved_quantity", {
+        header: () => (
+          <div
+            className="flex h-full w-full items-center"
+            data-testid="inventory-table-header-reserved-quantity"
+          >
+            <span data-testid="inventory-table-header-reserved-quantity-text">
+              {t("inventory.reserved")}
+            </span>
+          </div>
+        ),
+        cell: ({ getValue, row }) => {
+          const quantity = getValue()
+
+          if (Number.isNaN(quantity)) {
+            return <PlaceholderCell />
+          }
+
+          return (
+            <div className="flex size-full items-center overflow-hidden">
+              <span
+                className="truncate"
+                data-testid={`inventory-table-cell-${row.id}-reserved_quantity-value`}
+              >
+                {quantity}
+              </span>
             </div>
           )
         },
       }),
       columnHelper.display({
         id: "actions",
+        header: () => (
+          <div
+            className="flex h-full w-full items-center"
+            data-testid="inventory-table-header-actions"
+          >
+            <span data-testid="inventory-table-header-actions-text"></span>
+          </div>
+        ),
         cell: ({ row }) => <InventoryActions item={row.original} />,
       }),
     ],

--- a/packages/vendor/src/pages/inventory/_components/use-inventory-table-filters.tsx
+++ b/packages/vendor/src/pages/inventory/_components/use-inventory-table-filters.tsx
@@ -10,6 +10,12 @@ export const useInventoryTableFilters = () => {
 
   const filters: Filter[] = []
 
+  filters.push({
+    type: "string",
+    key: "sku",
+    label: t("fields.sku"),
+  })
+
   if (stock_locations) {
     const stockLocationFilter: Filter = {
       type: "select",
@@ -26,24 +32,6 @@ export const useInventoryTableFilters = () => {
   }
 
   filters.push({
-    type: "string",
-    key: "material",
-    label: t("fields.material"),
-  })
-
-  filters.push({
-    type: "string",
-    key: "sku",
-    label: t("fields.sku"),
-  })
-
-  filters.push({
-    type: "string",
-    key: "mid_code",
-    label: t("fields.midCode"),
-  })
-
-  filters.push({
     type: "number",
     key: "height",
     label: t("fields.height"),
@@ -56,26 +44,15 @@ export const useInventoryTableFilters = () => {
   })
 
   filters.push({
-    type: "number",
-    key: "length",
-    label: t("fields.length"),
+    type: "string",
+    key: "mid_code",
+    label: t("fields.midCode"),
   })
 
   filters.push({
-    type: "number",
-    key: "weight",
-    label: t("fields.weight"),
-  })
-
-  filters.push({
-    type: "select",
-    options: [
-      { label: t("fields.true"), value: "true" },
-      { label: t("fields.false"), value: "false" },
-    ],
-    key: "requires_shipping",
-    multiple: false,
-    label: t("fields.requiresShipping"),
+    type: "string",
+    key: "material",
+    label: t("fields.material"),
   })
 
   return filters

--- a/packages/vendor/src/pages/inventory/_components/use-inventory-table-query.tsx
+++ b/packages/vendor/src/pages/inventory/_components/use-inventory-table-query.tsx
@@ -15,45 +15,27 @@ export const useInventoryTableQuery = ({
       "location_id",
       "q",
       "order",
-      "requires_shipping",
       "offset",
       "sku",
-      "origin_country",
       "material",
       "mid_code",
       "hs_code",
-      "order",
-      "weight",
       "width",
-      "length",
       "height",
     ],
     prefix
   )
 
-  const {
-    offset,
-    weight,
-    width,
-    length,
-    height,
-    requires_shipping,
-    ...params
-  } = raw
+  const { offset, width, height, ...params } = raw
 
   const searchParams: HttpTypes.AdminInventoryItemParams = {
     limit: pageSize,
     offset: offset ? parseInt(offset) : undefined,
-    weight: weight ? JSON.parse(weight) : undefined,
     width: width ? JSON.parse(width) : undefined,
-    length: length ? JSON.parse(length) : undefined,
     height: height ? JSON.parse(height) : undefined,
-    requires_shipping: requires_shipping
-      ? JSON.parse(requires_shipping)
-      : undefined,
     q: params.q,
     sku: params.sku,
-    order: params.order,
+    order: params.order || "title",
     mid_code: params.mid_code,
     hs_code: params.hs_code,
     material: params.material,

--- a/packages/vendor/src/pages/inventory/create/inventory-create-form/inventory-create-form.tsx
+++ b/packages/vendor/src/pages/inventory/create/inventory-create-form/inventory-create-form.tsx
@@ -7,6 +7,7 @@ import {
   Input,
   ProgressStatus,
   ProgressTabs,
+  Text,
   Textarea,
   toast,
 } from "@medusajs/ui"
@@ -35,7 +36,10 @@ import {
 } from "@lib/form-helpers"
 import { queryClient } from "@lib/query-client"
 import { InventoryAvailabilityForm } from "./inventory-availability-form"
-import { CreateInventoryItemSchema } from "./schema"
+import {
+  buildCreateInventoryItemSchema,
+  CreateInventoryItemSchema,
+} from "./schema"
 
 enum Tab {
   DETAILS = "details",
@@ -74,7 +78,7 @@ export function InventoryCreateForm({ locations }: InventoryCreateFormProps) {
         locations.map((location) => [location.id, ""])
       ),
     },
-    resolver: zodResolver(CreateInventoryItemSchema),
+    resolver: zodResolver(buildCreateInventoryItemSchema(t)),
   })
 
   const {
@@ -317,9 +321,14 @@ export function InventoryCreateForm({ locations }: InventoryCreateFormProps) {
                 <Divider />
 
                 <div className="flex flex-col gap-y-6">
-                  <Heading level="h2">
-                    {t("inventory.create.attributes")}
-                  </Heading>
+                  <div className="flex flex-col gap-y-1">
+                    <Heading level="h2">
+                      {t("inventory.create.attributes")}
+                    </Heading>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {t("inventory.create.attributesHint")}
+                    </Text>
+                  </div>
 
                   <div className="grid grid-cols-1 gap-x-4 gap-y-4 lg:grid-cols-2 lg:gap-y-8">
                     <Form.Field

--- a/packages/vendor/src/pages/inventory/create/inventory-create-form/schema.ts
+++ b/packages/vendor/src/pages/inventory/create/inventory-create-form/schema.ts
@@ -18,6 +18,11 @@ export const CreateInventoryItemSchema = z.object({
   locations: z.record(z.string(), optionalInt).optional(),
 })
 
+export const buildCreateInventoryItemSchema = (t: (key: string) => string) =>
+  CreateInventoryItemSchema.extend({
+    title: z.string().min(1, t("inventory.create.errors.titleRequired")),
+  })
+
 export type CreateInventoryItemSchema = z.infer<
   typeof CreateInventoryItemSchema
 >

--- a/packages/vendor/src/pages/reservations/[id]/index.tsx
+++ b/packages/vendor/src/pages/reservations/[id]/index.tsx
@@ -5,7 +5,6 @@ import { UIMatch } from "react-router-dom"
 import { TwoColumnPageSkeleton } from "@components/common/skeleton"
 import { TwoColumnPage } from "@components/layout/pages"
 import { useLinkQuery, WidgetZone } from "@mercurjs/dashboard-shared"
-import { useDashboardExtension } from "@/extensions"
 import { useReservationItem } from "@hooks/api/reservations"
 import { useInventoryItem } from "@hooks/api"
 import { ReservationGeneralSection } from "./_components/reservation-general-section"
@@ -47,8 +46,6 @@ export const Component = () => {
     useLinkQuery("inventory_item", "*location_levels")
   )
 
-  const { getWidgets } = useDashboardExtension()
-
   if (isLoading || !reservation) {
     return (
       <TwoColumnPageSkeleton
@@ -61,15 +58,7 @@ export const Component = () => {
   }
 
   return (
-    <TwoColumnPage
-      widgets={{
-        before: getWidgets("reservation.details.before"),
-        after: getWidgets("reservation.details.after"),
-        sideBefore: getWidgets("reservation.details.side.before"),
-        sideAfter: getWidgets("reservation.details.side.after"),
-      }}
-      data={reservation}
-    >
+    <TwoColumnPage data={reservation}>
       <TwoColumnPage.Main>
         <WidgetZone id="reservations.detail.main" data={reservation}>
           <ReservationGeneralSection reservation={reservation} />

--- a/packages/vendor/src/pages/reservations/create/reservation-create-from/reservation-create-from.tsx
+++ b/packages/vendor/src/pages/reservations/create/reservation-create-from/reservation-create-from.tsx
@@ -221,6 +221,9 @@ export const ReservationCreateForm = (props: { inventoryItemId?: string }) => {
                           }}
                           {...field}
                           disabled={!inventoryItemId}
+                          placeholder={t(
+                            "inventory.reservation.locationPlaceholder"
+                          )}
                           options={(stock_locations ?? []).map(
                             (stockLocation) => ({
                               label: stockLocation.name,

--- a/packages/vendor/src/pages/reservations/create/reservation-create-from/reservation-create-from.tsx
+++ b/packages/vendor/src/pages/reservations/create/reservation-create-from/reservation-create-from.tsx
@@ -18,12 +18,19 @@ import { useInventoryItems } from "@hooks/api/inventory"
 import { useCreateReservationItem } from "@hooks/api/reservations"
 import { useStockLocations } from "@hooks/api/stock-locations"
 
-export const CreateReservationSchema = zod.object({
-  inventory_item_id: zod.string().min(1),
-  location_id: zod.string().min(1),
-  quantity: zod.number().min(1),
-  description: zod.string().optional(),
-})
+const buildCreateReservationSchema = (t: (key: string) => string) =>
+  zod.object({
+    inventory_item_id: zod
+      .string()
+      .min(1, t("inventory.reservation.errors.idRequired")),
+    location_id: zod
+      .string()
+      .min(1, t("inventory.reservation.errors.selectLocation")),
+    quantity: zod
+      .number()
+      .min(1, t("inventory.reservation.errors.enterQuantity")),
+    description: zod.string().optional(),
+  })
 
 const AttributeGridRow = ({
   title,
@@ -51,6 +58,8 @@ export const ReservationCreateForm = (props: { inventoryItemId?: string }) => {
     null
   )
 
+  const CreateReservationSchema = buildCreateReservationSchema(t)
+
   const form = useForm<zod.infer<typeof CreateReservationSchema>>({
     defaultValues: {
       inventory_item_id: props.inventoryItemId || "",
@@ -61,10 +70,28 @@ export const ReservationCreateForm = (props: { inventoryItemId?: string }) => {
     resolver: zodResolver(CreateReservationSchema),
   })
 
-  const { inventory_items } = useInventoryItems({
+  const { inventory_items: searchedItems } = useInventoryItems({
     fields: "*location_levels",
     q: inventorySearch ?? undefined,
   })
+
+  // The preselected item (from `?item_id=`) may not be in the search results,
+  // so fetch it explicitly and merge it into the options so it stays selected.
+  const { inventory_items: presetItems } = useInventoryItems(
+    {
+      id: props.inventoryItemId ? [props.inventoryItemId] : undefined,
+      fields: "id,sku,title,*location_levels",
+    },
+    { enabled: !!props.inventoryItemId }
+  )
+
+  const inventory_items = React.useMemo(() => {
+    const byId = new Map<string, NonNullable<typeof searchedItems>[number]>()
+    ;[...(presetItems ?? []), ...(searchedItems ?? [])].forEach((it) =>
+      byId.set(it.id, it)
+    )
+    return Array.from(byId.values())
+  }, [presetItems, searchedItems])
 
   const inventoryItemId = form.watch("inventory_item_id")
   const selectedInventoryItem = inventory_items?.find(
@@ -173,6 +200,7 @@ export const ReservationCreateForm = (props: { inventoryItemId?: string }) => {
                           )}
                         />
                       </Form.Control>
+                      <Form.ErrorMessage />
                     </Form.Item>
                   )
                 }}
@@ -201,6 +229,7 @@ export const ReservationCreateForm = (props: { inventoryItemId?: string }) => {
                           )}
                         />
                       </Form.Control>
+                      <Form.ErrorMessage />
                     </Form.Item>
                   )
                 }}


### PR DESCRIPTION
## Summary

Aligns the **Vendor Panel → Inventory** screens with the Figma design (Vendor Panel canvas `40014173:120897`, MER-141), mirroring the shipped admin inventory work from the seller-owned perspective. The vendor edits **its own** stock, so admin-only marketplace affordances are intentionally **not** ported: no Store column/filter, no cross-store bulk gate, and no "confirm with the Vendor" prompt/warning copy.

## Changes

**List** — Product column added; **In stock before Reserved** using the server accessors; `+offers.product_variant.product.title` hydrated via the `inventory_item` link query; default sort Title↑; filters trimmed to **SKU · Location · Height · Width · MID code · Material**; delete-item toast + Figma prompt copy.

**Detail** — dropped the "Details" suffix; quantity string moved to i18n; **Reservations** card rendered; sidebar **Variants → Associated offers**; Metadata/JSON sections shown.

**Drawers / forms** — Edit Details requires Title / optional SKU; Edit Attributes gains the inline tip + missing **Material** field; Manage Locations gains a search input + real pending state; Adjust Quantity shows a friendly empty error; Create Reservation gets friendly error messages, the `?item_id=` preset-item merge, and the two previously-missing `Form.ErrorMessage` surfaces (silent-validation fix).

**Tables** — level-delete prompt interpolates the location + toasts; reservations gain the unfulfilled-order **"Got it"** block and the restored **Order ID** + new **Description** columns; row actions right-aligned.

**Bulk stock** — level `id` included in the update payload; SKU header translated; Product column added.

**Copy** — success toasts and prompts are verbatim to the vendor frames.

## Testing

- `bun run build` (`@mercurjs/vendor`) passes (ESM + DTS).
- `oxlint` clean on the touched directories.
- Adds `integration-tests/http/inventory/vendor/inventory.spec.ts` — seeds a real seller → product → offer → inventory item and asserts the `offers.product_variant.product.title` join resolves non-empty (the Product column), the stock accessors return, and the list is seller-scoped (seller A never sees seller B's item).

The hidden `Admin Inventory Management` Figma section is out of scope.