### PR TITLE
feat(create-mercur-app): pin generated projects to the CLI's release channel

### DIFF
--- a/packages/create-mercur-app/src/commands/create.ts
+++ b/packages/create-mercur-app/src/commands/create.ts
@@ -15,7 +15,7 @@ import terminalLink from "terminal-link";
 import validateProjectName from "validate-npm-package-name";
 import waitOn from "wait-on";
 
-// import packageJson from "../../package.json";
+import packageJson from "../../package.json";
 import {
   sendTelemetryEvent,
   setTelemetryEmail,
@@ -30,6 +30,11 @@ import { handleError } from "../utils/handle-error";
 import { highlighter } from "../utils/highlighter";
 import { logger } from "../utils/logger";
 import { manageEnvFiles } from "../utils/manage-env-files";
+import {
+  applyReleaseChannel,
+  detectReleaseChannel,
+  type ReleaseChannel,
+} from "../utils/release-channel";
 import { spinner } from "../utils/spinner";
 
 const DEFAULT_BRANCH = "main";
@@ -68,6 +73,10 @@ export const create = new Command()
   .option("--skip-storefront", "skip adding the Next.js storefront.", false)
   .option("--skip-db", "skip database configuration.", false)
   .option("--skip-email", "skip email prompt.", false)
+  .option(
+    "--tag <tag>",
+    "the release channel to pin @mercurjs/* packages to: latest, rc, or canary. defaults to the channel of this CLI."
+  )
   .option("--db-connection-string <string>", "PostgreSQL connection string.")
   .option("--db-host <host>", "PostgreSQL host.", "localhost")
   .option("--db-port <port>", "PostgreSQL port.", "5432")
@@ -75,6 +84,7 @@ export const create = new Command()
     try {
       const createStart = Date.now();
       validateNodeVersion();
+      const channel = resolveChannel(opts.tag);
       showTelemetryNoticeIfNeeded();
 
       let projectName = name;
@@ -186,6 +196,20 @@ export const create = new Command()
         }
       } finally {
         await fs.remove(tarballPath).catch(() => null);
+      }
+
+      if (channel !== "latest") {
+        const channelSpinner = spinner(
+          `Pinning Mercur packages to the ${channel} release...`
+        ).start();
+        const pinned = await applyReleaseChannel({ projectDir, channel });
+        if (pinned) {
+          channelSpinner.succeed(`Mercur packages pinned to ${pinned}.`);
+        } else {
+          channelSpinner.warn(
+            `No ${channel} release found — keeping the template's pinned versions.`
+          );
+        }
       }
 
       const packageManager = await resolveProjectPackageManager();
@@ -338,6 +362,20 @@ export const create = new Command()
       handleError(error);
     }
   });
