### PR TITLE
feat(core): diff attribute edits the way product edits are diffed

### DIFF
--- a/integration-tests/http/product-edit/vendor/product-edit-attributes.spec.ts
+++ b/integration-tests/http/product-edit/vendor/product-edit-attributes.spec.ts
@@ -1,0 +1,253 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+  MercurModules,
+  ProductChangeActionType,
+  ProductAttributeValueSnapshot,
+} from "@mercurjs/types"
+
+import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
+
+jest.setTimeout(60_000)
+
+/**
+ * Attribute edits are staged through `productEditUpdateAttributesWorkflow`,
+ * which diffs the proposed batch against the product's current selection the
+ * way `productEditUpdateProductWorkflow` diffs native fields. These cover the
+ * diff itself: recorded `previous_value`, dropped no-ops, and the
+ * `attribute_ids` that `PRODUCT_ADD` records at creation.
+ */
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api }) => {
+    describe("Vendor /vendor/products/:id/attributes/batch — attribute diffing", () => {
+      let container: MedusaContainer
+      let sellerHeaders: { headers: Record<string, string> }
+
+      beforeAll(async () => {
+        container = getContainer()
+      })
+
+      beforeEach(async () => {
+        const seller = await createSellerUser(container, {
+          email: "attr-seller@test.com",
+          name: "Attr Seller",
+        })
+        sellerHeaders = seller.headers
+      })
+
+      const createGlobalAttribute = async (opts: {
+        name: string
+        type: "single_select" | "multi_select"
+        values: string[]
+      }) => {
+        const service: any = container.resolve(MercurModules.PRODUCT_ATTRIBUTE)
+        const [attribute] = await service.createProductAttributes([
+          {
+            name: opts.name,
+            handle: opts.name.toLowerCase(),
+            type: opts.type,
+            is_variant_axis: false,
+          },
+        ])
+        const values = await service.createProductAttributeValues(
+          opts.values.map((name, rank) => ({
+            name,
+            rank,
+            attribute_id: attribute.id,
+          })),
+        )
+        return {
+          id: attribute.id as string,
+          byName: new Map<string, string>(
+            values.map((v: { id: string; name: string }) => [v.name, v.id]),
+          ),
+        }
+      }
+
+      const actionsOf = async (
+        productId: string,
+        body: Record<string, unknown>,
+      ) => {
+        const res = await api.post(
+          `/vendor/products/${productId}/attributes/batch`,
+          body,
+          sellerHeaders,
+        )
+        expect(res.status).toBe(202)
+        return (res.data.product_change.actions ?? []) as Array<{
+          action: string
+          details: {
+            attribute_id?: string | null
+            value?: unknown
+            previous_value?: ProductAttributeValueSnapshot | null
+          }
+        }>
+      }
+
+      const latestProductAdd = async (productId: string) => {
+        const query = container.resolve(ContainerRegistrationKeys.QUERY)
+        const { data } = await query.graph({
+          entity: "product_change",
+          fields: ["id", "actions.action", "actions.details"],
+          filters: { product_id: productId },
+        })
+        const actions = (
+          data as Array<{
+            actions: Array<{ action: string; details: Record<string, unknown> }>
+          }>
+        ).flatMap((change) => change.actions ?? [])
+        return actions.find(
+          (a) => a.action === ProductChangeActionType.PRODUCT_ADD,
+        )
+      }
+
+      it("records previous_value on an attribute update", async () => {
+        const material = await createGlobalAttribute({
+          name: "Material",
+          type: "single_select",
+          values: ["Cotton", "Wool"],
+        })
+        const cotton = material.byName.get("Cotton")!
+        const wool = material.byName.get("Wool")!
+
+        const product = await createVendorProduct(api, sellerHeaders, {
+          title: "Diffed Product",
+          attributes: [{ id: material.id, value_ids: [cotton] }],
+        })
+
+        const actions = await actionsOf(product.id, {
+          update: [{ id: material.id, add: [wool], remove: [cotton] }],
+        })
+
+        const update = actions.find(
+          (a) => a.action === ProductChangeActionType.ATTRIBUTE_UPDATE,
+        )
+        expect(update).toBeDefined()
+        expect(update!.details.attribute_id).toBe(material.id)
+        expect(update!.details.previous_value).toMatchObject({
+          attribute_id: material.id,
+          value_ids: [cotton],
+        })
+      })
+
+      it("produces zero actions for a no-op attribute edit", async () => {
+        const material = await createGlobalAttribute({
+          name: "Material",
+          type: "single_select",
+          values: ["Cotton", "Wool"],
+        })
+        const cotton = material.byName.get("Cotton")!
+
+        const product = await createVendorProduct(api, sellerHeaders, {
+          title: "Unchanged Product",
+          attributes: [{ id: material.id, value_ids: [cotton] }],
+        })
+
+        // Re-adding the value the product already holds, and removing one it
+        // does not, are both no-ops against the current selection.
+        const actions = await actionsOf(product.id, {
+          update: [
+            { id: material.id, add: [cotton], remove: [material.byName.get("Wool")!] },
+          ],
+        })
+
+        expect(actions).toHaveLength(0)
+      })
+
+      it("skips removing an attribute the product does not hold", async () => {
+        const material = await createGlobalAttribute({
+          name: "Material",
+          type: "single_select",
+          values: ["Cotton"],
+        })
+        const product = await createVendorProduct(api, sellerHeaders, {
+          title: "Bare Product",
+        })
+
+        const actions = await actionsOf(product.id, {
+          remove: [material.id],
+        })
+
+        expect(actions).toHaveLength(0)
+      })
+
+      it("records previous_value when removing an attribute the product holds", async () => {
+        const material = await createGlobalAttribute({
+          name: "Material",
+          type: "single_select",
+          values: ["Cotton"],
+        })
+        const cotton = material.byName.get("Cotton")!
+
+        const product = await createVendorProduct(api, sellerHeaders, {
+          title: "Removable Product",
+          attributes: [{ id: material.id, value_ids: [cotton] }],
+        })
+
+        const actions = await actionsOf(product.id, { remove: [material.id] })
+
+        const removal = actions.find(
+          (a) => a.action === ProductChangeActionType.ATTRIBUTE_REMOVE,
+        )
+        expect(removal).toBeDefined()
+        expect(removal!.details.previous_value).toMatchObject({
+          attribute_id: material.id,
+          value_ids: [cotton],
+        })
+      })
+
+      it("carries attribute_id on adds of an existing attribute", async () => {
+        const material = await createGlobalAttribute({
+          name: "Material",
+          type: "single_select",
+          values: ["Cotton"],
+        })
+        const product = await createVendorProduct(api, sellerHeaders, {
+          title: "Adding Product",
+        })
+
+        const actions = await actionsOf(product.id, {
+          add: [{ id: material.id, value_ids: [material.byName.get("Cotton")!] }],
+        })
+
+        const add = actions.find(
+          (a) => a.action === ProductChangeActionType.ATTRIBUTE_ADD,
+        )
+        expect(add).toBeDefined()
+        expect(add!.details.attribute_id).toBe(material.id)
+        expect(add!.details.previous_value).toBeNull()
+      })
+
+      it("records attribute_ids on PRODUCT_ADD at creation", async () => {
+        const material = await createGlobalAttribute({
+          name: "Material",
+          type: "single_select",
+          values: ["Cotton"],
+        })
+
+        const product = await createVendorProduct(api, sellerHeaders, {
+          title: "Created With Attributes",
+          attributes: [
+            { id: material.id, value_ids: [material.byName.get("Cotton")!] },
+          ],
+        })
+
+        const productAdd = await latestProductAdd(product.id)
+        expect(productAdd).toBeDefined()
+        expect(productAdd!.details.attribute_ids).toEqual([material.id])
+      })
+
+      it("records an empty attribute_ids for a product created without attributes", async () => {
+        const product = await createVendorProduct(api, sellerHeaders, {
+          title: "Created Bare",
+        })
+
+        const productAdd = await latestProductAdd(product.id)
+        expect(productAdd).toBeDefined()
+        expect(productAdd!.details.attribute_ids).toEqual([])
+      })
+    })
+  },
+})

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-attributes.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-attributes.ts
@@ -1,14 +1,18 @@
 import { AdditionalData } from "@medusajs/framework/types"
