### PR TITLE
fix(admin): port Medusa's RBAC invite roles field so invited admins aren't locked out

### DIFF
--- a/integration-tests/http/invite/admin/invite.spec.ts
+++ b/integration-tests/http/invite/admin/invite.spec.ts
@@ -1,0 +1,138 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+
+import { adminHeaders, createAdminUser } from "../../../helpers/create-admin-user"
+
+jest.setTimeout(60000)
+
+const SUPER_ADMIN_ROLE_ID = "role_super_admin"
+
+const listInviteRoles = async (
+    container: MedusaContainer,
+    inviteId: string
+): Promise<string[]> => {
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+    const linkService = link.getLinkModule(
+        Modules.USER,
+        "invite_id",
+        Modules.RBAC,
+        "rbac_role_id"
+    )
+
+    const links = await linkService.list({ invite_id: inviteId })
+
+    return links.map((entry: any) => entry.rbac_role_id)
+}
+
+medusaIntegrationTestRunner({
+    testSuite: ({ getContainer, api }) => {
+        describe("Admin - Invites", () => {
+            let appContainer: MedusaContainer
+
+            beforeAll(() => {
+                appContainer = getContainer()
+            })
+
+            beforeEach(async () => {
+                const { user } = await createAdminUser(
+                    null,
+                    adminHeaders,
+                    appContainer
+                )
+
+                // `/admin/rbac/roles/assignable` reads the actor's roles from
+                // the user <> role link rather than from the JWT, so link the
+                // seeded super admin role the way `medusa user` does.
+                const link: any = appContainer.resolve(
+                    ContainerRegistrationKeys.LINK
+                )
+                await link.create({
+                    [Modules.USER]: { user_id: user.id },
+                    [Modules.RBAC]: { rbac_role_id: SUPER_ADMIN_ROLE_ID },
+                })
+            })
+
+            // The panel only renders the roles field when the `rbac` flag is
+            // reported as enabled, so `withMercur` forcing it on has to be
+            // visible here.
+            it("reports the rbac feature flag as enabled", async () => {
+                const response = await api.get(
+                    "/admin/feature-flags",
+                    adminHeaders
+                )
+
+                expect(response.status).toEqual(200)
+                expect(response.data.feature_flags.rbac).toBe(true)
+            })
+
+            it("lists the roles an admin is allowed to assign", async () => {
+                const response = await api.get(
+                    "/admin/rbac/roles/assignable",
+                    adminHeaders
+                )
+
+                expect(response.status).toEqual(200)
+                expect(response.data.roles.map((role: any) => role.id)).toContain(
+                    SUPER_ADMIN_ROLE_ID
+                )
+            })
+
+            it("links the roles the invite was created with", async () => {
+                const response = await api.post(
+                    "/admin/invites",
+                    {
+                        email: "with-roles@test.com",
+                        roles: [SUPER_ADMIN_ROLE_ID],
+                    },
+                    adminHeaders
+                )
+
+                expect(response.status).toEqual(200)
+                expect(
+                    await listInviteRoles(appContainer, response.data.invite.id)
+                ).toEqual([SUPER_ADMIN_ROLE_ID])
+            })
+
+            it("lets an admin invited with a role use policy-guarded routes", async () => {
+                const email = "invited@test.com"
+                const password = "somepassword"
+
+                const {
+                    data: { invite },
+                } = await api.post(
+                    "/admin/invites",
+                    { email, roles: [SUPER_ADMIN_ROLE_ID] },
+                    adminHeaders
+                )
+
+                const {
+                    data: { token: registrationToken },
+                } = await api.post("/auth/user/emailpass/register", {
+                    email,
+                    password,
+                })
+
+                const acceptResponse = await api.post(
+                    `/admin/invites/accept?token=${invite.token}`,
+                    { email, first_name: "Invited", last_name: "Admin" },
+                    { headers: { authorization: `Bearer ${registrationToken}` } }
+                )
+
+                expect(acceptResponse.status).toEqual(200)
+
+                const {
+                    data: { token: sessionToken },
+                } = await api.post("/auth/user/emailpass", { email, password })
+
+                // `/admin/stores` declares policies, so it 403s for an actor
+                // whose role list is empty.
+                const storesResponse = await api.get("/admin/stores", {
+                    headers: { authorization: `Bearer ${sessionToken}` },
+                })
+
+                expect(storesResponse.status).toEqual(200)
+            })
+        })
+    },
+})

--- a/packages/admin/src/app.tsx
+++ b/packages/admin/src/app.tsx
@@ -5,7 +5,7 @@ import customFields from "virtual:mercur/custom-fields";
 import { HelmetProvider } from "react-helmet-async";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ExtensionProvider } from "@mercurjs/dashboard-shared";
