### PR TITLE
fix(core): allow pre-seller members to read vendor stores

### DIFF
--- a/apps/docs/references/api/conventions.mdx
+++ b/apps/docs/references/api/conventions.mdx
@@ -29,7 +29,7 @@ Vendor routes authenticate the **member** actor (`/auth/member/emailpass` to obt
 2. Middleware verifies the authenticated member belongs to that seller and populates the request's seller context. Every query and mutation on the surface is then filtered to that seller automatically.
 3. The member's RBAC roles are resolved for the selected seller.
 
-A handful of vendor routes are public by design: seller registration (`POST /vendor/sellers`), invite acceptance (`POST /vendor/members/invites/accept`), `GET /vendor/stores`, and `GET /vendor/feature-flags`.
+A handful of vendor routes are public by design: seller registration (`POST /vendor/sellers`), invite acceptance (`POST /vendor/members/invites/accept`), and `GET /vendor/feature-flags`. `GET /vendor/stores` requires a session or bearer token, but works before the member belongs to a seller, so the onboarding wizard can reach it.
 
 ### Store
 

--- a/apps/docs/references/api/vendor.mdx
+++ b/apps/docs/references/api/vendor.mdx
@@ -140,7 +140,7 @@ Full RMA suites exist per domain, following the same action pattern Medusa uses 
 | `GET` `POST` | `/vendor/sales-channels[/:id]` | Manage sales channels (+ `/:id/products`) |
 | `GET` | `/vendor/regions[/:id]` | Read regions |
 | `GET` | `/vendor/currencies[/:code]` | Read currencies |
-| `GET` | `/vendor/stores` | List stores (**public**) |
+| `GET` | `/vendor/stores` | List stores (authenticated, no seller required) |
 | `GET` | `/vendor/feature-flags` | Feature flags (**public**) |
 | `POST` | `/vendor/uploads` | Upload files |
 

--- a/integration-tests/http/store-info/vendor/stores.spec.ts
+++ b/integration-tests/http/store-info/vendor/stores.spec.ts
@@ -40,6 +40,22 @@ medusaIntegrationTestRunner({
         expect(Array.isArray(response.data.stores)).toBe(true)
       })
 
+      it("returns stores for a member without a seller", async () => {
+        const registerResponse = await api.post(
+          "/auth/member/emailpass/register",
+          { email: `onboarding-${Date.now()}@test.com`, password: "somepassword" }
+        )
+
+        const response = await api.get("/vendor/stores", {
+          headers: {
+            authorization: `Bearer ${registerResponse.data.token}`,
+          },
+        })
+
+        expect(response.status).toBe(200)
+        expect(Array.isArray(response.data.stores)).toBe(true)
+      })
+
       it("strips disallowed relations from expanded fields", async () => {
         const response = await api.get(
           "/vendor/stores?fields=%2Bmembers.*",

--- a/packages/core/src/api/vendor/middlewares.ts
+++ b/packages/core/src/api/vendor/middlewares.ts
@@ -54,13 +54,23 @@ const unauthenticatedRoutes = [
 ]
 
 // Marketplace-level routes: authenticated, but reachable before the member
-// belongs to a seller (onboarding).
+// belongs to a seller (onboarding). They authenticate through their own
+// matcher with `allowUnregistered: true`, so the catch-all must skip them.
 const sellerlessRoutes = [...unauthenticatedRoutes, /^\/vendor\/stores$/]
 
 export const vendorMiddlewares: MiddlewareRoute[] = [
   {
     matcher: "/vendor/sellers",
     method: ["POST", "GET"],
+    middlewares: [
+      authenticate("member", ["session", "bearer"], {
+        allowUnregistered: true,
+      }),
+    ],
+  },
+  {
+    matcher: "/vendor/stores",
+    method: ["GET"],
     middlewares: [
       authenticate("member", ["session", "bearer"], {
         allowUnregistered: true,
@@ -81,7 +91,7 @@ export const vendorMiddlewares: MiddlewareRoute[] = [
     middlewares: [
       vendorCorsMiddleware,
       unlessBaseUrl(
-        unauthenticatedRoutes,
+        sellerlessRoutes,
         authenticate("member", ["session", "bearer"], {
           allowUnregistered: false,
         })

--- a/packages/core/src/api/vendor/stores/route.ts
+++ b/packages/core/src/api/vendor/stores/route.ts
@@ -2,22 +2,13 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework"
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { HttpTypes } from "@medusajs/framework/types"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest<HttpTypes.AdminStoreListParams>,
   res: MedusaResponse<HttpTypes.AdminStoreListResponse>
 ) => {
-  const memberId = req.auth_context?.actor_id
-
-  if (!memberId) {
-    throw new MedusaError(
-      MedusaError.Types.UNAUTHORIZED,
-      "You must be authenticated to access store information."
-    )
-  }
-
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
   const { data: stores, metadata } = await query.graph({


### PR DESCRIPTION
Fixes #1460

## Problem

Since 2.3.2, `GET /vendor/stores` fell through to the `/vendor/*` catch-all `authenticate("member", …, { allowUnregistered: false })` and the handler additionally threw `UNAUTHORIZED` when `req.auth_context.actor_id` was missing. The vendor onboarding route loader calls that endpoint before any seller exists, so a freshly registered member got a 401 and the client hard-redirected to `/login`. Self-serve registration and "+ Add new store" appeared broken.

## Fix

- Give `GET /vendor/stores` its own matcher with `allowUnregistered: true`, mirroring `GET|POST /vendor/sellers`, and skip it in the catch-all authenticate (it is already in `sellerlessRoutes`).
- Drop the `actor_id` guard in the handler — authentication is enforced by middleware, and unregistered members legitimately have no actor.
- Docs: `GET /vendor/stores` is authenticated (no seller required), not public.

Anonymous requests still 401.

## Tests

Added an integration test asserting a member registered via `/auth/member/emailpass/register` (no seller) gets 200 from `GET /vendor/stores`; existing anonymous-401 test unchanged.