+import { deepEqualObj } from "@medusajs/framework/utils"
 import {
   createWorkflow,
   transform,
   WorkflowResponse,
   type ReturnWorkflow,
 } from "@medusajs/framework/workflows-sdk"
+import { useQueryGraphStep } from "@medusajs/medusa/core-flows"
 import {
+  AttributeType,
   CreateProductChangeActionDTO,
   ProductAttributeBatchAdd,
   ProductAttributeBatchUpdate,
+  ProductAttributeValueSnapshot,
   ProductChangeActionType,
   ProductChangeDTO,
 } from "@mercurjs/types"
@@ -27,6 +31,35 @@ export type ProductEditUpdateAttributesWorkflowInput = {
 export const productEditUpdateAttributesWorkflowId =
   "product-edit-update-attributes"
 
+type LinkedValue = {
+  id: string
+  name?: string
+  attribute?: { id?: string; type?: AttributeType }
+}
+
+const SCALAR_TYPES = [
+  AttributeType.TEXT,
+  AttributeType.UNIT,
+  AttributeType.TOGGLE,
+]
+
+/**
+ * `text` / `unit` / `toggle` selections are stored as a linked value row whose
+ * `name` carries the scalar, so the scalar is read back off the link.
+ */
+const readScalar = (
+  type: AttributeType | undefined,
+  name: string | undefined,
+): string | number | boolean | null => {
+  if (!type || !SCALAR_TYPES.includes(type) || name === undefined) {
+    return null
+  }
+  if (type === AttributeType.TOGGLE) {
+    return name === "true"
+  }
+  return name
+}
+
 export const productEditUpdateAttributesWorkflow: ReturnWorkflow<
   ProductEditUpdateAttributesWorkflowInput,
   ProductChangeDTO,
@@ -40,37 +73,130 @@ export const productEditUpdateAttributesWorkflow: ReturnWorkflow<
       })),
     )
 
