### PR TITLE
fix(dashboard): resolve sidebar labels through translationNs

### DIFF
--- a/packages/admin/src/components/layout/nav-item/nav-item.tsx
+++ b/packages/admin/src/components/layout/nav-item/nav-item.tsx
@@ -20,6 +20,7 @@ type ItemType = "core" | "extension" | "setting";
 type NestedItemProps = {
   label: string;
   to: string;
+  translationNs?: string;
 };
 
 export type INavItem = {
@@ -30,6 +31,22 @@ export type INavItem = {
   type?: ItemType;
   from?: string;
   nested?: string;
+  translationNs?: string;
+};
+
+const NestedNavLabel = ({
+  label,
+  translationNs,
+}: {
+  label: string;
+  translationNs?: string;
+}) => {
+  const { t } = useTranslation(translationNs);
+  return (
+    <Text size="small" weight="plus" leading="compact">
+      {translationNs ? t(label) : label}
+    </Text>
+  );
 };
 
 const BASE_NAV_LINK_CLASSES =
@@ -93,8 +110,12 @@ export const NavItem = ({
   items,
   type = "core",
   from,
+  translationNs,
 }: INavItem) => {
+  const { t } = useTranslation(translationNs);
   const { pathname } = useLocation();
+
+  const displayLabel = translationNs ? t(label) : label;
   const [open, setOpen] = useState(getIsOpen(to, items, pathname));
 
   useEffect(() => {
@@ -166,7 +187,7 @@ export const NavItem = ({
             </div>
           )}
           <Text size="small" weight="plus" leading="compact">
-            {label}
+            {displayLabel}
           </Text>
         </NavLink>
       </NavItemTooltip>
@@ -182,7 +203,7 @@ export const NavItem = ({
               <Icon icon={icon} type={type} />
             </div>
             <Text size="small" weight="plus" leading="compact">
-              {label}
+              {displayLabel}
             </Text>
           </RadixCollapsible.Trigger>
           <RadixCollapsible.Content>
@@ -209,7 +230,7 @@ export const NavItem = ({
                       data-testid={`sidebar-nav-link-nested-${to.replace(/\//g, "-").replace(/^-/, "")}`}
                     >
                       <Text size="small" weight="plus" leading="compact">
-                        {label}
+                        {displayLabel}
                       </Text>
                     </NavLink>
                   </NavItemTooltip>
@@ -233,9 +254,10 @@ export const NavItem = ({
                           }}
                           data-testid={`sidebar-nav-link-nested-${item.to.replace(/\//g, "-").replace(/^-/, "")}`}
                         >
-                          <Text size="small" weight="plus" leading="compact">
-                            {item.label}
-                          </Text>
+                          <NestedNavLabel
+                            label={item.label}
+                            translationNs={item.translationNs}
+                          />
                         </NavLink>
                       </NavItemTooltip>
                     </li>

--- a/packages/vendor/src/components/layout/nav-item/nav-item.tsx
+++ b/packages/vendor/src/components/layout/nav-item/nav-item.tsx
@@ -20,6 +20,7 @@ type ItemType = "core" | "extension" | "setting";
 type NestedItemProps = {
   label: string;
   to: string;
+  translationNs?: string;
 };
 
 export type INavItem = {
@@ -30,6 +31,22 @@ export type INavItem = {
   type?: ItemType;
   from?: string;
   nested?: string;
+  translationNs?: string;
+};
+
+const NestedNavLabel = ({
+  label,
+  translationNs,
+}: {
+  label: string;
+  translationNs?: string;
+}) => {
+  const { t } = useTranslation(translationNs);
+  return (
+    <Text size="small" weight="plus" leading="compact">
+      {translationNs ? t(label) : label}
+    </Text>
+  );
 };
 
 const BASE_NAV_LINK_CLASSES =
@@ -93,8 +110,12 @@ export const NavItem = ({
   items,
   type = "core",
   from,
+  translationNs,
 }: INavItem) => {
+  const { t } = useTranslation(translationNs);
   const { pathname } = useLocation();
+
+  const displayLabel = translationNs ? t(label) : label;
   const [open, setOpen] = useState(getIsOpen(to, items, pathname));
 
   useEffect(() => {
@@ -166,7 +187,7 @@ export const NavItem = ({
             </div>
           )}
           <Text size="small" weight="plus" leading="compact">
-            {label}
+            {displayLabel}
           </Text>
         </NavLink>
       </NavItemTooltip>
@@ -182,7 +203,7 @@ export const NavItem = ({
               <Icon icon={icon} type={type} />
             </div>
             <Text size="small" weight="plus" leading="compact">
-              {label}
+              {displayLabel}
             </Text>
           </RadixCollapsible.Trigger>
           <RadixCollapsible.Content>
@@ -209,7 +230,7 @@ export const NavItem = ({
                       data-testid={`sidebar-nav-link-nested-${to.replace(/\//g, "-").replace(/^-/, "")}`}
                     >
                       <Text size="small" weight="plus" leading="compact">
-                        {label}
+                        {displayLabel}
                       </Text>
                     </NavLink>
                   </NavItemTooltip>
@@ -233,9 +254,10 @@ export const NavItem = ({
                           }}
                           data-testid={`sidebar-nav-link-nested-${item.to.replace(/\//g, "-").replace(/^-/, "")}`}
                         >
-                          <Text size="small" weight="plus" leading="compact">
-                            {item.label}
-                          </Text>
+                          <NestedNavLabel
+                            label={item.label}
+                            translationNs={item.translationNs}
+                          />
                         </NavLink>
                       </NavItemTooltip>
                     </li>


### PR DESCRIPTION
## Summary

Closes #1367.

`RouteConfig.translationNs` is plumbed all the way into the generated sidebar menu items, and `MainSidebar` passes it into the `NavItem` props — but `NavItem` (forked from `@medusajs/dashboard`) never consumed it. It rendered `label` verbatim, so any custom page whose `config.label` is an i18n key showed the raw key (e.g. `analytics.title`) in every language.

## Changes

In both `@mercurjs/admin` and `@mercurjs/vendor` `NavItem`:

- Destructure `translationNs` and resolve the label with `t(label)` in that namespace (falling back to the raw `label` when no namespace is given), matching upstream Medusa behavior.
- Apply the same resolution to the top-level item, the mobile collapsible trigger, and each nested item (nested items resolve against their own `translationNs` via a small `NestedNavLabel` helper so each can call `useTranslation` with its own namespace).
- Add `translationNs` to the `INavItem` and nested item types.

## Verification

- `bun run build` passes for both `@mercurjs/admin` and `@mercurjs/vendor`.