### PR TITLE
docs: replace home YouTube embed with admin showcase video

### DIFF
--- a/apps/docs/home.mdx
+++ b/apps/docs/home.mdx
@@ -9,14 +9,15 @@ sellers, offers, commissions, order splitting, and payouts on top of Medusa's
 commerce engine, with role-based access and an auditable change pipeline, on
 infrastructure you own.
 
-<iframe
+<video
+  autoPlay
+  muted
+  loop
+  playsInline
+  controls
   className="w-full aspect-video"
-  src="https://www.youtube.com/embed/eO_jMkQZqq4"
-  title="Mercur marketplace platform"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-  allowFullScreen
-></iframe>
+  src="/images/admin-showcase.mp4"
+/>
 
 ## Get started
 


### PR DESCRIPTION
## Summary

Replaces the YouTube `<iframe>` on the documentation home page (`apps/docs/home.mdx`) with a self-hosted `admin-showcase.mp4` video.

This aligns the home page with the existing self-hosted `<video>` convention already used on the introduction page (`platform-walkthrough.mp4`, `seller-walkthrough.mp4`), removing the third-party YouTube dependency.

## Changes

- Added `apps/docs/images/admin-showcase.mp4`
- Swapped the YouTube iframe for a `<video autoPlay muted loop playsInline controls>` element pointing at the local asset