### PR TITLE
fix(storefront): pin hoisted bun linker for Vercel Next.js detection

### DIFF
--- a/apps/storefront/bunfig.toml
+++ b/apps/storefront/bunfig.toml
@@ -1,0 +1,5 @@
+[install]
+# Vercel runs `bun install` with this directory as the cwd (Root Directory =
+# apps/storefront). The hoisted linker places `next` in this package's own
+# node_modules so Vercel's Next.js version detection can resolve it.
+linker = "hoisted"


### PR DESCRIPTION
## Problem

The storefront Vercel deploy fails with:

```
Warning: Could not identify Next.js version...
Error: No Next.js version detected.
```

`next` is present in `apps/storefront/package.json` (`15.5.21`), so the dependency isn't missing. The failure started after the package manager switched from yarn to bun (per the Vercel build log: *Skipping build cache since Package Manager changed from "yarn" to "bun"*).

## Root cause

Bun 1.3 defaults to the **isolated linker**. Confirmed locally — the workspace has a `node_modules/.bun` store. Under the isolated linker, `next` lives at `node_modules/.bun/next@.../node_modules/next` and each package's own `node_modules/next` is only a symlink. Vercel's Next.js version detection (Root Directory = `apps/storefront`) can't resolve `next` through that layout, so it reports no version. Yarn's hoisted layout previously placed `next` as a real directory, which is why it worked before.

## Fix

Add `apps/storefront/bunfig.toml` pinning `linker = "hoisted"`. Vercel runs the install with `apps/storefront` as the working directory, so this scopes the hoisted layout to the Vercel build only — `next` becomes a real directory Vercel can detect. The root workspace install stays on the isolated linker, so the core tsc build is unaffected.

## Verification

- Confirmed `node_modules/.bun` (isolated store) exists in the workspace.
- Config is scoped to `apps/storefront`, so local root installs are unchanged.
- A live Vercel deploy is still needed to confirm the detection passes end-to-end.