### PR TITLE
fix(core): stop stamping unhandled product-change actions as applied

### DIFF
--- a/integration-tests/http/product-edit/modules/apply-product-change-actions.spec.ts
+++ b/integration-tests/http/product-edit/modules/apply-product-change-actions.spec.ts
@@ -1,0 +1,186 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+  MercurModules,
+  ProductChangeActionType,
+  ProductChangeStatus,
+} from "@mercurjs/types"
+
+import { applyProductChangeActionsWorkflow } from "@mercurjs/core/workflows"
+
+import {
+  adminHeaders,
+  createAdminUser,
+} from "../../../helpers/create-admin-user"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+
+jest.setTimeout(60_000)
+
+medusaIntegrationTestRunner({
+  testSuite: ({ getContainer, dbConnection, api }) => {
+    describe("applyProductChangeActionsWorkflow", () => {
+      let container: MedusaContainer
+      let sellerHeaders: { headers: Record<string, string> }
+
+      beforeAll(async () => {
+        container = getContainer()
+      })
+
+      beforeEach(async () => {
+        await createAdminUser(dbConnection, adminHeaders, container)
+        const seller = await createSellerUser(container, {
+          email: "apply-actions-seller@test.com",
+          name: "Apply Actions Seller",
+        })
+        sellerHeaders = seller.headers
+      })
+
+      type ProductChangeRow = { id: string }
+      type ProductEditService = {
+        createProductChanges(
+          data: Array<Record<string, unknown>>,
+        ): Promise<ProductChangeRow[]>
+        createProductChangeActions(
+          data: Array<Record<string, unknown>>,
+        ): Promise<ProductChangeRow[]>
+      }
+
+      const service = () =>
+        container.resolve<ProductEditService>(MercurModules.PRODUCT_EDIT)
+
+      const stageChange = async (
+        productId: string,
+        actions: Array<Record<string, unknown>>,
+      ) => {
+        const [change] = await service().createProductChanges([
+          { product_id: productId, status: ProductChangeStatus.PENDING },
+        ])
+        const created = await service().createProductChangeActions(
+          actions.map((action) => ({
+            product_id: productId,
+            product_change_id: change.id,
+            applied: false,
+            ...action,
+          })),
+        )
+        return { change, actions: created }
+      }
+
+      const readActions = async (changeId: string) => {
+        const query = container.resolve(ContainerRegistrationKeys.QUERY)
+        const { data } = await query.graph({
+          entity: "product_change_action",
+          fields: ["id", "action", "applied", "reference", "reference_id"],
+          filters: { product_change_id: changeId },
+        })
+        return data as Array<{
+          id: string
+          action: string
+          applied: boolean
+          reference: string | null
+          reference_id: string | null
+        }>
+      }
+
+      const createProduct = async (title: string): Promise<string> => {
+        const res = await api.post("/vendor/products", { title }, sellerHeaders)
+        return res.data.product.id
+      }
+
+      it("applies and stamps a handled action", async () => {
+        const productId = await createProduct("Handled Only")
+        const { change } = await stageChange(productId, [
+          {
+            action: ProductChangeActionType.UPDATE,
+            details: { field: "subtitle", value: "applied subtitle" },
+          },
+        ])
+
+        await applyProductChangeActionsWorkflow(container).run({
+          input: { change_ids: [change.id] },
+        })
+
+        const actions = await readActions(change.id)
+        expect(actions).toHaveLength(1)
+        expect(actions[0].applied).toBe(true)
+
+        const product = await api.get(
+          `/admin/products/${productId}`,
+          adminHeaders,
+        )
+        expect(product.data.product.subtitle).toBe("applied subtitle")
+      })
+
+      it("leaves an action type it does not handle untouched and unstamped", async () => {
+        const productId = await createProduct("Unknown Action")
+        const { change } = await stageChange(productId, [
+          { action: "THIRD_PARTY_ACTION", details: { anything: true } },
+          { action: ProductChangeActionType.CHANGE_REQUESTED, details: {} },
+        ])
+
+        await applyProductChangeActionsWorkflow(container).run({
+          input: { change_ids: [change.id] },
+        })
+
+        const actions = await readActions(change.id)
+        expect(actions).toHaveLength(2)
+        expect(actions.every((a) => a.applied === false)).toBe(true)
+      })
+
+      it("stamps only the handled action when a change mixes handled and unknown types", async () => {
+        const productId = await createProduct("Mixed Actions")
+        const { change } = await stageChange(productId, [
+          {
+            action: ProductChangeActionType.UPDATE,
+            details: { field: "subtitle", value: "mixed subtitle" },
+          },
+          { action: "THIRD_PARTY_ACTION", details: {} },
+        ])
+
+        await applyProductChangeActionsWorkflow(container).run({
+          input: { change_ids: [change.id] },
+        })
+
+        const actions = await readActions(change.id)
+        const applied = actions.filter((a) => a.applied)
+        expect(applied).toHaveLength(1)
+        expect(applied[0].action).toBe(ProductChangeActionType.UPDATE)
+      })
+
+      it("persists reference / reference_id and makes them filterable", async () => {
+        const productId = await createProduct("Referenced Action")
+        const { change } = await stageChange(productId, [
+          {
+            action: ProductChangeActionType.UPDATE,
+            details: { field: "subtitle", value: "referenced" },
+            reference: "product_variant",
+            reference_id: "variant_ref_1",
+          },
+          {
+            action: ProductChangeActionType.UPDATE,
+            details: { field: "handle", value: "referenced-handle" },
+          },
+        ])
+
+        const all = await readActions(change.id)
+        const unreferenced = all.find((a) => a.reference === null)
+        expect(unreferenced).toBeDefined()
+        expect(unreferenced!.reference_id).toBeNull()
+
+        const query = container.resolve(ContainerRegistrationKeys.QUERY)
+        const { data } = await query.graph({
+          entity: "product_change_action",
+          fields: ["id", "reference", "reference_id"],
+          filters: {
+            reference: "product_variant",
+            reference_id: "variant_ref_1",
+          },
+        })
+
+        expect(data).toHaveLength(1)
+        expect(data[0].reference).toBe("product_variant")
+      })
+    })
+  },
+})

