### PR TITLE
docs: lead with enterprise platform positioning, decouple from Medusa framing

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "maple",
   "name": "MercurJS Documentation",
-  "description": "Mercur is the open-source enterprise marketplace platform built on Medusa. Composable, API-first, and AI-native, it runs on your own infrastructure with role-based access control, an auditable change pipeline, and full code ownership. It powers multi-vendor sellers, commissions, order splitting, and payouts, with an admin panel and a vendor portal.",
+  "description": "Mercur is the open-source enterprise marketplace platform. Composable, API-first, and AI-native, it runs on your own infrastructure with role-based access control, an auditable change pipeline, and full code ownership. It powers multi-vendor sellers, commissions, order splitting, and payouts, with an admin panel and a vendor portal, on a proven Medusa commerce core.",
   "logo": {
     "dark": "/logo.svg",
     "light": "/logo_dark.svg"

--- a/apps/docs/home.mdx
+++ b/apps/docs/home.mdx
@@ -1,13 +1,14 @@
 ---
 title: "Mercur Documentation"
 sidebarTitle: "Home"
-description: "The open-source enterprise marketplace platform built on Medusa."
+description: "The open-source enterprise marketplace platform. Composable, API-first, and AI-native, on infrastructure you own."
 ---
 
-Mercur is the open-source enterprise marketplace platform built on Medusa. It adds
-sellers, offers, commissions, order splitting, and payouts on top of Medusa's
-commerce engine, with role-based access and an auditable change pipeline, on
-infrastructure you own.
+Mercur is the open-source enterprise marketplace platform. It gives operators
+multi-vendor governance: sellers, offers, commissions, order splitting, and
+payouts, with role-based access and an auditable change pipeline, on
+infrastructure you own. Core commerce runs on the proven Medusa engine, so
+products, pricing, carts, orders, and payments are mature from day one.
 
 <video
   playsInline
@@ -26,7 +27,7 @@ infrastructure you own.
     Governance, ownership, and composability without a closed platform.
   </Card>
   <Card title="Architecture" icon="sitemap" href="/learn/architecture">
-    How Mercur layers the marketplace domain on Medusa.
+    How the marketplace platform is architected, module by module.
   </Card>
   <Card title="Build with AI" icon="robot" href="/resources/ai/overview">
     Version-matched docs, agent skills, and the MCP server.

--- a/apps/docs/learn/introduction.mdx
+++ b/apps/docs/learn/introduction.mdx
@@ -5,15 +5,16 @@ description: "Set up Mercur, tour the operator and seller panels, and see how a 
 
 ## What is Mercur
 
-Mercur is the open-source enterprise marketplace platform built on Medusa. Medusa
-provides the commerce engine (products, pricing, carts, orders, fulfillment, and
-payments), and Mercur adds the marketplace layer on top: sellers and their teams,
-onboarding, the catalog change pipeline, commissions, order splitting, and vendor
-payouts.
+Mercur is the open-source enterprise marketplace platform. It gives a marketplace
+operator real governance over sellers and their teams, onboarding, the catalog
+change pipeline, commissions, order splitting, and vendor payouts. Role-based
+access control, an auditable change pipeline, and per-seller settlement back all of
+it, while it stays composable, API-first, and fully code-owned. You run it on your
+own infrastructure.
 
-It gives a marketplace operator real governance: role-based access control, an
-auditable change pipeline, and per-seller settlement, while staying composable,
-API-first, and fully code-owned. You run it on your own infrastructure.
+Core commerce runs on the proven Medusa engine, so products, pricing, carts,
+orders, fulfillment, and payments are mature and maintained from day one, and
+Mercur focuses on the marketplace domain on top.
 
 ## Requirements
 
@@ -165,7 +166,7 @@ step is governed by the same roles and recorded for audit.
 
 <CardGroup cols={2}>
   <Card title="Architecture" icon="sitemap" href="/learn/architecture">
-    How Mercur layers the marketplace domain on Medusa.
+    How the marketplace platform is architected, module by module.
   </Card>
   <Card title="Platform" icon="cubes" href="/platform/store/overview">
     Every marketplace capability, with its data models and workflows.

--- a/apps/docs/learn/why-mercur.mdx
+++ b/apps/docs/learn/why-mercur.mdx
@@ -47,11 +47,13 @@ by construction or it fails to compile. Agents work inside the same roles and
 review pipeline as people. They extend the platform, they do not bypass its
 governance.
 
-## Built on Medusa
+## A proven commerce core
 
-Mercur runs on the Medusa commerce engine, so products, pricing, carts, orders,
-and payments are proven, maintained infrastructure. You inherit Medusa's maturity
-and extension model, and Mercur adds only the marketplace layer on top.
+Mercur does not reinvent commerce. Products, pricing, carts, orders, and payments
+run on the proven Medusa engine, so that layer is mature, maintained infrastructure
+from day one. On top of it, Mercur delivers the full marketplace platform:
+governance, multi-vendor orders, commissions, and payouts that a single-store
+engine does not provide.
 
 ## Mercur vs closed marketplace platforms
 
@@ -80,7 +82,7 @@ closed platform.
     Set up Mercur and run a marketplace locally.
   </Card>
   <Card title="Architecture" icon="sitemap" href="/learn/architecture">
-    How Mercur layers the marketplace domain on Medusa.
+    How the marketplace platform is architected, module by module.
   </Card>
   <Card title="Platform" icon="cubes" href="/platform/store/overview">
     Every marketplace capability, with its data models and workflows.


### PR DESCRIPTION
## Why

Across the top-funnel docs, Mercur was described as "the marketplace platform built on Medusa" with Medusa as the head noun and repeated "adds a layer on top" phrasing. That sentence shape reads to both readers and LLM crawlers as *Mercur is a Medusa plugin*, and pulls the project into the SMB/dev-tool cluster instead of the enterprise-marketplace category.

## What changed

Repositions the most-indexed strings so the **enterprise marketplace platform** is the category (noun) and composable / API-first / AI-native are qualifiers (how), with Medusa demoted to a single bounded mention as the underlying commerce engine.

- **`docs.json`** — meta description leads with the platform; Medusa moved to a trailing "proven Medusa commerce core" qualifier.
- **`home.mdx`** — governance-first lead; one Medusa sentence at the end.
- **`learn/introduction.mdx`** — collapsed the double "built on Medusa / Medusa provides / Mercur adds on top" into one bounded mention.
- **`learn/why-mercur.mdx`** — "Built on Medusa" section reframed to "A proven commerce core"; drops "adds only the marketplace layer on top."
- Architecture cards (×3) no longer use the repeated "layers the marketplace domain on Medusa" tagline.

Conforms to the docs voice conventions: no em-dashes (colon / period / comma instead), short declarative sentences.

## Scope

Docs-only. `architecture.mdx` intentionally retains the full Medusa detail, which is the correct home for it.