-    const actions = transform({ input }, ({ input }) => {
-      const acts: Array<
-        Omit<CreateProductChangeActionDTO, "product_change_id">
-      > = []
+    const { data: currentProducts } = useQueryGraphStep({
+      entity: "product",
+      fields: [
+        "id",
+        "product_attribute_values.id",
+        "product_attribute_values.name",
+        "product_attribute_values.attribute.id",
+        "product_attribute_values.attribute.type",
+      ],
+      filters: transform({ input }, ({ input }) => ({ id: input.product_id })),
+    }).config({ name: "load-current-attributes-for-diff" })
 
-      for (const attribute of input.add ?? []) {
-        acts.push({
-          product_id: input.product_id,
-          action: ProductChangeActionType.ATTRIBUTE_ADD,
-          details: { attribute },
-        })
-      }
+    const actions = transform(
+      { input, currentProducts },
+      ({ input, currentProducts }) => {
+        const linked = (
+          (currentProducts?.[0]?.product_attribute_values ?? []) as LinkedValue[]
+        ).filter((value) => value?.attribute?.id)
 
-      for (const attribute_id of input.remove ?? []) {
-        acts.push({
-          product_id: input.product_id,
-          action: ProductChangeActionType.ATTRIBUTE_REMOVE,
-          details: { attribute_id },
-        })
-      }
+        const snapshots = new Map<string, ProductAttributeValueSnapshot>()
+        for (const value of linked) {
+          const attributeId = value.attribute!.id!
+          const snapshot = snapshots.get(attributeId) ?? {
+            attribute_id: attributeId,
+            value_ids: [],
+            value: null,
+          }
+          snapshot.value_ids.push(value.id)
+          const scalar = readScalar(value.attribute!.type, value.name)
+          if (scalar !== null) {
+            snapshot.value = scalar
+          }
+          snapshots.set(attributeId, snapshot)
+        }
+        for (const snapshot of snapshots.values()) {
+          snapshot.value_ids.sort()
+        }
 
-      for (const update of input.update ?? []) {
-        acts.push({
-          product_id: input.product_id,
-          action: ProductChangeActionType.ATTRIBUTE_UPDATE,
-          details: { update },
-        })
-      }
+        const previousOf = (
+          attributeId: string | null,
+        ): ProductAttributeValueSnapshot | null =>
+          attributeId ? (snapshots.get(attributeId) ?? null) : null
 
-      return acts
-    })
+        const acts: Array<
+          Omit<CreateProductChangeActionDTO, "product_change_id">
+        > = []
+
+        for (const attribute of input.add ?? []) {
+          const attributeId = "id" in attribute ? attribute.id : null
+          const previous = previousOf(attributeId)
+
+          // An add whose selection the product already holds changes nothing.
+          if (previous && "id" in attribute) {
+            const proposedIds = [...(attribute.value_ids ?? [])].sort()
+            const sameIds =
+              proposedIds.length > 0 &&
+              deepEqualObj(proposedIds, previous.value_ids)
+            const sameScalar =
+              attribute.value !== undefined &&
+              deepEqualObj(attribute.value, previous.value)
+            if (sameIds || sameScalar) continue
+          }
+
+          acts.push({
+            product_id: input.product_id,
+            action: ProductChangeActionType.ATTRIBUTE_ADD,
+            details: {
+              attribute,
+              attribute_id: attributeId,
+              previous_value: previous,
+            },
+          })
+        }
+
+        for (const attribute_id of input.remove ?? []) {
+          const previous = previousOf(attribute_id)
+          // Removing something the product does not hold changes nothing.
+          if (!previous) continue
+
+          acts.push({
+            product_id: input.product_id,
+            action: ProductChangeActionType.ATTRIBUTE_REMOVE,
+            details: { attribute_id, previous_value: previous },
+          })
+        }
+
+        for (const update of input.update ?? []) {
+          const previous = previousOf(update.id)
+          const currentIds = new Set(previous?.value_ids ?? [])
+
+          const addsNothing = (update.add ?? []).every(
+            (entry) => typeof entry === "string" && currentIds.has(entry),
+          )
+          const removesNothing = (update.remove ?? []).every(
+            (entry) => !currentIds.has(entry),
+          )
+          const scalarUnchanged =
+            update.value === undefined ||
+            deepEqualObj(update.value, previous?.value ?? null)
+
+          if (
+            addsNothing &&
+            removesNothing &&
+            scalarUnchanged &&
+            update.title === undefined
+          ) {
+            continue
+          }
+
+          acts.push({
+            product_id: input.product_id,
+            action: ProductChangeActionType.ATTRIBUTE_UPDATE,
+            details: {
+              update,
+              attribute_id: update.id,
+              value: update.value,
+              previous_value: previous,
+            },
+          })
+        }
+
+        return acts
+      },
+    )
 
     const change = stageProductChangeWorkflow.runAsStep({
       input: transform({ input, actions }, ({ input, actions }) => ({

--- a/packages/core/src/workflows/product/workflows/create-products.ts
+++ b/packages/core/src/workflows/product/workflows/create-products.ts
@@ -224,22 +224,52 @@ export const createProductsWorkflow: ReturnWorkflow<
       name: "mercur-create-products-associate-sellers",
     })
 
+    // Read the attributes back off the products so PRODUCT_ADD records what
+    // each one started with. Without it, "which attributes did this product
+    // begin with" has no answer: attaching at creation emits no attribute action.
+    const { data: attachedAttributes } = useQueryGraphStep({
+      entity: "product",
+      fields: ["id", "product_attribute_values.attribute.id"],
+      filters: transform({ createdProducts }, ({ createdProducts }) => ({
+        id: createdProducts.map((product) => product.id as string),
+      })),
+    }).config({ name: "mercur-create-products-attached-attributes" })
+
     recordProductAuditChangeWorkflow.runAsStep({
       input: transform(
-        { createdProducts, input },
-        ({ createdProducts, input }) => ({
-          actor_id: input.created_by,
-          changes: createdProducts.map((product) => ({
-            product_id: product.id as string,
-            actions: [
-              {
-                product_id: product.id as string,
-                action: ProductChangeActionType.PRODUCT_ADD,
-                details: { status: product.status as string },
-              },
-            ],
-          })),
-        }),
+        { createdProducts, input, attachedAttributes },
+        ({ createdProducts, input, attachedAttributes }) => {
+          const attributeIdsByProduct = new Map<string, string[]>()
+          for (const product of (attachedAttributes ?? []) as Array<{
+            id: string
+            product_attribute_values?: Array<{ attribute?: { id?: string } }>
+          }>) {
+            const ids = new Set(
+              (product.product_attribute_values ?? [])
+                .map((value) => value.attribute?.id)
+                .filter((id): id is string => !!id),
+            )
+            attributeIdsByProduct.set(product.id, Array.from(ids).sort())
+          }
+
+          return {
+            actor_id: input.created_by,
+            changes: createdProducts.map((product) => ({
+              product_id: product.id as string,
+              actions: [
+                {
+                  product_id: product.id as string,
+                  action: ProductChangeActionType.PRODUCT_ADD,
+                  details: {
+                    status: product.status as string,
+                    attribute_ids:
+                      attributeIdsByProduct.get(product.id as string) ?? [],
+                  },
+                },
+              ],
+            })),
+          }
+        },
       ),
     })
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -58,6 +58,7 @@ export {
   type ProductAttributeBatchAdd,
   type ProductAttributeBatchUpdate,
   type ProductAttributeBatchInput,
+  type ProductAttributeValueSnapshot,
   type CreateProductChangeDTO,
   type CreateProductChangeActionDTO,
 } from "./product"

--- a/packages/types/src/product/mutations.ts
+++ b/packages/types/src/product/mutations.ts
@@ -160,6 +160,22 @@ export type ProductAttributeBatchUpdate = {
 }
 
 /**
+ * One attribute's selection on a product at a point in time. Recorded as
+ * `previous_value` on attribute product-change actions so a timeline of
+ * `add` / `remove` / `value` deltas can be replayed from its starting state.
+ *
+ * `value_ids` is sorted so two snapshots of the same selection compare equal
+ * regardless of link order.
+ */
+export type ProductAttributeValueSnapshot = {
+  attribute_id: string
+  /** Sorted. Every linked value id, whatever the attribute type. */
+  value_ids: string[]
+  /** The scalar for `text` / `unit` / `toggle`; `null` for select types. */
+  value: string | number | boolean | null
+}
+
+/**
  * Input for the attribute batch attach/detach/update engine
  * (`createAndLinkProductAttributesToProductWorkflow`). Applied in the order
  * **remove → add → update** so a same-call remove + re-add of one attribute


### PR DESCRIPTION
Second of the two changes proposed in the master/source-products spec. Independent of #1443 — both branch off `main` and touch different code.

## Problem

`productEditUpdateProductWorkflow` and `productEditUpdateAttributesWorkflow` are siblings that behave differently:

| | loads current state | diffs | records `previous_value` |
| --- | --- | --- | --- |
| `product-edit-update-product.ts` | yes — `useQueryGraphStep` | yes — `normalize` + `deepEqualObj` | yes — `{ field, value, previous_value }` |
| `product-edit-update-attributes.ts` | **no** | **no** | **no** — `{ attribute }` |

The attribute workflow built its actions in a `transform({ input })` from the request payload alone. It never read what the product currently had. The native-field path therefore produced a replayable audit trail and the attribute path produced a write-only log of intents.

Concrete gaps:

1. **No `previous_value`.** `ATTRIBUTE_UPDATE.details.update` is a delta (`{ id, add?, remove?, value? }`). A timeline of deltas cannot be replayed without the starting state, and none was recorded.
2. **No attribute id on adds.** An `ATTRIBUTE_ADD` could not be matched to the attribute it targets.
3. **No record of creation.** Attributes attached during `createProductsWorkflow` produced no attribute action — only `PRODUCT_ADD` with `details: { status }`. So "which attributes did this product start with" was unanswerable.
4. **No-op edits wrote rows.** Resubmitting the same value produced a `ProductChange` and an action, because nothing was diffed.

## Commit 1 — load current attributes and diff

Mirrors what `product-edit-update-product.ts` already does. Emitted `details` become:

```
ATTRIBUTE_ADD    { attribute, attribute_id: string | null, previous_value: null | snapshot }
ATTRIBUTE_UPDATE { update, attribute_id, value, previous_value }
ATTRIBUTE_REMOVE { attribute_id, previous_value }
```

One canonical snapshot type in `@mercurjs/types`, with `value_ids` sorted so two snapshots of the same selection compare equal regardless of link order:

```ts
export type ProductAttributeValueSnapshot = {
  attribute_id: string
  value_ids: string[]
  value: string | number | boolean | null
}
```

No-ops are dropped: an add whose selection the product already holds, a remove of an attribute it does not hold, and an update whose adds are all present / removes all absent / scalar unchanged.

**Purely additive.** Existing keys keep their names, shapes and positions, so `apply-product-change-actions.ts` — which destructures `details.attribute`, `details.attribute_id` and `details.update` — needs no change at all.

## Commit 2 — record which attributes existed at creation

Reads the attached attributes back after the attach step and enriches `PRODUCT_ADD`:

```ts
{ status: product.status, attribute_ids: string[] }
```

One extra query, one extra key, no new rows. Preferred over emitting N synthetic `ATTRIBUTE_ADD` rows at creation, which would overload that action type with a second meaning and risk a future apply path treating creation as an edit.

**No backfill migration.** The consuming fold needs a base case regardless: an attribute with no action history claims at `product.created_at`. Products created before this PR take that path, which is the correct answer for them. Products created after get the enriched `PRODUCT_ADD`. Old and new coexist with no dual-read.

## Deviations from the spec

- The spec's proposed query used `attributes.*`. This codebase's relation is `product_attribute_values` (with `.attribute` nested); `attributes` does not resolve. Fields used here are the ones already proven safe in `productAttributeBatchResponseFields`.
- `text` / `unit` / `toggle` scalars are stored as a linked value row whose `name` carries the scalar, so the snapshot reads the scalar back off the link rather than from a dedicated column.
- **Commit 3 (backfill `attribute_id` for inline adds) is not included.** The spec flags it as the riskiest — it changes a workflow that currently returns `void` — and says it should be split out or dropped. Nothing here depends on it: `attribute_id` is `null` only for the inline arm, and product-scoped attributes are excluded from the merge by definition.

## Tests

New `integration-tests/http/product-edit/vendor/product-edit-attributes.spec.ts` — 7 cases covering `previous_value` on update and remove, `attribute_id` on add, the no-op edit producing zero actions, the skipped remove, and `attribute_ids` on `PRODUCT_ADD` both with and without attributes at creation.

All 7 verified red on `main` and green with the change. `product-edit` + `product-attribute` suites: 51/51 green — including the existing `applyProductAttributeChangeActionsWorkflow` coverage, which is the proof of additivity. `bun run lint` clean, `bun run build` clean.