--- a/packages/core/src/modules/product-edit/migrations/Migration20260901120000.ts
+++ b/packages/core/src/modules/product-edit/migrations/Migration20260901120000.ts
@@ -1,0 +1,27 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations"
+
+export class Migration20260901120000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`
+      ALTER TABLE "product_change_action"
+        ADD COLUMN IF NOT EXISTS "reference" text NULL,
+        ADD COLUMN IF NOT EXISTS "reference_id" text NULL;
+    `)
+    this.addSql(`
+      CREATE INDEX IF NOT EXISTS "IDX_prodchact_reference_reference_id"
+        ON "product_change_action" ("reference", "reference_id")
+        WHERE "deleted_at" IS NULL;
+    `)
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`
+      DROP INDEX IF EXISTS "IDX_prodchact_reference_reference_id";
+    `)
+    this.addSql(`
+      ALTER TABLE "product_change_action"
+        DROP COLUMN IF EXISTS "reference",
+        DROP COLUMN IF EXISTS "reference_id";
+    `)
+  }
+}

--- a/packages/core/src/modules/product-edit/models/product-change-action.ts
+++ b/packages/core/src/modules/product-edit/models/product-change-action.ts
@@ -9,6 +9,8 @@ const ProductChangeAction = model
     ordering: model.autoincrement(),
     action: model.text(),
     details: model.json().default({}),
+    reference: model.text().nullable(),
+    reference_id: model.text().nullable(),
     internal_note: model.text().nullable(),
     applied: model.boolean().default(false),
     product_change: model
