### PR TITLE
fix(offer): attribute created offer prices by rule, not position

### DIFF
--- a/integration-tests/http/offer/vendor/create-offers-price-links.spec.ts
+++ b/integration-tests/http/offer/vendor/create-offers-price-links.spec.ts
@@ -1,0 +1,128 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createOffersWorkflow } from "@mercurjs/core/workflows"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
+
+jest.setTimeout(120000)
+
+medusaIntegrationTestRunner({
+    testSuite: ({ getContainer, api }) => {
+        describe("createOffersWorkflow - offer price links", () => {
+            let appContainer: MedusaContainer
+
+            beforeAll(() => {
+                appContainer = getContainer()
+            })
+
+            // Regression: with many offers in a single call, several offers
+            // land prices in the same variant price set. The offer↔price links
+            // must be attributed by the `offer_id` price rule, not by the order
+            // prices come back from the pricing module.
+            it("links every price to the offer that owns it", async () => {
+                const tag = `t${Date.now()}`
+                const { seller, member, headers } = await createSellerUser(
+                    appContainer,
+                    { email: `links-${tag}@test.com`, name: "Links Seller" }
+                )
+
+                const stockLocation = (
+                    await api.post(
+                        `/vendor/stock-locations`,
+                        { name: `WH ${tag}` },
+                        headers
+                    )
+                ).data.stock_location
+
+                const shippingProfile = (
+                    await api.post(
+                        `/vendor/shipping-profiles`,
+                        { name: `Profile ${tag}`, type: "default" },
+                        headers
+                    )
+                ).data.shipping_profile
+
+                const VARIANT_COUNT = 10
+                const OFFERS_PER_VARIANT = 3
+
+                const product = await createVendorProduct(api, headers, {
+                    title: `Links Product ${tag}`,
+                    variants: Array.from(
+                        { length: VARIANT_COUNT },
+                        (_, v) => ({ title: `V${v} ${tag}` })
+                    ),
+                })
+
+                const offersInput = product.variants.flatMap((variant, v) =>
+                    Array.from({ length: OFFERS_PER_VARIANT }, (_, o) => ({
+                        seller_id: seller.id,
+                        created_by: member.id,
+                        variant_id: variant.id,
+                        shipping_profile_id: shippingProfile.id,
+                        sku: `S-${v}-${o}-${tag}`,
+                        inventory_items: [
+                            {
+                                sku: `S-${v}-${o}-${tag}`,
+                                stock_levels: [
+                                    {
+                                        location_id: stockLocation.id,
+                                        stocked_quantity: 100,
+                                    },
+                                ],
+                            },
+                        ],
+                        prices: [
+                            {
+                                amount: (v + 1) * 100 + o,
+                                currency_code: "usd",
+                            },
+                        ],
+                    }))
+                )
+
+                const { result: created } = await createOffersWorkflow(
+                    appContainer
+                ).run({ input: { offers: offersInput } })
+
+                expect(created).toHaveLength(VARIANT_COUNT * OFFERS_PER_VARIANT)
+
+                const query = appContainer.resolve(
+                    ContainerRegistrationKeys.QUERY
+                )
+
+                const { data: offers } = await query.graph({
+                    entity: "offer",
+                    fields: [
+                        "id",
+                        "prices.id",
+                        "prices.price_rules.attribute",
+                        "prices.price_rules.value",
+                    ],
+                    filters: { id: created.map((o) => o.id) },
+                })
+
+                for (const offer of offers) {
+                    const prices = (offer.prices ?? []) as Array<{
+                        id: string
+                        price_rules?: Array<{
+                            attribute: string
+                            value: string
+                        }>
+                    }>
+
+                    // Each offer must own exactly its own price, and that
+                    // price's offer_id rule must point back at the offer.
+                    expect(prices).toHaveLength(1)
+
+                    for (const price of prices) {
+                        const offerRule = (price.price_rules ?? []).find(
+                            (r) => r.attribute === "offer_id"
+                        )
+                        expect(offerRule?.value).toBe(offer.id)
+                    }
+                }
+            })
+        })
+    },
+})

--- a/packages/core/src/workflows/offer/steps/add-offer-prices.ts
+++ b/packages/core/src/workflows/offer/steps/add-offer-prices.ts
@@ -5,8 +5,8 @@ import type { AddPricesDTO } from "@medusajs/framework/types"
 export type AddOfferPricesStepInput = AddPricesDTO[]
 
 export type AddOfferPricesStepOutput = Array<{
-  priceSetId: string
-  prices: Array<{ id: string }>
+  offer_id: string
+  price_ids: string[]
 }>
 
 export const addOfferPricesStepId = "add-offer-prices"
