### PR TITLE
fix(dashboard-sdk): register layouts and cell-renderers virtual modules

### DIFF
--- a/packages/dashboard-sdk/src/plugin.ts
+++ b/packages/dashboard-sdk/src/plugin.ts
@@ -49,6 +49,8 @@ const MEDUSA_VIRTUAL_MODULES = [
     "virtual:medusa/displays",
     "virtual:medusa/forms",
     "virtual:medusa/i18n",
+    "virtual:medusa/layouts",
+    "virtual:medusa/cell-renderers",
     "virtual:medusa/menu-items",
     "virtual:medusa/routes",
     "virtual:medusa/widgets",


### PR DESCRIPTION
## Problem

The admin and vendor panels fail to build on v2.3.0 with a blank white page. `@medusajs/dashboard@2.18.0` imports nine `virtual:medusa/*` modules, but `MEDUSA_VIRTUAL_MODULES` in `packages/dashboard-sdk/src/plugin.ts` declared only seven — missing `virtual:medusa/layouts` and `virtual:medusa/cell-renderers`.

Because those two were never added to `optimizeDeps.exclude` nor matched by `isMedusaVirtualModule()`, esbuild's dependency pre-bundler walks `@medusajs/dashboard/dist/app.mjs`, cannot resolve them, and exits:

```
X [ERROR] Could not resolve "virtual:medusa/layouts"
X [ERROR] Could not resolve "virtual:medusa/cell-renderers"
```

## Fix

Add both specifiers to `MEDUSA_VIRTUAL_MODULES`. No other change is needed:

- The existing `resolveId` hook now maps them to `\0virtual:medusa/*`.
- The existing `load` hook already returns `export default {}` for any resolved medusa virtual module — safe here because the dashboard reads `layoutModule?.layouts?.` defensively and imports cell-renderers purely for side effects.
- They are now included in `optimizeDeps.exclude` via the spread.

Fixing the list at the SDK source avoids requiring every consuming app to register a local compat plugin.

Closes #1386