-import { ThemeProvider } from "./providers";
+import { FeatureFlagProvider, ThemeProvider } from "./providers";
 import { I18nProvider, Toaster, TooltipProvider } from "@medusajs/ui";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { I18n } from "./components/utilities/i18n";
@@ -28,21 +28,23 @@ export default function App() {
       <HelmetProvider>
         <QueryClientProvider client={queryClient}>
           <ThemeProvider>
-            <ExtensionProvider
-              widgets={widgets}
-              navigation={navigation}
-              customFields={customFields}
-            >
-              <I18n />
-              <I18nProvider>
-                <RouterProvider
-                  router={createBrowserRouter(getRouteMap(routes), {
-                    basename: __BASE__,
-                  })}
-                />
-              </I18nProvider>
-              <Toaster />
-            </ExtensionProvider>
+            <FeatureFlagProvider>
+              <ExtensionProvider
+                widgets={widgets}
+                navigation={navigation}
+                customFields={customFields}
+              >
+                <I18n />
+                <I18nProvider>
+                  <RouterProvider
+                    router={createBrowserRouter(getRouteMap(routes), {
+                      basename: __BASE__,
+                    })}
+                  />
+                </I18nProvider>
+                <Toaster />
+              </ExtensionProvider>
+            </FeatureFlagProvider>
           </ThemeProvider>
         </QueryClientProvider>
       </HelmetProvider>

--- a/packages/admin/src/components/authentication/protected-route/protected-route.tsx
+++ b/packages/admin/src/components/authentication/protected-route/protected-route.tsx
@@ -1,14 +1,35 @@
 import { Spinner } from "@medusajs/icons";
+import { useMemo } from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useMePermissions } from "../../../hooks/api/rbac-roles";
 import { useMe } from "../../../hooks/api/users";