@@ -25,6 +27,12 @@ const ProductChangeAction = model
     {
       name: "IDX_prodchact_product_id",
       on: ["product_id"],
+      unique: false,
+      where: "deleted_at IS NULL",
+    },
+    {
+      name: "IDX_prodchact_reference_reference_id",
+      on: ["reference", "reference_id"],
       unique: false,
       where: "deleted_at IS NULL",
     },

--- a/packages/core/src/workflows/product-edit/workflows/apply-product-change-actions.ts
+++ b/packages/core/src/workflows/product-edit/workflows/apply-product-change-actions.ts
@@ -46,6 +46,18 @@ type BucketedActions = {
   pendingActionIds: string[]
 }
 
+const HANDLED_ACTION_TYPES = new Set<string>([
+  ProductChangeActionType.STATUS_CHANGE,
+  ProductChangeActionType.UPDATE,
+  ProductChangeActionType.VARIANT_ADD,
+  ProductChangeActionType.VARIANT_UPDATE,
+  ProductChangeActionType.VARIANT_REMOVE,
+  ProductChangeActionType.ATTRIBUTE_ADD,
+  ProductChangeActionType.ATTRIBUTE_REMOVE,
+  ProductChangeActionType.ATTRIBUTE_UPDATE,
+  ProductChangeActionType.PRODUCT_DELETE,
+])
+
 export const applyProductChangeActionsWorkflowId =
   "apply-product-change-actions"
 
@@ -91,6 +103,9 @@ export const applyProductChangeActionsWorkflow: ReturnWorkflow<
 
       for (const action of actions ?? []) {
         if (!action || action.applied) continue
+        // Types this workflow cannot act on keep `applied: false` — stamping
+        // them would assert an application that never happened.
+        if (!HANDLED_ACTION_TYPES.has(action.action as string)) continue
         pendingActionIds.push(action.id as string)
 
         const productId = action.product_id as string

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-attributes.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-attributes.ts
@@ -1,10 +1,12 @@
 import { AdditionalData } from "@medusajs/framework/types"
 import { deepEqualObj } from "@medusajs/framework/utils"
 import {
+  createHook,
   createWorkflow,
+  type Hook,
+  type ReturnWorkflow,
   transform,
   WorkflowResponse,
-  type ReturnWorkflow,
 } from "@medusajs/framework/workflows-sdk"
 import { useQueryGraphStep } from "@medusajs/medusa/core-flows"
 import {
@@ -27,6 +29,17 @@ export type ProductEditUpdateAttributesWorkflowInput = {
   remove?: string[]
   update?: ProductAttributeBatchUpdate[]
 } & AdditionalData
+
+export type ProductEditUpdateAttributesWorkflowHooks = [
+  Hook<
+    "productChangeCreated",
+    {
+      product_change: ProductChangeDTO
+      additional_data: Record<string, unknown> | undefined
+    },
+    unknown
+  >,
+]
 
 export const productEditUpdateAttributesWorkflowId =
   "product-edit-update-attributes"
@@ -63,7 +76,7 @@ const readScalar = (
 export const productEditUpdateAttributesWorkflow: ReturnWorkflow<
   ProductEditUpdateAttributesWorkflowInput,
   ProductChangeDTO,
-  []
+  ProductEditUpdateAttributesWorkflowHooks
 > = createWorkflow(
   productEditUpdateAttributesWorkflowId,
   function (input: ProductEditUpdateAttributesWorkflowInput) {
@@ -207,6 +220,13 @@ export const productEditUpdateAttributesWorkflow: ReturnWorkflow<
       })),
     })
 
-    return new WorkflowResponse(change)
+    const productChangeCreated = createHook("productChangeCreated", {
+      product_change: change,
+      additional_data: input.additional_data,
+    })
+
+    return new WorkflowResponse(change, {
+      hooks: [productChangeCreated],
+    })
   },
 )