+
+function resolveChannel(tag?: string): ReleaseChannel {
+  if (!tag) {
+    return detectReleaseChannel(packageJson.version ?? "");
+  }
+
+  if (tag !== "latest" && tag !== "rc" && tag !== "canary") {
+    throw new Error(
+      `Unknown --tag "${tag}". Expected one of: latest, rc, canary.`
+    );
+  }
+
+  return tag;
+}
 
 async function createOrFindProjectDir(projectDir: string): Promise<void> {
   const pathExists = await fs.pathExists(projectDir);

--- a/packages/create-mercur-app/src/utils/release-channel.ts
+++ b/packages/create-mercur-app/src/utils/release-channel.ts
@@ -1,0 +1,132 @@
+import path from "path";
+
+import fs from "fs-extra";
+
+export type ReleaseChannel = "latest" | "rc" | "canary";
+
+const REGISTRY_URL = "https://registry.npmjs.org";
+
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+export function detectReleaseChannel(cliVersion: string): ReleaseChannel {
+  if (cliVersion.includes("-canary")) {
+    return "canary";
+  }
+
+  if (cliVersion.includes("-rc")) {
+    return "rc";
+  }
+
+  return "latest";
+}
+
+async function resolveDistTag(
+  packageName: string,
+  channel: ReleaseChannel
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${REGISTRY_URL}/-/package/${packageName}/dist-tags`
+    );
+
+    if (!res.ok) {
+      return null;
+    }
+
+    const tags = (await res.json()) as Record<string, string>;
+    return tags[channel] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function collectPackageJsonPaths(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const results: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".")) {
+        continue;
+      }
+      results.push(
+        ...(await collectPackageJsonPaths(path.join(dir, entry.name)))
+      );
+    } else if (entry.name === "package.json") {
+      results.push(path.join(dir, entry.name));
+    }
+  }
+
+  return results;
+}
+
+function isMercurPackage(name: string): boolean {
+  return name.startsWith("@mercurjs/") || name === "mercurjs";
+}
+
+// The templates are the production starting point, so they pin stable
+// `@mercurjs/*` versions. When the user runs a pre-release of this CLI
+// (`create-mercur-app@canary`), those pins are repointed at the matching
+// dist-tag so the generated project matches the CLI that scaffolded it.
+// Returns the version everything was pinned to, or null if that channel has
+// no published release.
+export async function applyReleaseChannel({
+  projectDir,
+  channel,
+}: {
+  projectDir: string;
+  channel: ReleaseChannel;
+}): Promise<string | null> {
+  if (channel === "latest") {
+    return null;
+  }
+
+  const packageJsonPaths = await collectPackageJsonPaths(projectDir);
+  const resolved = new Map<string, string | null>();
+  let pinnedVersion: string | null = null;
+
+  for (const packageJsonPath of packageJsonPaths) {
+    const packageJson = await fs.readJSON(packageJsonPath);
+    let changed = false;
+
+    for (const field of DEPENDENCY_FIELDS) {
+      const deps = packageJson[field] as Record<string, string> | undefined;
+      if (!deps) {
+        continue;
+      }
+
+      for (const name of Object.keys(deps)) {
+        if (!isMercurPackage(name)) {
+          continue;
+        }
+
+        if (!resolved.has(name)) {
+          resolved.set(name, await resolveDistTag(name, channel));
+        }
+
+        const version = resolved.get(name);
+        if (!version) {
+          continue;
+        }
+
+        pinnedVersion ??= version;
+
+        if (deps[name] !== version) {
+          deps[name] = version;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      await fs.writeJSON(packageJsonPath, packageJson, { spaces: 2 });
+    }
+  }
+
+  return pinnedVersion;
+}


### PR DESCRIPTION
## Problem

`templates/basic` is the production starting point, so it pins stable `@mercurjs/*` versions. Running `create-mercur-app@canary` therefore produced a project on stable packages — the canary CLI and the scaffolded project disagreed.

## Solution

The CLI detects its own release channel and repoints the template's `@mercurjs/*` pins at the matching npm dist-tag.

- **Channel detection** — from the CLI's own version: `2.3.2-canary.4` → `canary`, `-rc.` → `rc`, otherwise `latest`. No flag needed for `bunx create-mercur-app@canary`.
- **Template source is unchanged** — still downloaded from `main` on every channel.
- **Version rewrite** — after extraction and before install, every `package.json` in the generated project (root, `packages/api`, `apps/admin`, `apps/vendor`, storefront) has its `@mercurjs/*` / `mercurjs` deps rewritten to that package's real dist-tag version. One registry lookup per package name, cached across files.
- **`latest` short-circuits** — the production path does zero extra work and zero network calls.
- **Graceful fallback** — a package with no release on that tag keeps the template's pin; if nothing resolves, the spinner warns rather than failing the scaffold.
- **`--tag <latest|rc|canary>`** forces a channel regardless of which CLI version is running.

## Verification

- `tsc --noEmit` clean.
- Ran `applyReleaseChannel` against copies of the real `templates/basic` package.json files: `latest` → no-op (`null`), `canary` → all pins moved `2.3.1` → `2.3.2-canary.4` across root, `apps/admin`, and `packages/api`.
- `detectReleaseChannel` returns `canary` / `latest` / `rc` for `2.3.2-canary.4` / `2.3.1` / `2.2.0-rc.3`.