### PR TITLE
fix: bug: (vendor): RouteDrawer inventory (and other) edit drawers missing `R...

### DIFF
--- a/packages/vendor/src/pages/inventory/[id]/_components/adjust-inventory/adjust-inventory-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/adjust-inventory/adjust-inventory-drawer.tsx
@@ -43,7 +43,9 @@ export const AdjustInventoryDrawer = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.manageLocations")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.manageLocations")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <AdjustInventoryForm

--- a/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item-attributes/edit-item-attributes-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item-attributes/edit-item-attributes-drawer.tsx
@@ -25,7 +25,9 @@ export const InventoryItemAttributesEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("products.editAttributes")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("products.editAttributes")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditInventoryItemAttributesForm item={inventoryItem} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/edit-item-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/edit-item-drawer.tsx
@@ -26,7 +26,9 @@ export const InventoryItemEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.editItemDetails")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.editItemDetails")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditInventoryItemForm item={inventoryItem} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/inventory/[id]/_components/manage-locations/manage-locations-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/manage-locations/manage-locations-drawer.tsx
@@ -33,7 +33,9 @@ export const ManageLocationsDrawer = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.manageLocations")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.manageLocations")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <ManageLocationsForm item={inventoryItem} locations={stock_locations} />

--- a/packages/vendor/src/pages/price-lists/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/edit/index.tsx
@@ -23,7 +23,9 @@ export const Component = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("priceLists.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("priceLists.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <PriceListEditForm priceList={price_list} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/products/[id]/attributes/create/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/create/index.tsx
@@ -13,7 +13,9 @@ export const Component = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("products.addAttribute")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("products.addAttribute")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       <CreateAttributeForm productId={id!} />
     </RouteDrawer>

--- a/packages/vendor/src/pages/promotions/[id]/add-to-campaign/index.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/add-to-campaign/index.tsx
@@ -24,7 +24,9 @@ export const Component = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("promotions.campaign.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("promotions.campaign.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isPending && !areCampaignsLoading && promotion && campaigns && (
         <AddCampaignPromotionForm promotion={promotion} campaigns={campaigns} />

--- a/packages/vendor/src/pages/promotions/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/edit/index.tsx
@@ -18,7 +18,9 @@ export const Component = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("promotions.edit.title")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("promotions.edit.title")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && promotion && <EditPromotionDetailsForm promotion={promotion} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/promotions/common/edit-rules/edit-rules.tsx
+++ b/packages/vendor/src/pages/promotions/common/edit-rules/edit-rules.tsx
@@ -48,7 +48,9 @@ export const EditRules = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t(`promotions.edit.${ruleType}.title`)}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t(`promotions.edit.${ruleType}.title`)}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && promotion && (
         <EditRulesWrapper

--- a/packages/vendor/src/pages/reservations/[id]/_components/edit-reservation/edit-reservation-modal.tsx
+++ b/packages/vendor/src/pages/reservations/[id]/_components/edit-reservation/edit-reservation-modal.tsx
@@ -52,7 +52,9 @@ export const ReservationEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.reservation.editItemDetails")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.reservation.editItemDetails")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <EditReservationForm

--- a/packages/vendor/src/pages/settings/locations/[location_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/edit/index.tsx
@@ -25,7 +25,11 @@ const LocationEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading className="capitalize">{t("locations.editLocation")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading className="capitalize">
+            {t("locations.editLocation")}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditLocationForm location={stock_location} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/edit/index.tsx
@@ -35,7 +35,9 @@ const LocationServiceZoneEdit = () => {
   return (
     <RouteDrawer prev={`/settings/locations/${location_id}`}>
       <RouteDrawer.Header>
-        <Heading>{t("stockLocations.serviceZones.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("stockLocations.serviceZones.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {serviceZone && (
         <EditServiceZoneForm

--- a/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/shipping-option/[so_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/shipping-option/[so_id]/edit/index.tsx
@@ -39,11 +39,13 @@ const LocationServiceZoneShippingOptionEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>
-          {t(
-            `stockLocations.${isPickup ? "pickupOptions" : "shippingOptions"}.edit.header`
-          )}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>
+            {t(
+              `stockLocations.${isPickup ? "pickupOptions" : "shippingOptions"}.edit.header`
+            )}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {shippingOption && (
         <EditShippingOptionForm

--- a/packages/vendor/src/pages/settings/product-types/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/product-types/[id]/edit/index.tsx
@@ -20,7 +20,9 @@ const ProductTypeEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("productTypes.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("productTypes.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditProductTypeForm productType={product_type} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/settings/regions/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/regions/[id]/edit/index.tsx
@@ -68,7 +68,9 @@ const RegionEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("regions.editRegion")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("regions.editRegion")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && region && (
         <EditRegionForm

--- a/packages/vendor/src/pages/settings/store/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/store/edit/index.tsx
@@ -30,9 +30,11 @@ const StoreEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading className="capitalize">
-          {t("app.menus.store.editStore")}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading className="capitalize">
+            {t("app.menus.store.editStore")}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditStoreForm seller={seller} />}
     </RouteDrawer>


### PR DESCRIPTION
Fixes #1394

## Root cause

Vendor RouteDrawer headers render a bare `Heading` instead of `RouteDrawer.Title`

## Changes

- Wrapped the visual `Heading` inside `RouteDrawer.Title asChild` in every vendor drawer that used `RouteDrawer.Header` without a title, matching the already-established in-tree pattern (e.g. products/[id]/edit, offers/[id]/edit). No i18n keys, layout or behavior changes.