--- a/packages/types/src/product/common.ts
+++ b/packages/types/src/product/common.ts
@@ -152,6 +152,8 @@ export interface ProductChangeActionDTO {
   ordering: number
   action: string
   details: Record<string, unknown>
+  reference: string | null
+  reference_id: string | null
   internal_note: string | null
   applied: boolean
   product_change?: ProductChangeDTO

--- a/packages/types/src/product/mutations.ts
+++ b/packages/types/src/product/mutations.ts
@@ -231,6 +231,8 @@ export interface CreateProductChangeActionDTO {
   product_id: string
   action: string
   details?: Record<string, unknown>
+  reference?: string | null
+  reference_id?: string | null
   internal_note?: string
   applied?: boolean
 }


### PR DESCRIPTION
Three small, independent changes to `product-edit`. The first is a bug fix; the other two are additive seams that make the module extensible from outside the package. None of them require a consumer to adopt anything.

## 1. `applied: true` was stamped on action types the workflow never handled

`applyProductChangeActionsWorkflow` collects pending action ids **before** it decides whether it can act on them:

```ts
for (const action of actions) {
  if (!action || action.applied) continue
  pendingActionIds.push(action.id)   // unconditional
  switch (action.action) { /* nine cases, no default */ }
}
```

and later stamps every collected id. So an action whose type the switch does not handle mutates nothing and is nevertheless marked applied.

`applied` is named and documented as *this action was carried out*; for anything outside the switch it means *this action was seen*. That is already wrong in core's own data — `CHANGE_REQUESTED` is documented as inert — and it closes off extensibility: `ProductChangeAction.action` is `model.text()`, not an enum column, which reads as an invitation to record domain-specific actions, but a third-party type is swept into `applied: true` by a workflow that never looked at it.

Fix: skip unhandled types before the id is collected. Rows core did not act on keep `applied: false`.

**Back-compat:** behaviour changes only for types the switch does not handle. Every handled type is stamped exactly as before. `PRODUCT_ADD` and `CHANGE_REQUESTED` are written `applied: true` at creation by `recordProductAuditChangeWorkflow`, not by this workflow, so their audit rows are unaffected.

## 2. `reference` / `reference_id` on `ProductChangeAction`

`product-edit` is modelled on Medusa's `order-edit`, but `OrderChangeAction` identifies its target with `reference` + `reference_id` **columns**, while `ProductChangeAction` has only `product_id` plus whatever the writer put in `details`. Core's own actions already need the distinction and encode it three different ways — `UPDATE` means the product, `VARIANT_UPDATE` carries `details.variant_id`, `ATTRIBUTE_UPDATE` carries `details.update.id` — none of them indexable, so "every action against variant X" has to be filtered in memory.

Adds two nullable columns and a composite index mirroring `OrderChangeAction`, plus a migration. Nothing reads them yet and nothing is required to write them; existing rows stay valid and existing writers leave both `null`.

## 3. Hook parity for `productEditUpdateAttributesWorkflow`

`product-edit-update-product.ts` exposes `createHook("productChangeCreated", …)`; its sibling `product-edit-update-attributes.ts` exposes nothing. A consumer that must react to an attribute edit is forced onto a subscriber, which loses atomicity with the staging transaction — the change commits before the consumer sees it, so a consumer failure cannot roll it back. The native-field path has no such gap.

Adds the same hook with the same payload shape. An unregistered hook is a no-op.

## Tests

New `integration-tests/http/product-edit/modules/apply-product-change-actions.spec.ts`:

- a handled action is applied and stamped (product actually mutated)
- an unrecognised type and `CHANGE_REQUESTED` mutate nothing and stay `applied: false`
- a change mixing handled and unknown actions stamps exactly one row
- `reference` / `reference_id` persist, default to `null`, and are filterable through `query.graph`

## Verification

`tsc --noEmit` clean on `packages/core` and `packages/types`; `oxlint` clean on the touched paths. The integration suite runs in CI (it cannot run from this worktree's install layout).