### PR TITLE
fix(dashboard-shared): enable DataGrid column resizing

### DIFF
--- a/packages/dashboard-shared/src/components/data-grid/components/data-grid-root.tsx
+++ b/packages/dashboard-shared/src/components/data-grid/components/data-grid-root.tsx
@@ -183,6 +183,7 @@ export const DataGridRoot = <
     onColumnVisibilityChange: setColumnVisibility,
     getSubRows,
     getCoreRowModel: getCoreRowModel(),
+    columnResizeMode: "onChange",
     defaultColumn: {
       size: 200,
       maxSize: 400,
@@ -337,6 +338,12 @@ export const DataGridRoot = <
     },
   })
   const virtualColumns = columnVirtualizer.getVirtualItems()
+
+  // The column virtualizer caches sizes from getSize(); re-measure when a resize changes them.
+  const columnSizing = grid.getState().columnSizing
+  useEffect(() => {
+    columnVirtualizer.measure()
+  }, [columnSizing, columnVirtualizer])
 
   let virtualPaddingLeft: number | undefined
   let virtualPaddingRight: number | undefined
@@ -743,6 +750,20 @@ export const DataGridRoot = <
                                 header.column.columnDef.header,
                                 header.getContext()
                               )}
+                          {header.column.getCanResize() && (
+                            <div
+                              onMouseDown={header.getResizeHandler()}
+                              onTouchStart={header.getResizeHandler()}
+                              onClick={(e) => e.stopPropagation()}
+                              className={clx(
+                                "hover:bg-ui-fg-interactive absolute right-0 top-0 z-[2] h-full w-1 cursor-col-resize touch-none select-none",
+                                {
+                                  "bg-ui-fg-interactive":
+                                    header.column.getIsResizing(),
+                                }
+                              )}
+                            />
+                          )}
                         </div>
                       )
 


### PR DESCRIPTION
Closes #1445

## Problem

`DataGrid` exported from `@mercurjs/dashboard-shared` diverged from the identical component shipped inside `@mercurjs/admin` / `@mercurjs/vendor`: the shared copy never enabled TanStack column resizing. Host grids (vendor offer create → Stock Levels & Prices) let you drag header borders; the same import in a custom route did not.

## Fix

Ported the resize wiring from the admin/vendor copies (same approach as medusajs/medusa#15925) into `packages/dashboard-shared/src/components/data-grid/components/data-grid-root.tsx`:

- `columnResizeMode: "onChange"` on `useReactTable`
- header resize handle (`getResizeHandler()`, `cursor-col-resize`, active `bg-ui-fg-interactive`) rendered when `column.getCanResize()`
- re-measure the column virtualizer when `columnSizing` changes, since it caches widths from `getSize()`

The shared file is now identical to the admin/vendor ones apart from one unrelated `headerContent` placement difference, which is left alone.

## Notes

- No new props; `size` / `minSize` / `maxSize` from `createDataGridHelper().column(...)` keep acting as the default and clamps.
- Admin/vendor host grids are untouched, so offer create keeps its current behaviour.

## Verification

- `tsup` build of `@mercurjs/dashboard-shared` succeeds (JS + DTS); `tsc --noEmit` reports no new errors in the touched file.