### PR TITLE
fix(core): scope /vendor/sellers/:id routes to the authenticated seller

### DIFF
--- a/integration-tests/http/seller/vendor/seller.spec.ts
+++ b/integration-tests/http/seller/vendor/seller.spec.ts
@@ -1195,6 +1195,170 @@ medusaIntegrationTestRunner({
           expect(responseB.data.seller_member.is_owner).toBe(false)
         })
       })
+
+      describe("Cross-seller scoping of /vendor/sellers/:id", () => {
+        it("should not retrieve another seller", async () => {
+          const response = await api
+            .get(`/vendor/sellers/${sellerA.id}`, headersB)
+            .catch((e) => e.response)
+
+          expect(response.status).toEqual(404)
+        })
+
+        it("should not update another seller", async () => {
+          const response = await api
+            .post(`/vendor/sellers/${sellerA.id}`, { name: "Taken Over" }, headersB)
+            .catch((e) => e.response)
+
+          expect(response.status).toEqual(404)
+
+          const unchanged = await api.get(
+            `/vendor/sellers/${sellerA.id}`,
+            headersA
+          )
+          expect(unchanged.data.seller.name).toEqual("Alpha Store")
+        })
+
+        it("should not update another seller's address", async () => {
+          const response = await api
+            .post(
+              `/vendor/sellers/${sellerA.id}/address`,
+              {
+                first_name: "Mal",
+                last_name: "Lory",
+                address_1: "1 Evil St",
+                city: "Nowhere",
+                country_code: "us",
+                postal_code: "00000",
+              },
+              headersB
+            )
+            .catch((e) => e.response)
+
+          expect(response.status).toEqual(404)
+        })
+
+        it("should not update another seller's payment details", async () => {
+          const response = await api
+            .post(
+              `/vendor/sellers/${sellerA.id}/payment-details`,
+              { holder_name: "Mal Lory", iban: "DE89370400440532013000" },
+              headersB
+            )
+            .catch((e) => e.response)
+
+          expect(response.status).toEqual(404)
+        })
+
+        it("should not upsert or delete another seller's professional details", async () => {
+          const upsert = await api
+            .post(
+              `/vendor/sellers/${sellerA.id}/professional-details`,
+              { corporate_name: "Mal Corp", tax_id: "TAX666" },
+              headersB
+            )
+            .catch((e) => e.response)
+
+          expect(upsert.status).toEqual(404)
+
+          const remove = await api
+            .delete(
+              `/vendor/sellers/${sellerA.id}/professional-details`,
+              headersB
+            )
+            .catch((e) => e.response)
+
+          expect(remove.status).toEqual(404)
+        })
+
+        it("should not list another seller's members or invites", async () => {
+          const members = await api
+            .get(`/vendor/sellers/${sellerA.id}/members`, headersB)
+            .catch((e) => e.response)
+
+          expect(members.status).toEqual(404)
+
+          const invites = await api
+            .get(`/vendor/sellers/${sellerA.id}/members/invites`, headersB)
+            .catch((e) => e.response)
+
+          expect(invites.status).toEqual(404)
+        })
+
+        it("should not invite a member into another seller", async () => {
+          const response = await api
+            .post(
+              `/vendor/sellers/${sellerA.id}/members`,
+              {
+                email: "intruder@test.com",
+                role_id: SellerRole.SELLER_ADMINISTRATION,
+              },
+              headersB
+            )
+            .catch((e) => e.response)
+
+          expect(response.status).toEqual(404)
+        })
+
+        it("should not change a role of another seller's member", async () => {
+          const membersResponse = await api.get(
+            `/vendor/sellers/${sellerA.id}/members`,
+            headersA
+          )
+          const ownerMember = membersResponse.data.seller_members.find(
+            (sm: any) => sm.is_owner === true
+          )
+
+          const response = await api
+            .post(
+              `/vendor/sellers/${sellerA.id}/members/${ownerMember.id}`,
+              { role_id: SellerRole.ORDER_MANAGEMENT },
+              headersB
+            )
+            .catch((e) => e.response)
+
+          expect(response.status).toEqual(404)
+        })
+
+        it("should not remove another seller's member", async () => {
+          const membersResponse = await api.get(
+            `/vendor/sellers/${sellerA.id}/members`,
+            headersA
+          )
+          const ownerMember = membersResponse.data.seller_members.find(
+            (sm: any) => sm.is_owner === true
+          )
+
+          const response = await api
+            .delete(
+              `/vendor/sellers/${sellerA.id}/members/${ownerMember.id}`,
+              headersB
+            )
+            .catch((e) => e.response)
+
+          expect(response.status).toEqual(404)
+        })
+
+        it("should not manage a member of another seller through its own :id", async () => {
+          const membersResponse = await api.get(
+            `/vendor/sellers/${sellerA.id}/members`,
+            headersA
+          )
+          const ownerMember = membersResponse.data.seller_members.find(
+            (sm: any) => sm.is_owner === true
+          )
+
+          const response = await api
+            .post(
+              `/vendor/sellers/${sellerB.id}/members/${ownerMember.id}`,
+              { role_id: SellerRole.ORDER_MANAGEMENT },
+              headersB
+            )
+            .catch((e) => e.response)
+
+          expect(response.status).toEqual(404)
+        })
+      })
     })
   },
 })

