### PR TITLE
fix(dashboard-sdk): resolve plugin roots via Node, and stop emitting top-level await

### DIFF
--- a/packages/dashboard-sdk/src/menu-items.ts
+++ b/packages/dashboard-sdk/src/menu-items.ts
@@ -303,9 +303,10 @@ export function generateMenuItems({ srcDir, pluginExtensions }: BuiltMercurConfi
         }
     }
 
-    // Plugin extensions — dynamic import to resolve .default
+    // Plugin extensions. Static rather than `await import(...)`: a top-level
+    // await here would force every consuming app to raise its build target.
     const pluginDeclarations = pluginExtensions.map((ext, i) =>
-        `const __plugin${i} = (await import("${normalizePath(ext)}")).default`
+        `import __plugin${i} from "${normalizePath(ext)}"`
     )
     const pluginSpreads = pluginExtensions.map((_, i) =>
         `        ...(__plugin${i}.menuItemModule?.menuItems ?? [])`

--- a/packages/dashboard-sdk/src/plugin.ts
+++ b/packages/dashboard-sdk/src/plugin.ts
@@ -103,23 +103,45 @@ function resolvePluginRoot(
     configDir: string,
     nodeModulesRoot: string,
 ): string | null {
-    try {
-        if (resolve.startsWith(".")) {
+    if (resolve.startsWith(".")) {
+        try {
             const resolved = path.resolve(configDir, resolve);
-            if (fs.existsSync(resolved)) {
-                return fs.realpathSync(resolved);
+            return fs.existsSync(resolved) ? fs.realpathSync(resolved) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    // Ask Node how it would resolve the specifier rather than guessing a single
+    // directory. `findNodeModulesRoot` returns the *nearest* node_modules, which
+    // in a monorepo is the app's own — holding only that app's dependencies —
+    // while workspace symlinks live at the repo root. Node walks every level.
+    const require = createRequire(path.join(configDir, "noop.js"));
+
+    try {
+        return fs.realpathSync(
+            path.dirname(require.resolve(`${resolve}/package.json`)),
+        );
+    } catch {
+        // `exports` may not expose package.json; fall back to the entry point
+        // and walk up to the directory that owns it.
+    }
+
+    try {
+        let dir = path.dirname(require.resolve(resolve));
+        while (dir !== path.dirname(dir)) {
+            if (fs.existsSync(path.join(dir, "package.json"))) {
+                return fs.realpathSync(dir);
             }
-            return null;
+            dir = path.dirname(dir);
         }
+    } catch {
+        // Not resolvable from the app — fall through to the directory probe.
+    }
 
-        // Check in node_modules, following symlinks for workspace packages
+    try {
         const packagePath = path.join(nodeModulesRoot, resolve);
-        if (!fs.existsSync(packagePath)) {
-            return null;
-        }
-
-        // Follow symlinks (handles workspace/linked packages)
-        return fs.realpathSync(packagePath);
+        return fs.existsSync(packagePath) ? fs.realpathSync(packagePath) : null;
     } catch {
         return null;
     }
@@ -135,7 +157,15 @@ function resolvePluginExtensions(plugins: any[], configDir: string, appType: "ad
         if (!resolve || typeof resolve !== "string") continue;
 
         const pluginRoot = resolvePluginRoot(resolve, configDir, nodeModulesRoot);
-        if (!pluginRoot) continue;
+        if (!pluginRoot) {
+            // Silently skipping leaves the dashboard missing whatever the plugin
+            // contributes, with a build that still looks clean.
+            console.warn(
+                `[@mercurjs/dashboard-sdk] Could not resolve plugin "${resolve}" from ${configDir}. ` +
+                    `Its ${appType} extensions will be missing from the build.`,
+            );
+            continue;
+        }
 
         const extFile = path.join(
             pluginRoot,

--- a/packages/dashboard-sdk/src/routes.ts
+++ b/packages/dashboard-sdk/src/routes.ts
@@ -292,9 +292,10 @@ export function generateRoutes({ srcDir, pluginExtensions }: BuiltMercurConfig):
         }
     }
 
-    // Plugin extensions — dynamic import to resolve .default
+    // Plugin extensions. Static rather than `await import(...)`: a top-level
+    // await here would force every consuming app to raise its build target.
     const pluginDeclarations = pluginExtensions.map((ext, i) =>
-        `const __plugin${i} = (await import("${normalizePath(ext)}")).default`
+        `import __plugin${i} from "${normalizePath(ext)}"`
     )
     const pluginSpreads = pluginExtensions.map((_, i) =>
         `    ...(__plugin${i}.routeModule?.routes ?? [])`

--- a/packages/dashboard-sdk/src/widgets.ts
+++ b/packages/dashboard-sdk/src/widgets.ts
@@ -177,7 +177,7 @@ export function generateWidgets({
 
     const pluginDeclarations = pluginExtensions.map(
         (ext, i) =>
-            `const __plugin${i} = (await import("${normalizePath(ext)}")).default`
+            `import __plugin${i} from "${normalizePath(ext)}"`
     )
     const pluginSpreads = pluginExtensions.map(
         (_, i) => `    ...(__plugin${i}.widgetModule?.widgets ?? [])`


### PR DESCRIPTION
Two stacked bugs that together left a plugin's routes, widgets and menu items missing from a host build — with a build that still reported success.

## Bug 1 — plugins silently dropped

`findNodeModulesRoot` walks up and returns the **nearest** `node_modules`:

```ts
while (dir !== path.dirname(dir)) {
  const candidate = path.join(dir, "node_modules")
  if (fs.existsSync(candidate) ...) return candidate   // first one wins
}
```

In a monorepo that's `apps/<app>/node_modules`, which holds only that app's own dependencies — the workspace symlinks live at the repo root. `resolvePluginRoot` then joined that single directory with the specifier and returned `null`, and `resolvePluginExtensions` did `if (!pluginRoot) continue`. No warning, no failure, plugin gone.

Resolution now goes through `createRequire().resolve`, so every level Node would search is searched — **the same approach `filterResolvableDeps` already used in this file**. `package.json` is tried first, falling back to the entry point and walking up to its owning directory, with the old directory probe kept as a last resort. An unresolvable plugin now warns rather than disappearing.

**Measured** against a fixture with the app's own `node_modules` present and the workspace symlink at the root:

```
nearest node_modules :  apps/app/node_modules
OLD (dir probe)      :  NULL   <- plugin silently dropped
NEW (node resolve)   :  packages/plugin
admin extensions found: YES
```

## Bug 2 — top-level await

The generated `virtual:mercur/{routes,menu-items,widgets}` declared plugin entries as:

```js
const __plugin0 = (await import("...")).default
```

That's a top-level await, which Vite's default browser target rejects — so a host that got past bug 1 hit a build error instead. All three now emit `import __plugin0 from "..."`.

**On the fix chosen:** having the plugin's `config()` hook return `build.target: "esnext"` also works, but the target applies to *everything the host bundles*, not just this module — it silently disables downleveling for the app's own code too. The dynamic import bought nothing here: the paths are known at generation time and already checked with `existsSync`. Removing the TLA at source avoids imposing anything on the host. Happy to switch to the target approach if you'd rather.

## Verification

- Fixture measurement above (old vs new resolution strategy, same layout).
- Generator output confirmed for all three modules: `static-import` present, `top-level-await` absent.
- `bun run build` 12/12; `bun run lint` clean.
- One `tsc` error in `packages/dashboard-sdk` (`@babel/traverse` has no types) is pre-existing — identical count with the change stashed.
- **Not verified:** a real host app build against a real plugin. The fixture proves which path resolution returns and what the generator emits, not that the resulting dashboard renders the routes.

## Note

A third item — the `__require` shim — was mentioned alongside these but is **not** included: `__require` appears nowhere in `packages/dashboard-sdk/src`, so I couldn't identify the intended change. Happy to add it here or in a follow-up once I know what it refers to.
