### PR TITLE
fix(admin,vendor): give RouteDrawer dialogs an accessible title

### DIFF
--- a/packages/admin/src/pages/collections/collection-edit/collection-edit.tsx
+++ b/packages/admin/src/pages/collections/collection-edit/collection-edit.tsx
@@ -21,7 +21,9 @@ export const CollectionEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("collections.editCollection")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("collections.editCollection")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && collection && (
         <EditCollectionForm collection={collection} />

--- a/packages/admin/src/pages/customer-groups/customer-group-edit/customer-group-edit.tsx
+++ b/packages/admin/src/pages/customer-groups/customer-group-edit/customer-group-edit.tsx
@@ -23,7 +23,9 @@ export const CustomerGroupEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("customerGroups.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("customerGroups.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && customer_group && (
         <EditCustomerGroupForm group={customer_group} />

--- a/packages/admin/src/pages/customers/customer-edit/customer-edit.tsx
+++ b/packages/admin/src/pages/customers/customer-edit/customer-edit.tsx
@@ -22,7 +22,9 @@ export const CustomerEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("customers.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("customers.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && customer && <EditCustomerForm customer={customer} />}
     </RouteDrawer>

--- a/packages/admin/src/pages/inventory/inventory-detail/components/adjust-inventory/adjust-inventory-drawer.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/components/adjust-inventory/adjust-inventory-drawer.tsx
@@ -37,9 +37,11 @@ export const AdjustInventoryDrawer = () => {
   return (
     <RouteDrawer data-testid="inventory-adjust-inventory-drawer">
       <RouteDrawer.Header data-testid="inventory-adjust-inventory-drawer-header">
-        <Heading data-testid="inventory-adjust-inventory-drawer-title">
-          {t("inventory.manageLocationQuantity")}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="inventory-adjust-inventory-drawer-title">
+            {t("inventory.manageLocationQuantity")}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <AdjustInventoryForm

--- a/packages/admin/src/pages/inventory/inventory-detail/components/edit-inventory-item-attributes/edit-item-attributes-drawer.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/components/edit-inventory-item-attributes/edit-item-attributes-drawer.tsx
@@ -25,7 +25,9 @@ export const InventoryItemAttributesEdit = () => {
   return (
     <RouteDrawer data-testid="inventory-edit-item-attributes-drawer">
       <RouteDrawer.Header data-testid="inventory-edit-item-attributes-drawer-header">
-        <Heading data-testid="inventory-edit-item-attributes-drawer-title">{t("products.editAttributes")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="inventory-edit-item-attributes-drawer-title">{t("products.editAttributes")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditInventoryItemAttributesForm item={inventoryItem} />}
     </RouteDrawer>

--- a/packages/admin/src/pages/inventory/inventory-detail/components/edit-inventory-item/edit-item-drawer.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/components/edit-inventory-item/edit-item-drawer.tsx
@@ -26,7 +26,9 @@ export const InventoryItemEdit = () => {
   return (
     <RouteDrawer data-testid="inventory-edit-item-drawer">
       <RouteDrawer.Header data-testid="inventory-edit-item-drawer-header">
-        <Heading data-testid="inventory-edit-item-drawer-title">{t("inventory.editItemDetails")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="inventory-edit-item-drawer-title">{t("inventory.editItemDetails")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditInventoryItemForm item={inventoryItem} />}
     </RouteDrawer>

--- a/packages/admin/src/pages/inventory/inventory-detail/components/manage-locations/manage-locations-drawer.tsx
+++ b/packages/admin/src/pages/inventory/inventory-detail/components/manage-locations/manage-locations-drawer.tsx
@@ -36,7 +36,9 @@ export const ManageLocationsDrawer = () => {
   return (
     <RouteDrawer data-testid="inventory-manage-locations-drawer">
       <RouteDrawer.Header data-testid="inventory-manage-locations-drawer-header">
-        <Heading data-testid="inventory-manage-locations-drawer-title">{t("inventory.manageLocations")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="inventory-manage-locations-drawer-title">{t("inventory.manageLocations")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <ManageLocationsForm

--- a/packages/admin/src/pages/locations/location-edit/location-edit.tsx
+++ b/packages/admin/src/pages/locations/location-edit/location-edit.tsx
@@ -25,7 +25,9 @@ export const LocationEdit = () => {
   return (
     <RouteDrawer data-testid="location-edit-drawer">
       <RouteDrawer.Header data-testid="location-edit-drawer-header">
-        <Heading className="capitalize" data-testid="location-edit-drawer-heading">{t("locations.editLocation")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading className="capitalize" data-testid="location-edit-drawer-heading">{t("locations.editLocation")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditLocationForm location={stock_location} />}
     </RouteDrawer>

--- a/packages/admin/src/pages/locations/location-service-zone-edit/location-service-zone-edit.tsx
+++ b/packages/admin/src/pages/locations/location-service-zone-edit/location-service-zone-edit.tsx
@@ -33,7 +33,9 @@ export const LocationServiceZoneEdit = () => {
   return (
     <RouteDrawer prev={`/settings/locations/${location_id}`} data-testid="location-service-zone-edit-drawer">
       <RouteDrawer.Header data-testid="location-service-zone-edit-drawer-header">
-        <Heading data-testid="location-service-zone-edit-drawer-heading">{t("stockLocations.serviceZones.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="location-service-zone-edit-drawer-heading">{t("stockLocations.serviceZones.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {serviceZone && (
         <EditServiceZoneForm

--- a/packages/admin/src/pages/locations/location-service-zone-shipping-option-edit/location-service-zone-shipping-option-edit.tsx
+++ b/packages/admin/src/pages/locations/location-service-zone-shipping-option-edit/location-service-zone-shipping-option-edit.tsx
@@ -38,11 +38,13 @@ export const LocationServiceZoneShippingOptionEdit = () => {
   return (
     <RouteDrawer data-testid="location-shipping-option-edit-drawer">
       <RouteDrawer.Header data-testid="location-shipping-option-edit-drawer-header">
-        <Heading data-testid="location-shipping-option-edit-drawer-heading">
-          {t(
-            `stockLocations.${isPickup ? "pickupOptions" : "shippingOptions"}.edit.header`
-          )}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="location-shipping-option-edit-drawer-heading">
+            {t(
+              `stockLocations.${isPickup ? "pickupOptions" : "shippingOptions"}.edit.header`
+            )}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {shippingOption && (
         <EditShippingOptionForm

--- a/packages/admin/src/pages/marketplace/marketplace-edit/marketplace-edit.tsx
+++ b/packages/admin/src/pages/marketplace/marketplace-edit/marketplace-edit.tsx
@@ -17,7 +17,9 @@ export const MarketplaceEdit = () => {
   return (
     <RouteDrawer data-testid="store-edit">
       <RouteDrawer.Header data-testid="store-edit-header">
-        <Heading data-testid="store-edit-heading">{t("marketplace.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="store-edit-heading">{t("marketplace.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditMarketplaceForm store={store} />}
     </RouteDrawer>

--- a/packages/admin/src/pages/orders/order-create-refund/order-create-refund.tsx
+++ b/packages/admin/src/pages/orders/order-create-refund/order-create-refund.tsx
@@ -17,9 +17,11 @@ export const OrderCreateRefund = () => {
   return (
     <RouteDrawer data-testid="order-create-refund-drawer">
       <RouteDrawer.Header data-testid="order-create-refund-header">
-        <Heading data-testid="order-create-refund-heading">
-          {t("orders.payment.createRefund")}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="order-create-refund-heading">
+            {t("orders.payment.createRefund")}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
 
       {order && <CreateRefundForm order={order} />}

--- a/packages/admin/src/pages/orders/order-edit-billing-address/order-edit-billing-address.tsx
+++ b/packages/admin/src/pages/orders/order-edit-billing-address/order-edit-billing-address.tsx
@@ -22,7 +22,9 @@ export const OrderEditBillingAddress = () => {
   return (
     <RouteDrawer data-testid="order-edit-billing-address-drawer">
       <RouteDrawer.Header data-testid="order-edit-billing-address-header">
-        <Heading data-testid="order-edit-billing-address-heading">{t("orders.edit.billingAddress.title")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="order-edit-billing-address-heading">{t("orders.edit.billingAddress.title")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
 
       {order && <EditOrderBillingAddressForm order={order} />}

--- a/packages/admin/src/pages/orders/order-edit-email/order-edit-email.tsx
+++ b/packages/admin/src/pages/orders/order-edit-email/order-edit-email.tsx
@@ -22,7 +22,9 @@ export const OrderEditEmail = () => {
   return (
     <RouteDrawer data-testid="order-edit-email-drawer">
       <RouteDrawer.Header data-testid="order-edit-email-header">
-        <Heading data-testid="order-edit-email-heading">{t("orders.edit.email.title")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="order-edit-email-heading">{t("orders.edit.email.title")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
 
       {order && <EditOrderEmailForm order={order} />}

--- a/packages/admin/src/pages/orders/order-edit-shipping-address/order-edit-shipping-address.tsx
+++ b/packages/admin/src/pages/orders/order-edit-shipping-address/order-edit-shipping-address.tsx
@@ -22,7 +22,9 @@ export const OrderEditShippingAddress = () => {
   return (
     <RouteDrawer data-testid="order-edit-shipping-address-drawer">
       <RouteDrawer.Header data-testid="order-edit-shipping-address-header">
-        <Heading data-testid="order-edit-shipping-address-heading">{t("orders.edit.shippingAddress.title")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="order-edit-shipping-address-heading">{t("orders.edit.shippingAddress.title")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
 
       {order && <EditOrderShippingAddressForm order={order} />}

--- a/packages/admin/src/pages/orders/order-request-transfer/order-request-transfer.tsx
+++ b/packages/admin/src/pages/orders/order-request-transfer/order-request-transfer.tsx
@@ -25,7 +25,9 @@ export const OrderRequestTransfer = () => {
   return (
     <RouteDrawer data-testid="order-request-transfer-drawer">
       <RouteDrawer.Header data-testid="order-request-transfer-header">
-        <Heading data-testid="order-request-transfer-heading">{t("orders.transfer.title")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="order-request-transfer-heading">{t("orders.transfer.title")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
 
       {order && <CreateOrderTransferForm order={order} />}

--- a/packages/admin/src/pages/price-lists/price-list-edit/price-list-edit.tsx
+++ b/packages/admin/src/pages/price-lists/price-list-edit/price-list-edit.tsx
@@ -22,7 +22,9 @@ export const PriceListEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("priceLists.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("priceLists.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <PriceListEditForm priceList={price_list} />}
     </RouteDrawer>

--- a/packages/admin/src/pages/product-types/product-type-edit/product-type-edit.tsx
+++ b/packages/admin/src/pages/product-types/product-type-edit/product-type-edit.tsx
@@ -20,7 +20,9 @@ export const ProductTypeEdit = () => {
   return (
     <RouteDrawer data-testid="product-type-edit-drawer">
       <RouteDrawer.Header data-testid="product-type-edit-drawer-header">
-        <Heading data-testid="product-type-edit-drawer-heading">{t("productTypes.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="product-type-edit-drawer-heading">{t("productTypes.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditProductTypeForm productType={product_type} />}
     </RouteDrawer>

--- a/packages/admin/src/pages/products/product-create-attribute/product-create-attribute.tsx
+++ b/packages/admin/src/pages/products/product-create-attribute/product-create-attribute.tsx
@@ -11,7 +11,9 @@ export const ProductCreateAttribute = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("products.addAttribute")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("products.addAttribute")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       <CreateAttributeForm productId={id!} />
     </RouteDrawer>

--- a/packages/admin/src/pages/promotions/common/edit-rules/edit-rules.tsx
+++ b/packages/admin/src/pages/promotions/common/edit-rules/edit-rules.tsx
@@ -55,7 +55,9 @@ export const EditRules = () => {
   return (
     <RouteDrawer data-testid={`promotion-edit-rules-${ruleType}`}>
       <RouteDrawer.Header data-testid={`promotion-edit-rules-header-${ruleType}`}>
-        <Heading data-testid={`promotion-edit-rules-heading-${ruleType}`}>{t(`promotions.edit.${ruleType}.title`)}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid={`promotion-edit-rules-heading-${ruleType}`}>{t(`promotions.edit.${ruleType}.title`)}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
 
       {!isLoading && promotion && (

--- a/packages/admin/src/pages/promotions/promotion-add-campaign/promotion-add-campaign.tsx
+++ b/packages/admin/src/pages/promotions/promotion-add-campaign/promotion-add-campaign.tsx
@@ -22,7 +22,9 @@ export const PromotionAddCampaign = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("promotions.campaign.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("promotions.campaign.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
 
       {!isPending && promotion && (

--- a/packages/admin/src/pages/promotions/promotion-edit-details/promotion-edit-details.tsx
+++ b/packages/admin/src/pages/promotions/promotion-edit-details/promotion-edit-details.tsx
@@ -22,7 +22,9 @@ export const PromotionEditDetails = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("promotions.edit.title")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("promotions.edit.title")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
 
       {!isLoading && promotion && (

--- a/packages/admin/src/pages/regions/region-edit/region-edit.tsx
+++ b/packages/admin/src/pages/regions/region-edit/region-edit.tsx
@@ -63,7 +63,9 @@ export const RegionEdit = () => {
   return (
     <RouteDrawer data-testid="region-edit-drawer">
       <RouteDrawer.Header data-testid="region-edit-drawer-header">
-        <Heading data-testid="region-edit-drawer-heading">{t("regions.editRegion")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="region-edit-drawer-heading">{t("regions.editRegion")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && region && (
         <EditRegionForm

--- a/packages/admin/src/pages/reservations/reservation-detail/components/edit-reservation/edit-reservation-modal.tsx
+++ b/packages/admin/src/pages/reservations/reservation-detail/components/edit-reservation/edit-reservation-modal.tsx
@@ -43,7 +43,9 @@ export const ReservationEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.reservation.editItemDetails")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.reservation.editItemDetails")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <EditReservationForm

--- a/packages/admin/src/pages/sales-channels/sales-channel-edit/sales-channel-edit.tsx
+++ b/packages/admin/src/pages/sales-channels/sales-channel-edit/sales-channel-edit.tsx
@@ -24,9 +24,11 @@ export const SalesChannelEdit = () => {
   return (
     <RouteDrawer data-testid="sales-channel-edit-drawer">
       <RouteDrawer.Header data-testid="sales-channel-edit-drawer-header">
-        <Heading className="capitalize" data-testid="sales-channel-edit-drawer-heading">
-          {t("salesChannels.editSalesChannel")}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading className="capitalize" data-testid="sales-channel-edit-drawer-heading">
+            {t("salesChannels.editSalesChannel")}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && !!sales_channel && (
         <EditSalesChannelForm salesChannel={sales_channel} />

--- a/packages/admin/src/pages/shipping-option-types/shipping-option-type-edit/shipping-option-type-edit.tsx
+++ b/packages/admin/src/pages/shipping-option-types/shipping-option-type-edit/shipping-option-type-edit.tsx
@@ -21,7 +21,9 @@ export const ShippingOptionTypeEdit = () => {
   return (
     <RouteDrawer data-testid="shipping-option-type-edit-drawer">
       <RouteDrawer.Header data-testid="shipping-option-type-edit-drawer-header">
-        <Heading data-testid="shipping-option-type-edit-drawer-heading">{t("shippingOptionTypes.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="shipping-option-type-edit-drawer-heading">{t("shippingOptionTypes.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <EditShippingOptionTypeForm shippingOptionType={shipping_option_type} />

--- a/packages/admin/src/pages/stores/store-edit/store-edit.tsx
+++ b/packages/admin/src/pages/stores/store-edit/store-edit.tsx
@@ -22,9 +22,11 @@ export const StoreEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading className="capitalize">
-          {t("stores.edit.header")}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading className="capitalize">
+            {t("stores.edit.header")}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && seller && <StoreEditForm seller={seller} />}
     </RouteDrawer>

--- a/packages/admin/src/pages/stores/store-member-invite/index.tsx
+++ b/packages/admin/src/pages/stores/store-member-invite/index.tsx
@@ -10,7 +10,9 @@ const Root = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("stores.members.addUser.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("stores.members.addUser.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       <InviteMemberForm />
     </RouteDrawer>

--- a/packages/admin/src/pages/users/user-edit/user-edit.tsx
+++ b/packages/admin/src/pages/users/user-edit/user-edit.tsx
@@ -17,7 +17,9 @@ export const UserEdit = () => {
   return (
     <RouteDrawer data-testid="user-edit">
       <RouteDrawer.Header data-testid="user-edit-header">
-        <Heading data-testid="user-edit-heading">{t("users.editUser")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading data-testid="user-edit-heading">{t("users.editUser")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && user && <EditUserForm user={user} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/inventory/[id]/_components/adjust-inventory/adjust-inventory-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/adjust-inventory/adjust-inventory-drawer.tsx
@@ -43,7 +43,9 @@ export const AdjustInventoryDrawer = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.manageLocations")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.manageLocations")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <AdjustInventoryForm

--- a/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item-attributes/edit-item-attributes-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item-attributes/edit-item-attributes-drawer.tsx
@@ -25,7 +25,9 @@ export const InventoryItemAttributesEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("products.editAttributes")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("products.editAttributes")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditInventoryItemAttributesForm item={inventoryItem} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/edit-item-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/edit-inventory-item/edit-item-drawer.tsx
@@ -26,7 +26,9 @@ export const InventoryItemEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.editItemDetails")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.editItemDetails")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditInventoryItemForm item={inventoryItem} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/inventory/[id]/_components/manage-locations/manage-locations-drawer.tsx
+++ b/packages/vendor/src/pages/inventory/[id]/_components/manage-locations/manage-locations-drawer.tsx
@@ -33,7 +33,9 @@ export const ManageLocationsDrawer = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.manageLocations")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.manageLocations")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <ManageLocationsForm item={inventoryItem} locations={stock_locations} />

--- a/packages/vendor/src/pages/price-lists/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/price-lists/[id]/edit/index.tsx
@@ -23,7 +23,9 @@ export const Component = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("priceLists.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("priceLists.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <PriceListEditForm priceList={price_list} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/products/[id]/attributes/create/index.tsx
+++ b/packages/vendor/src/pages/products/[id]/attributes/create/index.tsx
@@ -13,7 +13,9 @@ export const Component = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("products.addAttribute")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("products.addAttribute")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       <CreateAttributeForm productId={id!} />
     </RouteDrawer>

--- a/packages/vendor/src/pages/promotions/[id]/add-to-campaign/index.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/add-to-campaign/index.tsx
@@ -24,7 +24,9 @@ export const Component = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("promotions.campaign.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("promotions.campaign.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isPending && !areCampaignsLoading && promotion && campaigns && (
         <AddCampaignPromotionForm promotion={promotion} campaigns={campaigns} />

--- a/packages/vendor/src/pages/promotions/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/promotions/[id]/edit/index.tsx
@@ -18,7 +18,9 @@ export const Component = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("promotions.edit.title")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("promotions.edit.title")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && promotion && <EditPromotionDetailsForm promotion={promotion} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/promotions/common/edit-rules/edit-rules.tsx
+++ b/packages/vendor/src/pages/promotions/common/edit-rules/edit-rules.tsx
@@ -48,7 +48,9 @@ export const EditRules = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t(`promotions.edit.${ruleType}.title`)}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t(`promotions.edit.${ruleType}.title`)}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && promotion && (
         <EditRulesWrapper

--- a/packages/vendor/src/pages/reservations/[id]/_components/edit-reservation/edit-reservation-modal.tsx
+++ b/packages/vendor/src/pages/reservations/[id]/_components/edit-reservation/edit-reservation-modal.tsx
@@ -52,7 +52,9 @@ export const ReservationEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("inventory.reservation.editItemDetails")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("inventory.reservation.editItemDetails")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && (
         <EditReservationForm

--- a/packages/vendor/src/pages/settings/locations/[location_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/edit/index.tsx
@@ -25,7 +25,9 @@ const LocationEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading className="capitalize">{t("locations.editLocation")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading className="capitalize">{t("locations.editLocation")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditLocationForm location={stock_location} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/edit/index.tsx
@@ -35,7 +35,9 @@ const LocationServiceZoneEdit = () => {
   return (
     <RouteDrawer prev={`/settings/locations/${location_id}`}>
       <RouteDrawer.Header>
-        <Heading>{t("stockLocations.serviceZones.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("stockLocations.serviceZones.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {serviceZone && (
         <EditServiceZoneForm

--- a/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/shipping-option/[so_id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/locations/[location_id]/fulfillment-set/[fset_id]/service-zone/[zone_id]/shipping-option/[so_id]/edit/index.tsx
@@ -39,11 +39,13 @@ const LocationServiceZoneShippingOptionEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>
-          {t(
-            `stockLocations.${isPickup ? "pickupOptions" : "shippingOptions"}.edit.header`
-          )}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>
+            {t(
+              `stockLocations.${isPickup ? "pickupOptions" : "shippingOptions"}.edit.header`
+            )}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {shippingOption && (
         <EditShippingOptionForm

--- a/packages/vendor/src/pages/settings/product-types/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/product-types/[id]/edit/index.tsx
@@ -20,7 +20,9 @@ const ProductTypeEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("productTypes.edit.header")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("productTypes.edit.header")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditProductTypeForm productType={product_type} />}
     </RouteDrawer>

--- a/packages/vendor/src/pages/settings/regions/[id]/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/regions/[id]/edit/index.tsx
@@ -68,7 +68,9 @@ const RegionEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>{t("regions.editRegion")}</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>{t("regions.editRegion")}</Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {!isLoading && region && (
         <EditRegionForm

--- a/packages/vendor/src/pages/settings/store/edit/index.tsx
+++ b/packages/vendor/src/pages/settings/store/edit/index.tsx
@@ -30,9 +30,11 @@ const StoreEdit = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading className="capitalize">
-          {t("app.menus.store.editStore")}
-        </Heading>
+        <RouteDrawer.Title asChild>
+          <Heading className="capitalize">
+            {t("app.menus.store.editStore")}
+          </Heading>
+        </RouteDrawer.Title>
       </RouteDrawer.Header>
       {ready && <EditStoreForm seller={seller} />}
     </RouteDrawer>


### PR DESCRIPTION
Closes #1394

## Problem

Edit drawers rendered a visual `Heading` inside `RouteDrawer.Header` but never mounted Radix's `DialogTitle`. Result:

- screen readers announce an unnamed dialog
- DEV console logs ``DialogContent` requires a `DialogTitle`...`` on every open (duplicated under Strict Mode)

The issue reported it on the vendor inventory drawers; the same gap exists across both panels.

## Fix

Wrap the heading in `RouteDrawer.Title asChild`, the pattern already used by e.g. `products/[id]/edit` and `offers/[id]/edit`:

```tsx
<RouteDrawer.Header>
  <RouteDrawer.Title asChild>
    <Heading>{t("inventory.manageLocations")}</Heading>
  </RouteDrawer.Title>
</RouteDrawer.Header>
```

Applied to every `RouteDrawer.Header` in `packages/admin` and `packages/vendor` that lacked a title — 45 files, including all four inventory drawers named in the issue plus price lists, promotions, reservations, locations, service zones, shipping options, product types, regions, store, orders, customers, collections, sales channels, users and store members.

No visual change: `Drawer.Title` renders the same slot and `asChild` keeps the existing `Heading` element and its classes/test ids. `RouteDrawer` already passes `aria-describedby={undefined}`, so no `Description` is required.

`StackedDrawer.Header` usages were checked too — those already have titles.

## Verification

- No `RouteDrawer.Header` without a `RouteDrawer.Title` remains in either panel.
- Diff verified to keep exactly one `Heading` element inside each new `Title asChild` (`asChild` requires a single child).
- Type/syntax checked over the changed files; the dashboard packages have no component test harness, so no automated test accompanies this change.