### PR TITLE
fix(cli): stop plugin:build racing itself for src/admin/index.mjs

### DIFF
--- a/packages/cli/src/commands/plugin-build.ts
+++ b/packages/cli/src/commands/plugin-build.ts
@@ -29,12 +29,16 @@ export const pluginBuild = new Command()
         process.exit(1);
       }
 
-      const bundler = await import("@medusajs/admin-bundler");
       const pluginsDistFolder = path.resolve(cwd, ".medusa/server");
 
+      // Medusa's `buildPluginAdminExtensions` is deliberately not run here: it
+      // writes the same `src/admin/index.{mjs,cjs}` that the admin pass below
+      // does, and concurrently, so the two race for the file. It also builds
+      // from a crawled entry, which discards an authored `src/admin/index.ts`
+      // and drops the Mercur externals — so when it won the race the plugin's
+      // real entry vanished.
       const responses = await Promise.all([
         compiler.buildPluginBackend(tsConfig),
-        compiler.buildPluginAdminExtensions(bundler),
         ...(["admin", "vendor"] as const).map((app) =>
           buildDashboardExtensions({
             root: cwd,


### PR DESCRIPTION
## The race

`plugin:build` ran **two writers for the same file, concurrently in one `Promise.all`**. Both verified in source:

| writer | resolves to |
|---|---|
| Medusa `buildPluginAdminExtensions` | `<root>/.medusa/server/src/admin` — compiler's `#pluginsDistFolder` is `<root>/.medusa/server`, the bundler appends `"src/admin"`, and it's a lib build with `fileName: "index"`, `formats: ["es","cjs"]` |
| Mercur `buildDashboardExtensions` | `<root>/.medusa/server/src/admin/index.mjs` |

Same path, same artifacts, no ordering between them → last writer wins. `emptyOutDir: false` doesn't help; the collision is the file itself.

## Why it was damaging, not just wasteful

The two passes are **not equivalent**. `buildDashboardExtensions`:

- honours an authored `src/admin/index.ts` via `findAuthoredEntry`, so a package can hand-write what it contributes instead of having it derived from its folder tree;
- externalizes the Mercur surface (`@mercurjs/client`, `@mercurjs/dashboard-shared`) plus everything in the package's own manifest.

Medusa's bundler knows about neither and builds from a crawled `__admin-extensions__.js`. So whenever it won the race, a plugin's hand-written entry was **silently replaced** — the empty-panel symptom.

Removing it leaves one writer per path. Nothing is lost: both emit `index.mjs` **and** `index.cjs` into the same directory, so the remaining pass is a strict superset. It also drops a duplicate Vite pass (~0.5s in the fixture).

## Measured before/after

Fixture plugin with an authored `src/admin/index.ts` carrying a marker string, alongside `src/admin/widgets/` and `src/admin/routes/` so Medusa's crawled entry actually produces output. Ten consecutive clean builds (`rm -rf .medusa`) each, checking whether the marker survives into `src/admin/index.mjs`:

```
before   0/10 preserved the authored entry
after   10/10
```

Vendor output and the backend compile are unaffected (`src/vendor/index.{mjs,js}` still emitted, routes bundled).

**On the failure rate:** the fixture loses *every* time rather than intermittently — Medusa's pass consistently finishes last there. The ordering is unspecified, so other environments see it intermittently (a 1-in-3 success rate was observed elsewhere). Either way the file is contended and the outcome isn't guaranteed.

## Verification notes

- Two `tsc` errors in `packages/cli` are pre-existing — identical count with the change stashed (`registry/utils.ts`, `update-files.ts`).
- `bun run lint` passes.
- **Not verified:** behaviour against a real plugin in a browser. The fixture proves which entry lands on disk, not that the resulting panel renders. Worth confirming against an actual plugin before relying on it.

## Follow-up

The conservative alternative — awaiting Medusa's pass *before* the `Promise.all` so Mercur's deterministically overwrites it — was not taken. It keeps a wasted build and leaves Medusa's stale `_chunks/` behind, for no benefit once the remaining pass is a superset.
