### PR TITLE
fix(core): validate cart shipping profiles against the offer

### DIFF
--- a/integration-tests/http/offer/order/order.spec.ts
+++ b/integration-tests/http/offer/order/order.spec.ts
@@ -45,6 +45,7 @@ medusaIntegrationTestRunner({
                 stocked: number
                 offerPrice: number
                 required_quantity?: number
+                existingProduct?: any
             }) => {
                 const result = await createSellerUser(appContainer, {
                     email: opts.email,
@@ -132,16 +133,20 @@ medusaIntegrationTestRunner({
                     headers
                 )
 
-                const product = await createVendorProduct(api, headers, {
-                    title: `Prod${uniqueSuffix}`,
-                    sku: `V${uniqueSuffix}`,
-                })
+                const product =
+                    opts.existingProduct ??
+                    (await createVendorProduct(api, headers, {
+                        title: `Prod${uniqueSuffix}`,
+                        sku: `V${uniqueSuffix}`,
+                    }))
 
-                await api.post(
-                    `/vendor/sales-channels/${salesChannel.id}/products`,
-                    { add: [product.id] },
-                    headers
-                )
+                if (!opts.existingProduct) {
+                    await api.post(
+                        `/vendor/sales-channels/${salesChannel.id}/products`,
+                        { add: [product.id] },
+                        headers
+                    )
+                }
 
                 const offer = (
                     await api.post(
@@ -757,6 +762,54 @@ medusaIntegrationTestRunner({
                     expect(after.stocked).toEqual(47)
                     expect(after.reserved).toEqual(0)
                 })
+            })
+
+            it("should complete a cart for an offer whose seller is not the product's default seller", async () => {
+                const sellerA = await seedSellerOfferWithShipping({
+                    email: "profile-a@test.com",
+                    name: "ProfileA",
+                    stocked: 10,
+                    offerPrice: 2500,
+                })
+                const sellerB = await seedSellerOfferWithShipping({
+                    email: "profile-b@test.com",
+                    name: "ProfileB",
+                    stocked: 10,
+                    offerPrice: 3500,
+                    existingProduct: sellerA.product,
+                })
+
+                expect(sellerB.offer.shipping_profile_id).not.toEqual(
+                    sellerA.offer.shipping_profile_id
+                )
+
+                const { completeResp } = await completeCartCheckout(
+                    sellerB.offer.id,
+                    sellerB.variant.id,
+                    1
+                )
+
+                expect(completeResp.status).toEqual(200)
+                expect(completeResp.data.type).toEqual("order_group")
+
+                const query = appContainer.resolve(
+                    ContainerRegistrationKeys.QUERY
+                )
+                const { data: orderGroup } = await query.graph({
+                    entity: "order_group",
+                    filters: { id: completeResp.data.order_group.id },
+                    fields: [
+                        "id",
+                        "orders.id",
+                        "orders.seller.id",
+                        "orders.items.offer.id",
+                    ],
+                })
+
+                const orders = (orderGroup[0] as any).orders
+                expect(orders).toHaveLength(1)
+                expect(orders[0].seller.id).toEqual(sellerB.sellerId)
+                expect(orders[0].items[0].offer.id).toEqual(sellerB.offer.id)
             })
         })
     },

--- a/packages/core/src/workflows/cart/steps/validate-seller-cart-shipping.ts
+++ b/packages/core/src/workflows/cart/steps/validate-seller-cart-shipping.ts
@@ -10,9 +10,6 @@ import { SellerDTO } from "@mercurjs/types"
 type ValidateSellerCartShippingStepInput = {
     cart: Omit<CartWorkflowDTO, "items"> & {
         items: (CartLineItemDTO & {
-            variant?: {
-                product?: { shipping_profile?: { id?: string } | null } | null
-            } | null
             offer?: {
                 id: string
                 seller_id?: string
@@ -71,14 +68,10 @@ export const validateSellerCartShippingStep = createStep(
             )
         )
 
-        // The offer, not the master product, owns the shipping profile a seller
-        // ships from — the product-level profile is only a fallback.
+        // The offer, not the master product, owns the shipping profile a
+        // seller ships from.
         const missingProfiles = itemsRequiringShipping
-            .map(
-                (item) =>
-                    item.offer?.shipping_profile_id ??
-                    item.variant?.product?.shipping_profile?.id
-            )
+            .map((item) => item.offer?.shipping_profile_id ?? undefined)
             .filter((profileId) => !availableProfiles.has(profileId))
 
         if (missingProfiles.length > 0) {

--- a/packages/core/src/workflows/cart/steps/validate-seller-cart-shipping.ts
+++ b/packages/core/src/workflows/cart/steps/validate-seller-cart-shipping.ts
@@ -10,12 +10,19 @@ import { SellerDTO } from "@mercurjs/types"
 type ValidateSellerCartShippingStepInput = {
     cart: Omit<CartWorkflowDTO, "items"> & {
         items: (CartLineItemDTO & {
-            offer?: { id: string; seller_id?: string } | null
+            variant?: {
+                product?: { shipping_profile?: { id?: string } | null } | null
+            } | null
+            offer?: {
+                id: string
+                seller_id?: string
+                shipping_profile_id?: string | null
+            } | null
         })[]
     }
-    shippingOptions: ShippingOptionDTO & {
+    shippingOptions: (ShippingOptionDTO & {
         seller: SellerDTO
-    }[]
+    })[]
 }
 
 export const validateSellerCartShippingStep = createStep(
@@ -40,6 +47,44 @@ export const validateSellerCartShippingStep = createStep(
             throw new MedusaError(
                 MedusaError.Types.INVALID_DATA,
                 "No shipping method selected but the cart contains seller items that require shipping."
+            )
+        }
+
+        const itemsRequiringShipping = (cart.items ?? []).filter(
+            (item) => item.requires_shipping
+        )
+        const shippingMethods = cart.shipping_methods ?? []
+
+        if (itemsRequiringShipping.length > 0 && shippingMethods.length === 0) {
+            throw new MedusaError(
+                MedusaError.Types.INVALID_DATA,
+                "No shipping method selected but the cart contains items that require shipping."
+            )
+        }
+
+        const optionProfileMap = new Map(
+            shippingOptions.map((so) => [so.id, so.shipping_profile_id])
+        )
+        const availableProfiles = new Set(
+            shippingMethods.map((method) =>
+                optionProfileMap.get(method.shipping_option_id as string)
+            )
+        )
+
+        // The offer, not the master product, owns the shipping profile a seller
+        // ships from — the product-level profile is only a fallback.
+        const missingProfiles = itemsRequiringShipping
+            .map(
+                (item) =>
+                    item.offer?.shipping_profile_id ??
+                    item.variant?.product?.shipping_profile?.id
+            )
+            .filter((profileId) => !availableProfiles.has(profileId))
+
+        if (missingProfiles.length > 0) {
+            throw new MedusaError(
+                MedusaError.Types.INVALID_DATA,
+                "The cart items require shipping profiles that are not satisfied by the current shipping methods"
             )
         }
 

--- a/packages/core/src/workflows/cart/workflows/complete-cart-with-split-orders.ts
+++ b/packages/core/src/workflows/cart/workflows/complete-cart-with-split-orders.ts
@@ -33,7 +33,6 @@ import {
     updateCartsStep,
     useQueryGraphStep,
     validateCartPaymentsStep,
-    validateShippingStep,
 } from "@medusajs/medusa/core-flows"
 import { CreateOrderGroupDTO, MercurModules, SellerDTO } from "@mercurjs/types"
 import { createOrderGroupStep } from "../../order-group"
@@ -134,11 +133,7 @@ export const completeCartWithSplitOrdersWorkflow = createWorkflow(
             })
             validateSellerCartShippingStep({
                 cart: cartData.data,
-                shippingOptions: shippingOptionsData.data as ShippingOptionDTO & { seller: SellerDTO }[],
-            })
-            validateShippingStep({
-                cart: cartData.data,
-                shippingOptions: shippingOptionsData.data,
+                shippingOptions: shippingOptionsData.data as (ShippingOptionDTO & { seller: SellerDTO })[],
             })
             const { sales_channel_id } = transform(
                 { cart: cartData.data },


### PR DESCRIPTION
Fixes #1411.

## Problem

`complete-cart-with-split-orders` called Medusa core's `validateShippingStep` with the cart as-is. That step compares each item's `variant.product.shipping_profile.id` — the master product's default profile — against the profiles of the selected shipping options. In Mercur the source of truth is `offer.shipping_profile_id`, so any purchase from a seller other than the product's default seller (the common marketplace case) failed with a 400: *"The cart items require shipping profiles that are not satisfied by the current shipping methods."*

## Fix

The profile check now lives in Mercur's own `validateSellerCartShippingStep`, which already receives the cart and the seller-scoped shipping options. Each item's expected profile is `offer.shipping_profile_id` — the offer is the only source of truth, there is no product-level fallback — and the step performs the same set-difference check core does, plus core's "no shipping method selected" guard. The core `validateShippingStep` call is removed from the workflow.

Items requiring shipping without an offer are already rejected by the seller check earlier in the same step.

`completeCartFields` already fetched `items.offer.shipping_profile_id` and `shipping_methods`, so no query changes were needed.

## Tests

`integration-tests/http/offer/order/order.spec.ts` gains a regression case: seller A creates the master product, seller B creates an offer on A's variant with B's own shipping profile, and a cart holding B's offer is completed. It asserts the two offers really do have different shipping profiles, that completion returns 200, and that the resulting order group holds a single order for seller B linked to B's offer. The seed helper now takes an optional `existingProduct` so a second seller can offer against an existing master product.

The suite previously had both halves of this scenario but never together — every multi-seller checkout test had each seller create its own product, so the product's default profile always happened to belong to the buying seller.

## Verification

`tsc --noEmit` on `packages/core` is clean. The integration suite could not be executed in this worktree (no local install layout); relying on CI to run it.