--- a/packages/core/src/api/utils/ensure-seller-scope-middleware.ts
+++ b/packages/core/src/api/utils/ensure-seller-scope-middleware.ts
@@ -1,0 +1,77 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaNextFunction,
+  MedusaResponse,
+} from "@medusajs/framework"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+
+/**
+ * Binds the `:id` path parameter of the `/vendor/sellers/:id` subtree to the
+ * seller the request is authenticated against. Mismatches are reported as
+ * NOT_FOUND so the route cannot be used to probe for existing seller ids.
+ */
+export async function ensureSellerIdParamMiddleware(
+  req: AuthenticatedMedusaRequest,
+  _res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  const sellerId = req.seller_context?.seller_id
+
+  if (!sellerId || req.params.id !== sellerId) {
+    return next(
+      new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Seller with id: ${req.params.id} was not found`
+      )
+    )
+  }
+
+  next()
+}
+
+/**
+ * Binds the `:member_id` path parameter to a member of the authenticated
+ * seller, so member management cannot reach another store's members.
+ */
+export async function ensureSellerMemberParamMiddleware(
+  req: AuthenticatedMedusaRequest,
+  _res: MedusaResponse,
+  next: MedusaNextFunction
+) {
+  const sellerId = req.seller_context?.seller_id
+  const sellerMemberId = req.params.member_id
+
+  if (!sellerId) {
+    return next(
+      new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Seller member with id: ${sellerMemberId} was not found`
+      )
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: sellerMembers } = await query.graph({
+    entity: "seller_member",
+    fields: ["id"],
+    filters: {
+      id: sellerMemberId,
+      seller_id: sellerId,
+    },
+  })
+
+  if (!sellerMembers.length) {
+    return next(
+      new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Seller member with id: ${sellerMemberId} was not found`
+      )
+    )
+  }
+
+  next()
+}

--- a/packages/core/src/api/utils/index.ts
+++ b/packages/core/src/api/utils/index.ts
@@ -1,6 +1,7 @@
 export * from "./unless-base-url"
 export * from "./scan-unauthenticated-routes"
 export * from "./ensure-seller-middleware"
+export * from "./ensure-seller-scope-middleware"
 export * from "./resolve-admin-roles-middleware"
 export * from "./policy-resources"
 export * from "./filter-by-seller-id"

--- a/packages/core/src/api/vendor/sellers/middlewares.ts
+++ b/packages/core/src/api/vendor/sellers/middlewares.ts
@@ -1,5 +1,9 @@
 import { PolicyResource } from "../../utils/policy-resources"
 import {
+  ensureSellerIdParamMiddleware,
+  ensureSellerMemberParamMiddleware,
+} from "../../utils/ensure-seller-scope-middleware"
+import {
   validateAndTransformBody,
   validateAndTransformQuery,
 } from "@medusajs/framework"
@@ -83,6 +87,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["GET"],
     matcher: "/vendor/sellers/:id",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformQuery(
         VendorGetSellerParams,
         QueryConfig.retrieveVendorSellerQueryConfig
@@ -99,6 +104,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/vendor/sellers/:id",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformBody(VendorUpdateSeller),
       validateAndTransformQuery(
         VendorGetSellerParams,
@@ -116,6 +122,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/vendor/sellers/:id/address",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformBody(VendorUpsertSellerAddress),
       validateAndTransformQuery(
         VendorGetSellerParams,
@@ -133,6 +140,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/vendor/sellers/:id/payment-details",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformBody(VendorUpsertSellerPaymentDetails),
       validateAndTransformQuery(
         VendorGetSellerParams,
@@ -150,6 +158,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/vendor/sellers/:id/professional-details",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformBody(VendorUpsertSellerProfessionalDetails),
       validateAndTransformQuery(
         VendorGetSellerParams,
@@ -167,6 +176,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["DELETE"],
     matcher: "/vendor/sellers/:id/professional-details",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformQuery(
         VendorGetSellerParams,
         QueryConfig.retrieveVendorSellerQueryConfig
@@ -183,6 +193,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["GET"],
     matcher: "/vendor/sellers/:id/members/me",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformQuery(
         VendorGetSellerParams,
         QueryConfig.retrieveVendorMemberQueryConfig
@@ -199,6 +210,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["GET"],
     matcher: "/vendor/sellers/:id/members/invites",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformQuery(
         VendorGetSellersParams,
         QueryConfig.listVendorMemberInvitesQueryConfig
@@ -215,6 +227,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["GET"],
     matcher: "/vendor/sellers/:id/members",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformQuery(
         VendorGetSellersParams,
         QueryConfig.listVendorMembersQueryConfig
@@ -235,6 +248,7 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/vendor/sellers/:id/members",
     middlewares: [
+      ensureSellerIdParamMiddleware,
       validateAndTransformBody(VendorInviteMember),
     ],
     policies: [
@@ -248,6 +262,8 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
     method: ["POST"],
     matcher: "/vendor/sellers/:id/members/:member_id",
     middlewares: [
+      ensureSellerIdParamMiddleware,
+      ensureSellerMemberParamMiddleware,
       validateAndTransformBody(VendorUpdateMemberRole),
     ],
     policies: [
@@ -260,7 +276,10 @@ export const vendorSellersMiddlewares: MiddlewareRoute[] = [
   {
     method: ["DELETE"],
     matcher: "/vendor/sellers/:id/members/:member_id",
-    middlewares: [],
+    middlewares: [
+      ensureSellerIdParamMiddleware,
+      ensureSellerMemberParamMiddleware,
+    ],
     policies: [
       {
         resource: Entities.seller_member,


### PR DESCRIPTION
## What

The `/vendor/sellers/:id` route subtree resolved the seller from the URL parameter, while the sibling `/vendor/sellers/me` routes resolve it from `req.seller_context`. This aligns the `:id` subtree with the rest of the vendor API:

- `ensureSellerIdParamMiddleware` — binds `:id` to the seller the request is authenticated against.
- `ensureSellerMemberParamMiddleware` — binds `:member_id` to a member of that seller.

Both are applied to every `/vendor/sellers/:id*` matcher in `packages/core/src/api/vendor/sellers/middlewares.ts`. A parameter that does not resolve within the authenticated seller returns `404`.

## Compatibility

No client change required. Both panels already pass the id of the store they are acting as, which is the same store the `x-seller-id` header / session selects.

## Tests

Adds a `Cross-seller scoping of /vendor/sellers/:id` block to `integration-tests/http/seller/vendor/seller.spec.ts` covering retrieve, update, address, payment details, professional details, member list/invites, member invite, role change, and member removal. Existing suites are unchanged and still pass.
