### PR TITLE
fix: bug: `NoRecords` empty state still `h-[150px]` in published `@mercurjs/*...

### DIFF
--- a/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
@@ -91,7 +91,7 @@ export const NoRecords = ({
   return (
     <div
       className={clx(
-        "flex h-[150px] w-full flex-col items-center justify-center gap-y-4",
+        "flex h-[400px] w-full flex-col items-center justify-center gap-y-4",
         className
       )}
     >

--- a/packages/dashboard-shared/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/dashboard-shared/src/components/common/empty-table-content/empty-table-content.tsx
@@ -85,7 +85,7 @@ export const NoRecords = ({
   return (
     <div
       className={clx(
-        "flex h-[150px] w-full flex-col items-center justify-center gap-y-4",
+        "flex h-[400px] w-full flex-col items-center justify-center gap-y-4",
         className
       )}
     >

--- a/packages/vendor/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/vendor/src/components/common/empty-table-content/empty-table-content.tsx
@@ -79,7 +79,7 @@ export const NoRecords = ({
   return (
     <div
       className={clx(
-        "flex h-[150px] w-full flex-col items-center justify-center gap-y-4",
+        "flex h-[400px] w-full flex-col items-center justify-center gap-y-4",
         className
       )}
     >


### PR DESCRIPTION
Fixes #1395

## Root cause

NoRecords empty state hardcodes h-[150px] in all three dashboard packages

## Changes

- Changed the NoRecords wrapper height from h-[150px] to h-[400px] in packages/admin, packages/vendor, and packages/dashboard-shared so it matches NoResults and stays aligned across all packages that ship the component.