+import type { Permission, UserPolicy } from "../../../lib/permissions";
+import { useFeatureFlag } from "../../../providers/feature-flag-provider";
+import { PermissionsProvider } from "../../../providers/permissions-provider";
 import { SearchProvider } from "../../../providers/search-provider";
 import { SidebarProvider } from "../../../providers/sidebar-provider";
 
 export const ProtectedRoute = () => {
-  const { user, isLoading } = useMe();
   const location = useLocation();
+  const isRbacEnabled = useFeatureFlag("rbac");
 
-  if (isLoading) {
+  const { user, isLoading: isLoadingUser } = useMe();
+  const { data: permissionsResponse, isLoading: isLoadingPermissions } =
+    useMePermissions({
+      // Don't fetch permissions until we know the user is authenticated.
+      enabled: !!user && isRbacEnabled,
+    });
+
+  const policy: UserPolicy | null = useMemo(() => {
+    if (!permissionsResponse) {
+      return null;
+    }
+    return {
+      permissions: permissionsResponse.permissions as Permission[],
+    };
+  }, [permissionsResponse]);
+
+  if (isLoadingUser) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner className="text-ui-fg-interactive animate-spin" />
@@ -21,10 +42,16 @@ export const ProtectedRoute = () => {
   }
 
   return (
-    <SidebarProvider>
-      <SearchProvider>
-        <Outlet />
-      </SearchProvider>
-    </SidebarProvider>
+    <PermissionsProvider
+      policy={policy}
+      isLoading={isLoadingPermissions}
+      isRbacEnabled={isRbacEnabled}
+    >
+      <SidebarProvider>
+        <SearchProvider>
+          <Outlet />
+        </SearchProvider>
+      </SidebarProvider>
+    </PermissionsProvider>
   );
 };

--- a/packages/admin/src/hooks/api/feature-flags.tsx
+++ b/packages/admin/src/hooks/api/feature-flags.tsx
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { fetchQuery } from "../../lib/client"
+
+export type FeatureFlags = {
+  view_configurations?: boolean
+  translation?: boolean
+  rbac?: boolean
+  [key: string]: boolean | undefined
+}
+
+export const useFeatureFlags = () => {
+  return useQuery<FeatureFlags>({
+    queryKey: ["admin", "feature-flags"],
+    queryFn: async () => {
+      const response = (await fetchQuery("/admin/feature-flags", {
+        method: "GET",
+      })) as { feature_flags: FeatureFlags }
+
+      return response.feature_flags
+    },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  })
+}

--- a/packages/admin/src/hooks/api/rbac-roles.tsx
+++ b/packages/admin/src/hooks/api/rbac-roles.tsx
@@ -1,0 +1,61 @@
+import { HttpTypes } from "@medusajs/types"
+import { ClientError } from "@mercurjs/client"
+import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/client"
+
+const ME_PERMISSIONS_QUERY_KEY = ["rbac_me_permissions"] as const
+
+export const mePermissionsQueryKey = ME_PERMISSIONS_QUERY_KEY
+
+export const useMePermissions = (
+  options?: Omit<
+    UseQueryOptions<
+      HttpTypes.AdminRbacMePermissionsResponse,
+      ClientError,
+      HttpTypes.AdminRbacMePermissionsResponse,
+      QueryKey
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryFn: () =>
+      sdk.admin.rbac.me.permissions.query(
+        {} as never
+      ) as unknown as Promise<HttpTypes.AdminRbacMePermissionsResponse>,
+    queryKey: mePermissionsQueryKey,
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}
+
+const ASSIGNABLE_ROLES_QUERY_KEY = ["rbac_assignable_roles"] as const
+
+export const assignableRolesQueryKey = ASSIGNABLE_ROLES_QUERY_KEY
+
+/**
+ * Fetches the roles the authenticated actor is allowed to assign.
+ */
+export const useRbacAssignableRoles = (
+  query?: HttpTypes.AdminRbacRoleListParams,
+  options?: Omit<
+    UseQueryOptions<
+      HttpTypes.AdminRbacAssignableRolesListResponse,
+      ClientError,
+      HttpTypes.AdminRbacAssignableRolesListResponse,
+      QueryKey
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryFn: () =>
+      sdk.admin.rbac.roles.assignable.query({
+        ...query,
+      } as never) as unknown as Promise<HttpTypes.AdminRbacAssignableRolesListResponse>,
+    queryKey: [...ASSIGNABLE_ROLES_QUERY_KEY, query],
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}

--- a/packages/admin/src/hooks/table/query/use-user-invite-table-query.tsx
+++ b/packages/admin/src/hooks/table/query/use-user-invite-table-query.tsx
@@ -3,11 +3,13 @@ import { useQueryParams } from "../../use-query-params"
 type UseUserInviteTableQueryProps = {
   prefix?: string
   pageSize?: number
+  fields?: string
 }
 
 export const useUserInviteTableQuery = ({
   prefix,
   pageSize = 20,
+  fields,
 }: UseUserInviteTableQueryProps) => {
   const queryObject = useQueryParams(
     ["offset", "q", "order", "created_at", "updated_at"],
@@ -23,6 +25,7 @@ export const useUserInviteTableQuery = ({
     created_at: created_at ? JSON.parse(created_at) : undefined,
     updated_at: updated_at ? JSON.parse(updated_at) : undefined,
     q,
+    fields,
   }
 
   return {

--- a/packages/admin/src/i18n/translations/$schema.json
+++ b/packages/admin/src/i18n/translations/$schema.json
@@ -11724,6 +11724,18 @@
       ],
       "additionalProperties": false
     },
+    "roles": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "domain"
+      ],
+      "additionalProperties": false
+    },
     "users": {
       "type": "object",
       "properties": {
@@ -11853,6 +11865,9 @@
         },
         "invite": {
           "type": "string"
+        },
+        "inviteRolesTooltip": {
+          "type": "string"
         }
       },
       "required": [
@@ -11873,7 +11888,8 @@
         "list",
         "deleteUserWarning",
         "deleteUserSuccess",
-        "invite"
+        "invite",
+        "inviteRolesTooltip"
       ],
       "additionalProperties": false
     },
@@ -16507,7 +16523,8 @@
     "commissionLines",
     "commissions",
     "commissionRates",
-    "offers"
+    "offers",
+    "roles"
   ],
   "additionalProperties": false
 }

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -2978,7 +2978,11 @@
     },
     "deleteUserWarning": "You are about to delete the user {{name}}. This action cannot be undone.",
     "deleteUserSuccess": "User {{name}} was successfully removed.",
