### PR TITLE
fix(core): require member auth on GET /vendor/stores

### DIFF
--- a/integration-tests/http/store-info/vendor/stores.spec.ts
+++ b/integration-tests/http/store-info/vendor/stores.spec.ts
@@ -1,0 +1,44 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import { createSellerDefaultsWorkflow } from "@mercurjs/core/workflows"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+
+jest.setTimeout(50000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, api }) => {
+    describe("Vendor - Stores", () => {
+      let appContainer: MedusaContainer
+      let headers: any
+
+      beforeAll(async () => {
+        appContainer = getContainer()
+      })
+
+      beforeEach(async () => {
+        await createSellerDefaultsWorkflow(appContainer).run()
+
+        const result = await createSellerUser(appContainer, {
+          email: "seller@test.com",
+          name: "Seller Store",
+        })
+        headers = result.headers
+      })
+
+      it("rejects anonymous requests", async () => {
+        const error = await api
+          .get("/vendor/stores")
+          .catch((e) => e)
+
+        expect(error.response.status).toBe(401)
+      })
+
+      it("returns stores for an authenticated member", async () => {
+        const response = await api.get("/vendor/stores", headers)
+
+        expect(response.status).toBe(200)
+        expect(Array.isArray(response.data.stores)).toBe(true)
+      })
+    })
+  },
+})

--- a/packages/core/src/api/vendor/middlewares.ts
+++ b/packages/core/src/api/vendor/middlewares.ts
@@ -49,10 +49,13 @@ const unauthenticatedRoutes = [
   /^\/vendor\/sellers$/,
   /^\/vendor\/sellers\/select$/,
   /^\/vendor\/feature-flags$/,
-  /^\/vendor\/stores$/,
   /^\/vendor\/members\/invites\/accept$/,
   ...scanUnauthenticatedRoutes(process.cwd()),
 ]
+
+// Marketplace-level routes: authenticated, but reachable before the member
+// belongs to a seller (onboarding).
+const sellerlessRoutes = [...unauthenticatedRoutes, /^\/vendor\/stores$/]
 
 export const vendorMiddlewares: MiddlewareRoute[] = [
   {
@@ -84,7 +87,7 @@ export const vendorMiddlewares: MiddlewareRoute[] = [
         })
       ),
       unlessBaseUrl(
-        unauthenticatedRoutes,
+        sellerlessRoutes,
         ensureSellerMiddleware
       ),
     ],

--- a/packages/core/src/api/vendor/stores/route.ts
+++ b/packages/core/src/api/vendor/stores/route.ts
@@ -2,13 +2,22 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { HttpTypes } from "@medusajs/framework/types"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest<HttpTypes.AdminStoreListParams>,
   res: MedusaResponse<HttpTypes.AdminStoreListResponse>
 ) => {
+  const memberId = req.auth_context?.actor_id
+
+  if (!memberId) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "You must be authenticated to access store information."
+    )
+  }
+
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
   const { data: stores, metadata } = await query.graph({


### PR DESCRIPTION
Closes #1421

`GET /vendor/stores` was listed in the vendor `unauthenticatedRoutes` exemptions, so anonymous callers could list marketplace store information.

## Changes

- `packages/core/src/api/vendor/middlewares.ts` — removed `/^\/vendor\/stores$/` from `unauthenticatedRoutes` so the `authenticate("member")` middleware applies (401 for anonymous callers). Added a separate `sellerlessRoutes` list used only for the `ensureSellerMiddleware` exemption, keeping the route reachable during onboarding before a member belongs to a seller.
- `packages/core/src/api/vendor/stores/route.ts` — defense in depth: handler-level `auth_context.actor_id` check mirroring `GET /vendor/sellers`.
- `integration-tests/http/store-info/vendor/stores.spec.ts` — new spec: anonymous → 401, authenticated member → 200.

## Verification

Build and integration tests were not run locally (this worktree can't resolve `@mercurjs/cli` for the core build); relying on CI.