### PR TITLE
fix(core): avoid double-counting payment statuses

### DIFF
--- a/packages/core/src/workflows/order-group/utils/__tests__/aggregate-status.unit.spec.ts
+++ b/packages/core/src/workflows/order-group/utils/__tests__/aggregate-status.unit.spec.ts
@@ -1,0 +1,73 @@
+import type { OrderDetailDTO } from "@medusajs/framework/types"
+
+import { getLastPaymentStatus } from "../aggregate-status"
+
+const orderWithPaymentCollection = (
+  paymentCollection: Record<string, unknown>,
+) =>
+  ({
+    currency_code: "usd",
+    payment_collections: [paymentCollection],
+  }) as unknown as OrderDetailDTO
+
+describe("getLastPaymentStatus", () => {
+  it.each([
+    [
+      "fully captured",
+      {
+        status: "captured",
+        amount: 100,
+        captured_amount: 100,
+        refunded_amount: 0,
+      },
+      "captured",
+    ],
+    [
+      "fully refunded",
+      {
+        status: "refunded",
+        amount: 100,
+        captured_amount: 100,
+        refunded_amount: 100,
+      },
+      "refunded",
+    ],
+    [
+      "partially captured",
+      {
+        status: "captured",
+        amount: 100,
+        captured_amount: 50,
+        refunded_amount: 0,
+      },
+      "partially_captured",
+    ],
+    [
+      "partially refunded",
+      {
+        status: "refunded",
+        amount: 100,
+        captured_amount: 100,
+        refunded_amount: 50,
+      },
+      "partially_refunded",
+    ],
+    [
+      "authorized",
+      {
+        status: "authorized",
+        amount: 100,
+        captured_amount: 0,
+        refunded_amount: 0,
+      },
+      "authorized",
+    ],
+  ])(
+    "returns the terminal status for the %s collection",
+    (_, collection, expected) => {
+      expect(getLastPaymentStatus(orderWithPaymentCollection(collection))).toBe(
+        expected,
+      )
+    },
+  )
+})

--- a/packages/core/src/workflows/order-group/utils/aggregate-status.ts
+++ b/packages/core/src/workflows/order-group/utils/aggregate-status.ts
@@ -31,11 +31,12 @@ export const getLastPaymentStatus = (order: OrderDetailDTO) => {
   }
 
   for (const paymentCollection of order.payment_collections) {
-    if (
+    const captureIsAmountDerived =
       MathBN.gt(paymentCollection.captured_amount ?? 0, 0) ||
       (isDefined(paymentCollection.amount) &&
         MathBN.eq(paymentCollection.amount, 0))
-    ) {
+
+    if (captureIsAmountDerived) {
       const isGte = MathBN.lte(
         MathBN.sub(
           paymentCollection.amount,
@@ -46,7 +47,12 @@ export const getLastPaymentStatus = (order: OrderDetailDTO) => {
       paymentStatus[PaymentStatus.CAPTURED] += isGte ? 1 : 0.5
     }
 
-    if (MathBN.gt(paymentCollection.refunded_amount ?? 0, 0)) {
+    const refundIsAmountDerived = MathBN.gt(
+      paymentCollection.refunded_amount ?? 0,
+      0
+    )
+
+    if (refundIsAmountDerived) {
       const isGte = MathBN.lte(
         MathBN.sub(
           paymentCollection.amount,
@@ -57,7 +63,15 @@ export const getLastPaymentStatus = (order: OrderDetailDTO) => {
       paymentStatus[PaymentStatus.REFUNDED] += isGte ? 1 : 0.5
     }
 
-    paymentStatus[paymentCollection.status] += 1
+    const statusIsAmountDerived =
+      (paymentCollection.status === PaymentStatus.CAPTURED &&
+        captureIsAmountDerived) ||
+      (paymentCollection.status === PaymentStatus.REFUNDED &&
+        refundIsAmountDerived)
+
+    if (!statusIsAmountDerived) {
+      paymentStatus[paymentCollection.status] += 1
+    }
   }
 
   const totalPayments = order.payment_collections.length


### PR DESCRIPTION
Fixes #1398.

## Summary

- count capture and refund amounts once per payment collection
- skip a redundant persisted `captured` or `refunded` status when the matching amount path already contributed that bucket
- cover fully and partially captured/refunded collections plus the authorized baseline

## Root cause

`getLastPaymentStatus` incremented the same terminal bucket twice when a collection carried both a terminal status and the matching positive amount. A single fully captured or refunded collection therefore exceeded the collection count and was returned as `partially_*`.

## Verification

- red before: 2 failed / 3 passed (fully captured and fully refunded returned `partially_*`)
- focused unit regression: 5 passed
- `bun run build` in `packages/core`
- `bun run lint` (0 errors)

The root monorepo build also reached and passed `@mercurjs/core`; it later stopped on pre-existing lint errors in the unchanged storefront package.