-    "invite": "Invite"
+    "invite": "Invite",
+    "inviteRolesTooltip": "If no role is selected, the user will be invited with a superuser role."
+  },
+  "roles": {
+    "domain": "Roles"
   },
   "marketplace": {
     "domain": "Marketplace",

--- a/packages/admin/src/lib/permissions/constants.ts
+++ b/packages/admin/src/lib/permissions/constants.ts
@@ -1,0 +1,16 @@
+import type { PermissionOperation } from "./types"
+
+/**
+ * Map of operations to the operations they imply.
+ * The wildcard (*) implies all CRUD operations.
+ */
+export const OPERATION_IMPLICATIONS: Record<
+  PermissionOperation,
+  PermissionOperation[]
+> = {
+  read: ["read"],
+  create: ["create"],
+  update: ["update"],
+  delete: ["delete"],
+  "*": ["read", "create", "update", "delete", "*"],
+}

--- a/packages/admin/src/lib/permissions/index.ts
+++ b/packages/admin/src/lib/permissions/index.ts
@@ -1,0 +1,13 @@
+export type {
+  Permission,
+  PermissionOperation,
+  PermissionRequirement,
+  PermissionResource,
+  PermissionsContextValue,
+  PermissionsRequirementsContextValue,
+  UserPolicy,
+} from "./types"
+
+export { OPERATION_IMPLICATIONS } from "./constants"
+
+export { buildPermission, parsePermission } from "./utils"

--- a/packages/admin/src/lib/permissions/types.ts
+++ b/packages/admin/src/lib/permissions/types.ts
@@ -1,0 +1,133 @@
+/**
+ * Permission types for RBAC in the admin dashboard.
+ *
+ * Permissions follow the pattern: `{resource}:{operation}`
+ * Examples:
+ *   - customer:read - Can view customers
+ *   - customer:create - Can create customers
+ *   - customer:* - Wildcard, full access (read + create + update + delete)
+ */
+
+/**
+ * Resources that can have permissions applied to them.
+ * These map to Medusa commerce domains.
+ */
+export type PermissionResource =
+  | "customer"
+  | "customer_group"
+  | "order"
+  | "product"
+  | "product_category"
+  | "product_collection"
+  | "product_tag"
+  | "product_type"
+  | "inventory"
+  | "reservation"
+  | "promotion"
+  | "campaign"
+  | "price_list"
+  | "region"
+  | "store"
+  | "user"
+  | "rbac_role"
+  | "rbac_policy"
+  | "sales_channel"
+  | "stock_location"
+  | "shipping_profile"
+  | "shipping_option"
+  | "tax_region"
+  | "api_key"
+  | "return_reason"
+  | "refund_reason"
+  | "workflow"
+  | "translation"
+
+/**
+ * Operations that can be performed on resources.
+ */
+export type PermissionOperation = "read" | "create" | "update" | "delete" | "*"
+
+/**
+ * A single permission string in the format "resource:operation"
+ */
+export type Permission = `${PermissionResource}:${PermissionOperation}`
+
+/**
+ * A policy represents the user's set of permissions.
+ */
+export interface UserPolicy {
+  /**
+   * Array of permission strings the user has been granted.
+   */
+  permissions: Permission[]
+}
+
+/**
+ * Required permissions descriptor for a subtree or component.
+ */
+export interface PermissionRequirement {
+  /**
+   * Permissions required for the subtree/component.
+   */
+  permissions: Permission[]
+  /**
+   * If true, requires ALL permissions. Default is ANY.
+   */
+  requireAll?: boolean
+  /**
+   * Optional source label for debugging or display.
+   */
+  source?: string
+}
+
+/**
+ * Props for permission-related context and hooks.
+ */
+export interface PermissionsContextValue {
+  /**
+   * The user's current policy containing their permissions.
+   */
+  policy: UserPolicy | null
+  /**
+   * Whether the policy is currently being loaded.
+   */
+  isLoading: boolean
+  /**
+   * Check if the user has a specific permission.
+   */
+  hasPermission: (permission: Permission) => boolean
+  /**
+   * Check if the user has any of the specified permissions.
+   */
+  hasAnyPermission: (permissions: Permission[]) => boolean
+  /**
+   * Check if the user has all of the specified permissions.
+   */
+  hasAllPermissions: (permissions: Permission[]) => boolean
+  /**
+   * Check if user can perform an operation on a resource.
+   */
+  can: (resource: PermissionResource, operation: PermissionOperation) => boolean
+}
+
+/**
+ * Context value for required permissions collection.
+ */
+export interface PermissionsRequirementsContextValue {
+  /**
+   * Collected permission requirements for the current subtree.
+   */
+  requiredPermissions: PermissionRequirement[]
+  /**
+   * Register required permissions for the current subtree.
+   */
+  registerRequiredPermissions: (
+    id: string,
+    requirement: PermissionRequirement
+  ) => void
+  /**
+   * Unregister required permissions for the current subtree.
+   */
+  unregisterRequiredPermissions: (id: string) => void
+}
+

--- a/packages/admin/src/lib/permissions/utils.ts
+++ b/packages/admin/src/lib/permissions/utils.ts
@@ -1,0 +1,42 @@
+import type {
+  Permission,
+  PermissionOperation,
+  PermissionResource,
+} from "./types"
+
+/**
+ * Parse a permission string into its resource and operation components.
+ *
+ * @param permission - Permission string in format "resource:operation"
+ * @returns Object with resource and operation, or null if invalid
+ */
+export function parsePermission(permission: string): {
+  resource: PermissionResource
+  operation: PermissionOperation
+} | null {
+  const parts = permission.split(":")
+  if (parts.length !== 2) {
+    return null
+  }
+
+  const [resource, operation] = parts
+
+  return {
+    resource: resource as PermissionResource,
+    operation: operation as PermissionOperation,
+  }
+}
+
+/**
+ * Build a permission string from resource and operation.
+ *
+ * @param resource - The permission resource
+ * @param operation - The permission operation
+ * @returns Permission string
+ */
+export function buildPermission(
+  resource: PermissionResource,
+  operation: PermissionOperation
+): Permission {
+  return `${resource}:${operation}` as Permission
+}

--- a/packages/admin/src/pages/users/user-invite/components/invite-user-form/invite-user-form.tsx
+++ b/packages/admin/src/pages/users/user-invite/components/invite-user-form/invite-user-form.tsx
@@ -21,6 +21,8 @@ import { Trans, useTranslation } from "react-i18next";
 import * as zod from "zod";
 import { ActionMenu } from "../../../../../components/common/action-menu/index.ts";
 import { Form } from "../../../../../components/common/form/index.ts";
+import { ListSummary } from "../../../../../components/common/list-summary/index.ts";
+import { Combobox } from "../../../../../components/inputs/combobox/index.ts";
 import { RouteFocusModal } from "../../../../../components/modals/index.ts";
 import { _DataTable } from "../../../../../components/table/data-table/index.ts";
 import { KeyboundForm } from "../../../../../components/utilities/keybound-form/keybound-form.tsx";
@@ -30,12 +32,16 @@ import {
   useInvites,
   useResendInvite,
 } from "../../../../../hooks/api/invites.tsx";
+import { useRbacAssignableRoles } from "../../../../../hooks/api/rbac-roles.tsx";
 import { useUserInviteTableQuery } from "../../../../../hooks/table/query/use-user-invite-table-query.tsx";
 import { useDataTable } from "../../../../../hooks/use-data-table.tsx";
 import { isFetchError } from "../../../../../lib/is-fetch-error.ts";
+import { useFeatureFlag } from "../../../../../providers/feature-flag-provider/index.tsx";
+import { usePermissions } from "../../../../../providers/permissions-provider/index.ts";
 
 const InviteUserSchema = zod.object({
   email: zod.string().email(),
+  roles: zod.array(zod.string()).optional(),
 });
 
 const PAGE_SIZE = 10;
@@ -53,17 +59,54 @@ const INVITE_URL = `${window.location.origin}${getBaseUrl()}/invite?token=`;
 
 export const InviteUserForm = () => {
   const { t } = useTranslation();
+  const isRbacEnabled = useFeatureFlag("rbac");
+  const { hasPermission } = usePermissions();
+  const canReadRbacRoles = hasPermission("rbac_role:read");
+  const showRbacRolesField = isRbacEnabled && canReadRbacRoles;
 
   const form = useForm<zod.infer<typeof InviteUserSchema>>({
     defaultValues: {
       email: "",
+      roles: [],
     },
     resolver: zodResolver(InviteUserSchema),
   });
 
+  const { data: assignableData, isPending: isRolesLoading } =
+    useRbacAssignableRoles(
+      { limit: 200, order: "name" },
+      { enabled: showRbacRolesField },
+    );
+
+  const roleOptions = useMemo(() => {
+    return (assignableData?.roles ?? []).map((role) => ({
+      label: role.name,
+      value: role.id,
+    }));
+  }, [assignableData?.roles]);
+
+  const inviteFields = useMemo(() => {
+    if (!showRbacRolesField) {
+      return undefined;
+    }
+
+    return [
+      "id",
+      "email",
+      "accepted",
+      "token",
+      "expires_at",
+      "created_at",
+      "updated_at",
+      "rbac_roles.id",
+      "rbac_roles.name",
+    ].join(",");
+  }, [showRbacRolesField]);
+
   const { raw, searchParams } = useUserInviteTableQuery({
     prefix: PREFIX,
     pageSize: PAGE_SIZE,
+    fields: inviteFields,
   });
 
   const {
@@ -74,7 +117,7 @@ export const InviteUserForm = () => {
     error,
   } = useInvites(searchParams);
 
-  const columns = useColumns();
+  const columns = useColumns({ isRbacEnabled: showRbacRolesField });
 
   const { table } = useDataTable({
     data: invites ?? [],
@@ -90,7 +133,15 @@ export const InviteUserForm = () => {
 
   const handleSubmit = form.handleSubmit(async (values) => {
     try {
-      await mutateAsync({ email: values.email });
+      const payload: HttpTypes.AdminCreateInvite = {
+        email: values.email,
+      };
+
+      if (showRbacRolesField && values.roles?.length) {
+        payload.roles = values.roles;
+      }
+
+      await mutateAsync(payload);
       form.reset();
     } catch (error) {
       if (isFetchError(error) && error.status === 400) {
@@ -169,6 +220,39 @@ export const InviteUserForm = () => {
                       );
                     }}
                   />
+                  {showRbacRolesField && (
+                    <Form.Field
+                      control={form.control}
+                      name="roles"
+                      render={({ field }) => {
+                        return (
+                          <Form.Item data-testid="user-invite-form-roles-item">
+                            <Form.Label
+                              optional
+                              tooltip={t("users.inviteRolesTooltip")}
+                              data-testid="user-invite-form-roles-label"
+                            >
+                              {t("roles.domain")}
+                            </Form.Label>
+                            <Form.Control data-testid="user-invite-form-roles-control">
+                              <Combobox
+                                {...field}
+                                value={field.value ?? []}
+                                onChange={(value) => {
+                                  field.onChange(value ?? []);
+                                }}
+                                options={roleOptions}
+                                placeholder={t("labels.selectValues")}
+                                disabled={isRolesLoading}
+                                data-testid="user-invite-form-roles-input"
+                              />
+                            </Form.Control>
+                            <Form.ErrorMessage data-testid="user-invite-form-roles-error" />
+                          </Form.Item>
+                        );
+                      }}
+                    />
+                  )}
                 </div>
                 <div className="flex items-center justify-end">
                   <Button
@@ -291,7 +375,7 @@ const InviteActions = ({ invite }: { invite: HttpTypes.AdminInvite }) => {
 
 const columnHelper = createColumnHelper<HttpTypes.AdminInvite>();
 
-const useColumns = () => {
+const useColumns = ({ isRbacEnabled }: { isRbacEnabled: boolean }) => {
   const { t } = useTranslation();
 
   return useMemo(
@@ -302,6 +386,32 @@ const useColumns = () => {
           return getValue();
         },
       }),
+      ...(isRbacEnabled
+        ? [
+            columnHelper.display({
+              id: "roles",
+              header: t("roles.domain"),
+              cell: ({ row }) => {
+                const roleNames =
+                  row.original.rbac_roles?.map((role) => role.name) ?? [];
+
+                if (!roleNames.length) {
+                  return (
+                    <Text size="small" className="text-ui-fg-subtle">
+                      -
+                    </Text>
+                  );
+                }
+
+                return (
+                  <div className="flex items-center">
+                    <ListSummary inline n={1} list={roleNames} />
+                  </div>
+                );
+              },
+            }),
+          ]
+        : []),
       columnHelper.accessor("accepted", {
         header: t("fields.status"),
         cell: ({ getValue, row }) => {
@@ -376,6 +486,6 @@ const useColumns = () => {
         cell: ({ row }) => <InviteActions invite={row.original} />,
       }),
     ],
-    [t],
+    [t, isRbacEnabled],
   );
 };

--- a/packages/admin/src/providers/feature-flag-provider/index.tsx
+++ b/packages/admin/src/providers/feature-flag-provider/index.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useCallback, useContext, useMemo } from "react"
+import { useFeatureFlags, FeatureFlags } from "../../hooks/api/feature-flags"
+
+interface FeatureFlagContextValue {
+  flags: FeatureFlags
+  isLoading: boolean
+  isFeatureEnabled: (flag: keyof FeatureFlags) => boolean
+}
+
+const FeatureFlagContext = createContext<FeatureFlagContextValue | null>(null)
+
+export const useFeatureFlag = (flag: keyof FeatureFlags): boolean => {
+  const context = useContext(FeatureFlagContext)
+  if (!context) {
+    // If no context, assume feature is disabled
+    return false
+  }
+  return context.isFeatureEnabled(flag)
+}
+
+export const useFeatureFlagContext = () => {
+  const context = useContext(FeatureFlagContext)
+  if (!context) {
+    throw new Error(
+      "useFeatureFlagContext must be used within FeatureFlagProvider"
+    )
+  }
+  return context
+}
+
+interface FeatureFlagProviderProps {
+  children: React.ReactNode
+}
+
+export const FeatureFlagProvider: React.FC<FeatureFlagProviderProps> = ({
+  children,
+}) => {
+  const { data: flags = {}, isLoading } = useFeatureFlags()
+
+  const isFeatureEnabled = useCallback(
+    (flag: keyof FeatureFlags): boolean => {
+      return flags[flag] === true
+    },
+    [flags]
+  )
+
+  const value = useMemo(
+    () => ({ flags, isLoading, isFeatureEnabled }),
+    [flags, isLoading, isFeatureEnabled]
+  )
+
+  return (
+    <FeatureFlagContext.Provider value={value}>
+      {children}
+    </FeatureFlagContext.Provider>
+  )
+}

--- a/packages/admin/src/providers/index.ts
+++ b/packages/admin/src/providers/index.ts
@@ -2,3 +2,5 @@ export * from "./theme-provider"
 export * from './sidebar-provider'
 export * from './keybind-provider'
 export * from './search-provider'
+export * from './feature-flag-provider'
+export * from './permissions-provider'

--- a/packages/admin/src/providers/permissions-provider/index.ts
+++ b/packages/admin/src/providers/permissions-provider/index.ts
@@ -1,0 +1,3 @@
+export { PermissionsContext } from "./permissions-context"
+export { PermissionsProvider } from "./permissions-provider"
+export { usePermissions } from "./use-permissions"

--- a/packages/admin/src/providers/permissions-provider/permissions-context.tsx
+++ b/packages/admin/src/providers/permissions-provider/permissions-context.tsx
@@ -1,0 +1,5 @@
+import { createContext } from "react"
+import type { PermissionsContextValue } from "../../lib/permissions"
+
+export const PermissionsContext =
+  createContext<PermissionsContextValue | null>(null)

--- a/packages/admin/src/providers/permissions-provider/permissions-provider.tsx
+++ b/packages/admin/src/providers/permissions-provider/permissions-provider.tsx
@@ -1,0 +1,121 @@
+import { PropsWithChildren, useCallback, useMemo } from "react"
+import {
+  buildPermission,
+  OPERATION_IMPLICATIONS,
+  parsePermission,
+  type Permission,
+  type PermissionOperation,
+  type PermissionResource,
+  type PermissionsContextValue,
+  type UserPolicy,
+} from "../../lib/permissions"
+import { PermissionsContext } from "./permissions-context"
+
+interface PermissionsProviderProps extends PropsWithChildren {
+  /**
+   * The user's policy containing their permissions.
+   */
+  policy: UserPolicy | null
+  /**
+   * Whether the policy is currently being loaded.
+   */
+  isLoading?: boolean
+  /**
+   * Whether the RBAC feature flag is enabled. When `false`, every permission
+   * check resolves to `true`.
+   */
+  isRbacEnabled?: boolean
+}
+
+export const PermissionsProvider = ({
+  policy,
+  isLoading = false,
+  isRbacEnabled = true,
+  children,
+}: PermissionsProviderProps) => {
+  const permissionsMap = useMemo(() => {
+    const index: Record<Permission, true> = Object.create(null)
+
+    for (const granted of policy?.permissions ?? []) {
+      const parsed = parsePermission(granted)
+      if (!parsed) {
+        continue
+      }
+
+      const { resource, operation } = parsed
+      const impliedOperations = OPERATION_IMPLICATIONS[operation] || [operation]
+
+      for (const impliedOperation of impliedOperations) {
+        index[buildPermission(resource, impliedOperation)] = true
+      }
+    }
+
+    return index
+  }, [policy])
+
+  const hasPermission = useCallback(
+    (permission: Permission): boolean => {
+      if (!isRbacEnabled) {
+        return true
+      }
+      return !!permissionsMap[permission]
+    },
+    [isRbacEnabled, permissionsMap]
+  )
+
+  const hasAnyPermission = useCallback(
+    (permissions: Permission[]): boolean => {
+      if (!isRbacEnabled) {
+        return true
+      }
+      if (!permissions?.length) {
+        return false
+      }
+
+      return permissions.some(hasPermission)
+    },
+    [isRbacEnabled, hasPermission]
+  )
+
+  const hasAllPermissions = useCallback(
+    (permissions: Permission[]): boolean => {
+      if (!isRbacEnabled) {
+        return true
+      }
+      if (!permissions?.length) {
+        return false
+      }
+
+      return permissions.every(hasPermission)
+    },
+    [isRbacEnabled, hasPermission]
+  )
+
+  const can = useCallback(
+    (resource: PermissionResource, operation: PermissionOperation): boolean => {
+      if (!isRbacEnabled) {
+        return true
+      }
+      return !!permissionsMap[buildPermission(resource, operation)]
+    },
+    [isRbacEnabled, permissionsMap]
+  )
+
+  const value: PermissionsContextValue = useMemo(
+    () => ({
+      policy,
+      isLoading,
+      hasPermission,
+      hasAnyPermission,
+      hasAllPermissions,
+      can,
+    }),
+    [policy, isLoading, hasPermission, hasAnyPermission, hasAllPermissions, can]
+  )
+
+  return (
+    <PermissionsContext.Provider value={value}>
+      {children}
+    </PermissionsContext.Provider>
+  )
+}

--- a/packages/admin/src/providers/permissions-provider/use-permissions.tsx
+++ b/packages/admin/src/providers/permissions-provider/use-permissions.tsx
@@ -1,0 +1,35 @@
+import { useContext } from "react"
+import { PermissionsContext } from "./permissions-context"
+
+/**
+ * Hook to access permission checking utilities.
+ *
+ * @returns PermissionsContextValue with permission checking methods
+ * @throws Error if used outside of PermissionsProvider
+ *
+ * @example
+ * ```tsx
+ * const { can, hasPermission } = usePermissions()
+ *
+ * // Check using resource and operation
+ * if (can("customer", "create")) {
+ *   // Show create button
+ * }
+ *
+ * // Check using permission string
+ * if (hasPermission("customer:read")) {
+ *   // Show customer list
+ * }
+ * ```
+ */
+export const usePermissions = () => {
+  const context = useContext(PermissionsContext)
+
+  if (!context) {
+    throw new Error(
+      "usePermissions must be used within a PermissionsProvider"
+    )
+  }
+
+  return context
+}


### PR DESCRIPTION
## Problem

`withMercur` enables Medusa's `rbac` feature flag unconditionally, and `checkPermissions` rejects an actor whose role list is empty *before* it evaluates the requested policy. The invite form in `@mercurjs/admin` posted only `email`, so every admin invited through the panel accepted a role-less invite and got `403 {"message":"Forbidden"}` on `/admin/stores`, `/admin/users`, `/admin/notifications` and the rest of the policy-guarded Admin API.

The route was never at fault: `AdminCreateInvite` has always accepted `roles`. This is fork drift. Medusa shipped its RBAC dashboard UI in `@medusajs/dashboard@2.17.0` (`06b05343b4`, "RBAC admin dashboard CRUD") — the same version line we pin for the backend — and `@mercurjs/admin` was forked before that landed. So we turn enforcement on while shipping the pre-RBAC panel, a combination that never exists upstream, where the flag and the UI are gated by the same condition.

## Fix

Ports Medusa's implementation rather than inventing a Mercur-specific one. No API route override.

- `providers/feature-flag-provider` + `hooks/api/feature-flags` — reads `/admin/feature-flags`, mounted in `app.tsx`
- `providers/permissions-provider` + `lib/permissions` — the permission model and `usePermissions`, mounted in `ProtectedRoute` from `/admin/rbac/me/permissions`, same wiring as upstream
- `hooks/api/rbac-roles` — `useRbacAssignableRoles` (`/admin/rbac/roles/assignable`) and `useMePermissions`
- invite form — roles combobox and a Roles column on the pending-invites table, gated on `rbac` + `rbac_role:read`, identical to upstream

Deviations from the upstream source, all mechanical: calls go through `@mercurjs/client` (`sdk.admin.rbac.*`) instead of `sdk.admin.rbacRole.*`, `ClientError` replaces `FetchError`, our `data-testid` convention is kept, and the feature-flag context value is memoized so the repo's `--max-warnings 0` lint stays green.

## Tests

`integration-tests/http/invite/admin/invite.spec.ts`:
- `/admin/feature-flags` reports `rbac: true` — the gate the roles field depends on
- `/admin/rbac/roles/assignable` returns `role_super_admin` for a linked admin
- an invite created with roles links them
- end-to-end invite → register → accept → login → `GET /admin/stores` returns 200

## Known gap, inherited from upstream

Upstream's tooltip claims "If no role is selected, the user will be invited with a superuser role", but no such fallback exists in `createInvitesWorkflow`, `acceptInviteWorkflow`, `createUsersWorkflow` or the route — I checked Medusa `main`. So an operator who leaves the combobox empty still creates a locked-out admin, exactly as on stock Medusa with RBAC on. I kept the string verbatim to keep future re-syncs diffable. If we want that promise to actually hold, it needs a server-side default on invite creation — say the word and I'll add it.

Also still missing, and out of scope here: the `routes/roles/*` screens (role list, role create, assigning a role to an existing user), so repairing an already-locked-out account is still an API operation. Porting those is the natural follow-up.