### PR TITLE
fix(dashboard): let NoRecords empty state grow instead of overflowing

### DIFF
--- a/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/admin/src/components/common/empty-table-content/empty-table-content.tsx
@@ -91,7 +91,7 @@ export const NoRecords = ({
   return (
     <div
       className={clx(
-        "flex h-[150px] w-full flex-col items-center justify-center gap-y-4",
+        "flex min-h-[150px] w-full flex-col items-center justify-center gap-y-4",
         className
       )}
     >

--- a/packages/dashboard-shared/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/dashboard-shared/src/components/common/empty-table-content/empty-table-content.tsx
@@ -85,7 +85,7 @@ export const NoRecords = ({
   return (
     <div
       className={clx(
-        "flex h-[150px] w-full flex-col items-center justify-center gap-y-4",
+        "flex min-h-[150px] w-full flex-col items-center justify-center gap-y-4",
         className
       )}
     >

--- a/packages/vendor/src/components/common/empty-table-content/empty-table-content.tsx
+++ b/packages/vendor/src/components/common/empty-table-content/empty-table-content.tsx
@@ -79,7 +79,7 @@ export const NoRecords = ({
   return (
     <div
       className={clx(
-        "flex h-[150px] w-full flex-col items-center justify-center gap-y-4",
+        "flex min-h-[150px] w-full flex-col items-center justify-center gap-y-4",
         className
       )}
     >


### PR DESCRIPTION
Closes #1395

`NoRecords` renders its box with a fixed `h-[150px]` and no `overflow-hidden` on itself. `_DataTable` only adds `overflow-hidden` when `layout === "fill"`, but the default is `layout = "fit"` — the path every built-in list page uses — and nothing above it in the section/container chain clips overflow either.

When the content (icon + title + message + gaps, plus the action button on the button variant) exceeds 150px — longer message copy, a wrapped line, or the button variant — the excess spills past the box's edges into whatever sits below it in the section.

Change `h-[150px]` → `min-h-[150px]` in all three copies (`dashboard-shared`, `admin`, `vendor`). Same visual target height; the box now grows instead of overflowing.

Not changed: `NoResults` in the same file uses `h-[400px]` — same pattern, but with enough headroom that it isn't spilling in practice. Happy to align it if preferred.