@@ -20,9 +20,7 @@ export const addOfferPricesStep = createStep(
 
     const pricingModule = container.resolve(Modules.PRICING)
 
-    const uniquePriceSetIds = Array.from(
-      new Set(data.map((d) => d.priceSetId)),
-    )
+    const uniquePriceSetIds = Array.from(new Set(data.map((d) => d.priceSetId)))
 
     const existingSets = await pricingModule.listPriceSets(
       { id: uniquePriceSetIds },
@@ -37,35 +35,49 @@ export const addOfferPricesStep = createStep(
 
     const updatedSets = await pricingModule.addPrices(data)
 
-    const newPricesBySet = new Map<string, string[]>()
+    const newPriceIds: string[] = []
     for (const updated of updatedSets) {
       const before = existingIdsBySet.get(updated.id) ?? new Set<string>()
-      const newPrices = (updated.prices ?? [])
-        .map((p) => p.id)
-        .filter((id) => !before.has(id))
-      newPricesBySet.set(updated.id, newPrices)
-    }
-
-    const queueBySet = new Map<string, string[]>()
-    for (const [setId, ids] of newPricesBySet) {
-      queueBySet.set(setId, [...ids])
-    }
-
-    const output: AddOfferPricesStepOutput = data.map((entry) => {
-      const queue = queueBySet.get(entry.priceSetId) ?? []
-      const consumed = queue.splice(0, entry.prices.length)
-      queueBySet.set(entry.priceSetId, queue)
-      return {
-        priceSetId: entry.priceSetId,
-        prices: consumed.map((id) => ({ id })),
+      for (const price of updated.prices ?? []) {
+        if (!before.has(price.id)) {
+          newPriceIds.push(price.id)
+        }
       }
-    })
+    }
 
-    const createdPriceIds = output.flatMap((entry) =>
-      entry.prices.map((p) => p.id),
-    )
+    // Attribute each new price to its offer through the `offer_id` price rule
+    // written in the payload, not by position: a single price set can receive
+    // prices from several offers in one call, and the order `addPrices` returns
+    // them in is not guaranteed to match the input order.
+    const createdPrices = newPriceIds.length
+      ? await pricingModule.listPrices(
+          { id: newPriceIds },
+          { relations: ["price_rules"] },
+        )
+      : []
 
-    return new StepResponse(output, createdPriceIds)
+    const priceIdsByOffer = new Map<string, string[]>()
+    for (const price of createdPrices) {
+      const rules =
+        (
+          price as {
+            price_rules?: Array<{ attribute: string; value: string }>
+          }
+        ).price_rules ?? []
+      const offerId = rules.find((r) => r.attribute === "offer_id")?.value
+      if (!offerId) {
+        continue
+      }
+      const bucket = priceIdsByOffer.get(offerId) ?? []
+      bucket.push(price.id)
+      priceIdsByOffer.set(offerId, bucket)
+    }
+
+    const output: AddOfferPricesStepOutput = Array.from(
+      priceIdsByOffer.entries(),
+    ).map(([offer_id, price_ids]) => ({ offer_id, price_ids }))
+
+    return new StepResponse(output, newPriceIds)
   },
   async (createdPriceIds, { container }) => {
     if (!createdPriceIds?.length) {

--- a/packages/core/src/workflows/offer/workflows/create-offers.ts
+++ b/packages/core/src/workflows/offer/workflows/create-offers.ts
@@ -296,25 +296,17 @@ export const createOffersWorkflow: ReturnWorkflow<
     const addedPrices = addOfferPricesStep(addPricesInput)
 
     const offerPriceLinks = transform(
-      { input, offers, addedPrices },
-      ({ input, offers, addedPrices }) => {
+      { addedPrices },
+      ({ addedPrices }) => {
         const links: LinkDefinition[] = []
-        let cursor = 0
-        input.offers.forEach((offer, idx) => {
-          if (!offer.prices?.length) {
-            return
-          }
-          const entry = addedPrices[cursor++]
-          if (!entry) {
-            return
-          }
-          for (const price of entry.prices) {
+        for (const entry of addedPrices) {
+          for (const priceId of entry.price_ids) {
             links.push({
-              [MercurModules.OFFER]: { offer_id: offers[idx].id },
-              [Modules.PRICING]: { price_id: price.id },
+              [MercurModules.OFFER]: { offer_id: entry.offer_id },
+              [Modules.PRICING]: { price_id: priceId },
             })
           }
-        })
+        }
         return links
       },
     )


### PR DESCRIPTION
## Problem

`createOffersWorkflow` pairs newly created prices back to offers **by array position**. When a single call creates enough offers that several of them add prices to the **same variant price set**, the order the pricing module returns those prices in is not guaranteed to match the input order. The `offer ↔ price` remote links therefore get attributed to the wrong offers.

The price rows themselves are always correct — each carries the right `price_rule (attribute: "offer_id")`, because that rule travels with the price payload. Only the links are wrong, so the two carriers of "this price belongs to this offer" disagree.

### Impact

- `assertOfferPriceOwnership` derives `owned_price_ids` from these links, so a seller editing their own offer's prices could operate on **another seller's price row** (a cross-seller write).
- `query.graph({ entity: "offer", fields: ["prices.*"] })` returns another offer's prices, silently feeding wrong input to anything computed from `offer.prices`.

Reproduces reliably from ~10 variants × 3 offers in one call.

## Fix

`addOfferPricesStep` no longer hands out price ids by position. After `addPrices`, it reads the newly created prices back with their `price_rules` and groups price ids by their own `offer_id` rule, returning an offer-keyed mapping. `create-offers` builds the links directly from that mapping.

This is order-independent and mirrors how `updateOffersWorkflow` already attributes prices to offers by rule.

## Test

Adds `integration-tests/http/offer/vendor/create-offers-price-links.spec.ts`: runs `createOffersWorkflow` with 30 offers (10 variants × 3) in one call and asserts every offer owns exactly its own price and that price's `offer_id` rule points back at the offer. This fails on the old positional pairing.

## Note

This ships in released versions, so existing installs may have mis-attributed links. Repairing them is a separate, environment-specific data migration (and must dismiss the stale link before creating the correct one, since a price may link to only one offer) — not included here.