### PR TITLE
fix(client): keep the API error code on ClientError

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -19,11 +19,18 @@ export type InferClientOutput<T> = T extends (...args: any[]) => Promise<infer O
 export class ClientError extends Error {
     status: number | undefined;
     statusText: string | undefined;
+    /**
+     * The API's machine-readable error code (`MedusaError.code`), when the
+     * error body carried one — e.g. `"insufficient_inventory"`. Lets a caller
+     * branch on the reason for a refusal without matching on `message`.
+     */
+    code: string | undefined;
 
-    constructor(message: string, statusText?: string, status?: number) {
+    constructor(message: string, statusText?: string, status?: number, code?: string) {
         super(message);
         this.statusText = statusText;
         this.status = status;
+        this.code = code;
     }
 }
 
@@ -135,11 +142,13 @@ export function createClient(options: ClientOptions) {
             if (response.status >= 300) {
                 const jsonError = (await response.json().catch(() => ({}))) as {
                     message?: string;
+                    code?: string;
                 };
                 throw new ClientError(
                     jsonError.message ?? response.statusText,
                     response.statusText,
-                    response.status
+                    response.status,
+                    typeof jsonError.code === "string" ? jsonError.code : undefined
                 );
             }
 


### PR DESCRIPTION
## Summary

`createClient` reads the API's JSON error body when a response is `>= 300` and throws a
`ClientError` built from `message`, `statusText` and `status`. The body's `code` is read and
dropped.

Medusa's error handler puts three fields on every error response — `type`, `message` and
`code` (`@medusajs/framework`, `http/middlewares/error-handler`) — and `code` is the
machine-readable one: a route throws `new MedusaError(type, message, code)` precisely so a
client can branch on the reason for a refusal. Because the client discards it, a storefront
built on Mercur that needs to react to a specific refusal (a publish limit, a payout account
that is not ready yet, an already-answered request) has to match on the wording of
`message`, which breaks the moment the copy changes.

This keeps `code` on `ClientError`. Nothing else changes: `message`, `statusText` and
`status` are read exactly as before, and `code` is `undefined` when the body has none or is
not JSON.

## Changes

- `ClientError` gains a `code: string | undefined` field and an optional fourth constructor
  argument. Existing callers of the constructor are unaffected.
- The error branch in `createClient` reads `code` from the JSON body alongside `message` and
  passes it through, only when it is a string.

## Testing

- `bun run typecheck` in `packages/client` (the package's own `tsconfig.json`) — clean.
- The package has no test harness, so the change was exercised with a stubbed `fetch`
  against the compiled output, five cases: a Medusa error body with a `code` (the code, status,
  statusText and message all arrive on the thrown `ClientError`); a body without a `code`
  (`code` is `undefined`, message unchanged); a non-JSON error body (message falls back to
  `statusText`, `code` is `undefined`); a non-string `code` (ignored); a 2xx response (still
  resolves the JSON body). Snippet:

  <details>
  <summary>stubbed-fetch check</summary>

  ```js
  const assert = require("node:assert/strict")
  const { createClient, ClientError } = require("./dist/index.mjs") // or the built output

  const respond = (status, statusText, body) => async () =>
    new Response(body === undefined ? "not json" : JSON.stringify(body), {
      status, statusText, headers: { "content-type": "application/json" },
    })
  const client = createClient({ baseUrl: "http://api.test" })
  const capture = async (run) => { try { await run() } catch (e) { return e }; throw new Error("no throw") }

  ;(async () => {
    globalThis.fetch = respond(400, "Bad Request", { type: "not_allowed", message: "Limit reached", code: "LIMIT_REACHED" })
    let error = await capture(() => client.vendor.products.mutate({ title: "x" }))
    assert.ok(error instanceof ClientError)
    assert.equal(error.code, "LIMIT_REACHED")
    assert.equal(error.status, 400)

    globalThis.fetch = respond(404, "Not Found", { type: "not_found", message: "Seller not found" })
    error = await capture(() => client.store.sellers.query({ id: "x" }))
    assert.equal(error.code, undefined)
    assert.equal(error.message, "Seller not found")

    globalThis.fetch = respond(502, "Bad Gateway", undefined)
    error = await capture(() => client.store.sellers.query())
    assert.equal(error.message, "Bad Gateway")
    assert.equal(error.code, undefined)

    globalThis.fetch = respond(400, "Bad Request", { message: "nope", code: 42 })
    error = await capture(() => client.store.sellers.query())
    assert.equal(error.code, undefined)

    globalThis.fetch = respond(200, "OK", { sellers: [] })
    assert.deepEqual(await client.store.sellers.query(), { sellers: [] })
    console.log("5/5 passed")
  })()
  ```

  </details>

## Checklist

- [x] This pull request targets `main` (`CONTRIBUTING.md` names `new`, which no longer exists on the remote).
- [x] I updated documentation, locales if the change requires it. — Not needed: the public type gains one optional field, documented on the class.
- [x] I added or adjusted tests that cover the change. — See Testing: the package has no test harness; the stubbed-fetch check above covers the five cases.

## Linked issues

None found for this in the tracker (searched for `ClientError` and "error code" in issues and pull requests).

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)