### PR TITLE
fix(core): actor-scope the pending product-change guard

### DIFF
--- a/integration-tests/http/product-edit/vendor/product-edit.spec.ts
+++ b/integration-tests/http/product-edit/vendor/product-edit.spec.ts
@@ -39,13 +39,13 @@ medusaIntegrationTestRunner({
           name: "Edit Seller",
         })
         sellerHeaders = a.headers
-        sellerId = a.headers.headers["x-seller-id"]
+        sellerId = sellerHeaders.headers["x-seller-id"]
         const b = await createSellerUser(container, {
           email: "other-seller@test.com",
           name: "Other Seller",
         })
         otherSellerHeaders = b.headers
-        otherSellerId = b.headers.headers["x-seller-id"]
+        otherSellerId = otherSellerHeaders.headers["x-seller-id"]
       })
 
       const createVendorProduct = async (

--- a/integration-tests/http/product-edit/vendor/product-edit.spec.ts
+++ b/integration-tests/http/product-edit/vendor/product-edit.spec.ts
@@ -26,6 +26,8 @@ medusaIntegrationTestRunner({
       let container: MedusaContainer
       let sellerHeaders: { headers: Record<string, string> }
       let otherSellerHeaders: { headers: Record<string, string> }
+      let sellerId: string
+      let otherSellerId: string
 
       beforeAll(async () => {
         container = getContainer()
@@ -37,11 +39,13 @@ medusaIntegrationTestRunner({
           name: "Edit Seller",
         })
         sellerHeaders = a.headers
+        sellerId = a.headers.headers["x-seller-id"]
         const b = await createSellerUser(container, {
           email: "other-seller@test.com",
           name: "Other Seller",
         })
         otherSellerHeaders = b.headers
+        otherSellerId = b.headers.headers["x-seller-id"]
       })
 
       const createVendorProduct = async (
@@ -171,7 +175,7 @@ medusaIntegrationTestRunner({
 
         it("rejects a second pending edit while one is already open", async () => {
           const productId = await createVendorProduct("Title")
-          await seedPendingChange(productId, "seller-x", [
+          await seedPendingChange(productId, sellerId, [
             {
               action: ProductChangeActionType.UPDATE,
               details: { field: "title", value: "Pending" },
@@ -190,6 +194,34 @@ medusaIntegrationTestRunner({
           expect(res.data.message).toBe(
             "There is already an active update request for this product. Only one request can be active at a time.",
           )
+        })
+
+        it("allows an edit while another seller holds a pending change on the same product", async () => {
+          const productId = await createVendorProduct("Shared Title")
+          await seedPendingChange(productId, otherSellerId, [
+            {
+              action: ProductChangeActionType.UPDATE,
+              details: { field: "title", value: "Other Seller Pending" },
+            },
+          ])
+
+          const res = await api.post(
+            `/vendor/products/${productId}`,
+            { title: "My Edit" },
+            sellerHeaders,
+          )
+
+          expect(res.status).toBe(202)
+          expect(res.data.product_change.created_by).toBe(sellerId)
+
+          // The other seller's pending change is untouched by this edit.
+          const changes = await listChanges(productId)
+          const otherPending = changes.filter(
+            (c) =>
+              c.status === ProductChangeStatus.PENDING &&
+              c.created_by === otherSellerId,
+          )
+          expect(otherPending).toHaveLength(1)
         })
       })
 
@@ -229,7 +261,6 @@ medusaIntegrationTestRunner({
           // Seed a pending change owned by the *first* seller. The route
           // resolves the change by `(product_id, created_by, status: pending)`,
           // so the seed must carry the seller's id, not a fake one.
-          const sellerId = sellerHeaders.headers["x-seller-id"]
           const changeId = await seedPendingChange(productId, sellerId, [
             {
               action: ProductChangeActionType.UPDATE,
@@ -270,7 +301,6 @@ medusaIntegrationTestRunner({
           expect(res.status).toBe(200)
           expect(res.data.product_change).toBeNull()
 
-          const sellerId = sellerHeaders.headers["x-seller-id"]
           await seedPendingChange(productId, sellerId, [
             {
               action: ProductChangeActionType.UPDATE,
@@ -287,7 +317,6 @@ medusaIntegrationTestRunner({
 
         it("does not leak another seller's pending change", async () => {
           const productId = await createVendorProduct("Owned", sellerHeaders)
-          const otherSellerId = otherSellerHeaders.headers["x-seller-id"]
           await seedPendingChange(productId, otherSellerId, [
             {
               action: ProductChangeActionType.UPDATE,

--- a/packages/core/src/modules/product-edit/migrations/Migration20260828120000.ts
+++ b/packages/core/src/modules/product-edit/migrations/Migration20260828120000.ts
@@ -1,0 +1,17 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations"
+
+export class Migration20260828120000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_product_change_product_id_status"
+        ON "product_change" ("product_id", "status")
+        WHERE "deleted_at" IS NULL;
+    `)
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`
+      DROP INDEX IF EXISTS "IDX_product_change_product_id_status";
+    `)
+  }
+}

--- a/packages/core/src/modules/product-edit/models/product-change.ts
+++ b/packages/core/src/modules/product-edit/models/product-change.ts
@@ -45,6 +45,12 @@ const ProductChange = model
       unique: false,
       where: "deleted_at IS NULL",
     },
+    {
+      name: "IDX_product_change_product_id_status",
+      on: ["product_id", "status"],
+      unique: false,
+      where: "deleted_at IS NULL",
+    },
   ])
 
 export default ProductChange

--- a/packages/core/src/workflows/product-edit/steps/validate-no-pending-product-change.ts
+++ b/packages/core/src/workflows/product-edit/steps/validate-no-pending-product-change.ts
@@ -1,5 +1,6 @@
 import {
   ContainerRegistrationKeys,
+  isDefined,
   MedusaError,
 } from "@medusajs/framework/utils"
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
@@ -10,12 +11,17 @@ export const validateNoPendingProductChangeStepId =
 
 type ValidateNoPendingProductChangeStepInput = {
   product_ids: string[]
+  /**
+   * When set, only changes created by this actor conflict. Omitting it keeps
+   * the product-wide behaviour for external callers.
+   */
+  created_by?: string | null
 }
 
 export const validateNoPendingProductChangeStep = createStep(
   validateNoPendingProductChangeStepId,
   async (
-    { product_ids }: ValidateNoPendingProductChangeStepInput,
+    { product_ids, created_by }: ValidateNoPendingProductChangeStepInput,
     { container },
   ) => {
     if (!product_ids.length) {
@@ -26,24 +32,19 @@ export const validateNoPendingProductChangeStep = createStep(
 
     const { data: changes } = await query.graph({
       entity: "product_change",
-      fields: ["id", "product_id", "status"],
-      filters: {},
+      fields: ["id", "product_id", "created_by"],
+      filters: {
+        product_id: product_ids,
+        status: ProductChangeStatus.PENDING,
+        ...(isDefined(created_by) ? { created_by } : {}),
+      },
     })
 
-    const conflicts = new Set<string>()
-    for (const change of changes as Array<{
-      id: string
-      product_id?: string
-      status?: string
-    }>) {
-      if (
-        change.status === ProductChangeStatus.PENDING &&
-        change.product_id &&
-        product_ids.includes(change.product_id)
-      ) {
-        conflicts.add(change.product_id)
-      }
-    }
+    const conflicts = new Set(
+      (changes as Array<{ product_id?: string }>)
+        .map((change) => change.product_id)
+        .filter(Boolean) as string[],
+    )
 
     if (conflicts.size) {
       throw new MedusaError(

--- a/packages/core/src/workflows/product-edit/workflows/create-product-change.ts
+++ b/packages/core/src/workflows/product-edit/workflows/create-product-change.ts
@@ -43,11 +43,17 @@ export const createProductChangeWorkflow: ReturnWorkflow<
   function (input: CreateProductChangeWorkflowInput) {
     const validate = createHook("validate", { input })
 
-    const productIds = transform({ input }, ({ input }) =>
-      Array.from(new Set(input.changes.map((c) => c.product_id))),
-    )
+    const guardInput = transform({ input }, ({ input }) => {
+      const actors = new Set(input.changes.map((c) => c.created_by))
 
-    validateNoPendingProductChangeStep({ product_ids: productIds })
+      return {
+        product_ids: Array.from(new Set(input.changes.map((c) => c.product_id))),
+        // A batch spanning several actors falls back to product-wide scoping.
+        created_by: actors.size === 1 ? input.changes[0].created_by : undefined,
+      }
+    })
+
+    validateNoPendingProductChangeStep(guardInput)
 
     const changes = createProductChangesStep(input.changes)
 

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-delete-product.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-delete-product.ts
@@ -33,6 +33,7 @@ export const productEditDeleteProductWorkflow: ReturnWorkflow<
     validateNoPendingProductChangeStep(
       transform({ input }, ({ input }) => ({
         product_ids: [input.product_id],
+        created_by: input.created_by,
       })),
     )
 

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-attributes.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-attributes.ts
@@ -37,6 +37,7 @@ export const productEditUpdateAttributesWorkflow: ReturnWorkflow<
     validateNoPendingProductChangeStep(
       transform({ input }, ({ input }) => ({
         product_ids: [input.product_id],
+        created_by: input.created_by,
       })),
     )
 

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-product.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-product.ts
@@ -72,6 +72,7 @@ export const productEditUpdateProductWorkflow: ReturnWorkflow<
     validateNoPendingProductChangeStep(
       transform({ input }, ({ input }) => ({
         product_ids: [input.product_id],
+        created_by: input.created_by,
       })),
     )
 

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-variants.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-variants.ts
@@ -57,6 +57,7 @@ export const productEditUpdateVariantsWorkflow: ReturnWorkflow<
     validateNoPendingProductChangeStep(
       transform({ input }, ({ input }) => ({
         product_ids: [input.product_id],
+        created_by: input.created_by,
       })),
     )
 


### PR DESCRIPTION
## Problem

`product-edit` disagrees with itself about what a pending `ProductChange` belongs to.

| Code | Scope |
| --- | --- |
| `api/vendor/products/[id]/cancel/route.ts` | `{ product_id, created_by, status: PENDING }` |
| `api/vendor/products/[id]/preview/route.ts` | `{ product_id, created_by, status: PENDING }` |
| `workflows/product-edit/steps/validate-no-pending-product-change.ts` | `{ product_id }` only |

Retrieval treats a pending change as belonging to an **actor**. The guard treats it as belonging to a **product**. The guard is stricter than the rest of its own module, and it is the outlier.

Where several sellers contribute data to one product, seller B's edit fails with:

> There is already an active update request for this product. Only one request can be active at a time.

…because seller A has an unrelated pending change on the same product. It is state, not a race: no lock helps, no retry helps, and it persists for as long as the operator takes to decide. The error names a product B may not be able to see, caused by a seller B cannot see.

### Second defect in the same file

```ts
const { data: changes } = await query.graph({
  entity: "product_change",
  fields: ["id", "product_id", "status"],
  filters: {},                                   // ← every ProductChange row ever written
})
```

It then filtered in memory. This ran on **every vendor product edit**, across all five call sites.

## Changes

- `created_by?: string | null` added to the step input; when set, only that actor's pending changes conflict.
- Product, status and actor pushed into the `query.graph` filters; the in-memory filtering loop is gone.
- `created_by` threaded at all five call sites — all of them already carried it in their workflow input. The batch call site (`create-product-change`) scopes only when the batch is unanimous, and falls back to product-wide otherwise.
- Composite index `IDX_product_change_product_id_status` on `ProductChange`, plus its migration.

## Back-compat

- Omitting `created_by` reproduces today's behaviour exactly, so any external caller of the step is unaffected.
- With the five call sites threading it, behaviour changes only where two *different actors* hold pending changes on one product. In a single-seller-per-product catalogue — the default shape — per-actor and per-product scoping are identical, so no existing install changes behaviour.
- It aligns the guard with `cancel` and `preview`, which already assume per-actor semantics.

## Tests

`integration-tests/http/product-edit/vendor/product-edit.spec.ts`:

- **Unchanged:** one seller, second edit while their own change is pending → still `NOT_ALLOWED`. (This test previously seeded `created_by: "seller-x"` — a *different* actor from the caller — so it was passing for the wrong reason. It now seeds the caller's own seller id, which is what it always meant to assert.)
- **New:** two sellers, pending change on one product → the second seller's edit succeeds (202) and the first seller's pending change is untouched.

Verified the new test fails on `main` with exactly the reported error and passes with the fix. Full spec file: 19/19 green. `bun run build` clean.