### PR TITLE
fix(dashboard): make DataGrid columns resizable

### DIFF
--- a/packages/admin/src/components/data-grid/components/data-grid-root.tsx
+++ b/packages/admin/src/components/data-grid/components/data-grid-root.tsx
@@ -183,6 +183,7 @@ export const DataGridRoot = <
     onColumnVisibilityChange: setColumnVisibility,
     getSubRows,
     getCoreRowModel: getCoreRowModel(),
+    columnResizeMode: "onChange",
     defaultColumn: {
       size: 200,
       maxSize: 400,
@@ -337,6 +338,12 @@ export const DataGridRoot = <
     },
   })
   const virtualColumns = columnVirtualizer.getVirtualItems()
+
+  // The column virtualizer caches sizes from getSize(); re-measure when a resize changes them.
+  const columnSizing = grid.getState().columnSizing
+  useEffect(() => {
+    columnVirtualizer.measure()
+  }, [columnSizing, columnVirtualizer])
 
   let virtualPaddingLeft: number | undefined
   let virtualPaddingRight: number | undefined
@@ -743,6 +750,20 @@ export const DataGridRoot = <
                                 header.column.columnDef.header,
                                 header.getContext()
                               )}
+                          {header.column.getCanResize() && (
+                            <div
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                              onClick={(e) => e.stopPropagation()}
+                              className={clx(
+                                "hover:bg-ui-fg-interactive absolute right-0 top-0 z-[2] h-full w-1 cursor-col-resize touch-none select-none",
+                                {
+                                  "bg-ui-fg-interactive":
+                                    header.column.getIsResizing(),
+                                }
+                              )}
+                            />
+                          )}
                         </div>
                       )
 

--- a/packages/vendor/src/components/data-grid/components/data-grid-root.tsx
+++ b/packages/vendor/src/components/data-grid/components/data-grid-root.tsx
@@ -183,6 +183,7 @@ export const DataGridRoot = <
     onColumnVisibilityChange: setColumnVisibility,
     getSubRows,
     getCoreRowModel: getCoreRowModel(),
+    columnResizeMode: "onChange",
     defaultColumn: {
       size: 200,
       maxSize: 400,
@@ -337,6 +338,12 @@ export const DataGridRoot = <
     },
   })
   const virtualColumns = columnVirtualizer.getVirtualItems()
+
+  // The column virtualizer caches sizes from getSize(); re-measure when a resize changes them.
+  const columnSizing = grid.getState().columnSizing
+  useEffect(() => {
+    columnVirtualizer.measure()
+  }, [columnSizing, columnVirtualizer])
 
   let virtualPaddingLeft: number | undefined
   let virtualPaddingRight: number | undefined
@@ -743,6 +750,20 @@ export const DataGridRoot = <
                                 header.column.columnDef.header,
                                 header.getContext()
                               )}
+                          {header.column.getCanResize() && (
+                            <div
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                              onClick={(e) => e.stopPropagation()}
+                              className={clx(
+                                "hover:bg-ui-fg-interactive absolute right-0 top-0 z-[2] h-full w-1 cursor-col-resize touch-none select-none",
+                                {
+                                  "bg-ui-fg-interactive":
+                                    header.column.getIsResizing(),
+                                }
+                              )}
+                            />
+                          )}
                         </div>
                       )
 


### PR DESCRIPTION
Resolves #1360

## Problem

In the vendor **Create Offer → Stock Levels & Prices** step (and other grids), products with long names are truncated in the fixed-width Title column — e.g. both *Meridian Twin-Strap Buckle Sandal* and *Meridian Twin-Strap Sandal* render as *Meridian Twin-St…*, making variant groups indistinguishable.

## Root cause

The admin and vendor `DataGrid` were copied from `@medusajs/dashboard`, but the copy dropped Medusa's built-in **column resizing**. Upstream Medusa relies on resizable columns (`columnResizeMode: "onChange"` + a header drag handle) as the primary way to read long product/variant names in these grids; the Mercur copy shipped without it, so truncated titles had no recourse.

## Fix

Restore column resizing in both `packages/admin` and `packages/vendor` `data-grid-root.tsx`, ported verbatim from `@medusajs/dashboard@2.18.0`:

- `columnResizeMode: "onChange"` on the table config
- A drag handle on each resizable column header (`getResizeHandler()`), styled as upstream (`cursor-col-resize`, interactive hover/active state)
- A `columnVirtualizer.measure()` effect keyed on `columnSizing`, so the virtualized columns re-measure and drags actually take effect

This fixes truncation across every DataGrid in both panels (offer stock levels, price lists, product-create pricing/inventory, bulk edit, …) using the native Medusa mechanism rather than a bespoke layout, and matches the "resizable columns" solution suggested in the issue.

## Testing

- `tsc --noEmit` clean for both packages on the touched files
- Verified in a running vendor panel: the Title column header shows a resize handle and drags wider (capped at `maxSize: 400`), fully revealing long product/variant names