### PR TITLE
fix(offer): tolerate dangling price links in updateOffersWorkflow

### DIFF
--- a/integration-tests/http/offer/vendor/update-offers-dangling-price-link.spec.ts
+++ b/integration-tests/http/offer/vendor/update-offers-dangling-price-link.spec.ts
@@ -1,0 +1,214 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { MedusaContainer } from "@medusajs/framework/types"
+import {
+    ContainerRegistrationKeys,
+    Modules,
+} from "@medusajs/framework/utils"
+import {
+    createOffersWorkflow,
+    updateOffersWorkflow,
+} from "@mercurjs/core/workflows"
+import { createSellerUser } from "../../../helpers/create-seller-user"
+import { createVendorProduct } from "../../../helpers/create-product"
+
+jest.setTimeout(120000)
+
+medusaIntegrationTestRunner({
+    testSuite: ({ getContainer, api }) => {
+        describe("updateOffersWorkflow - dangling offer price links", () => {
+            let appContainer: MedusaContainer
+
+            beforeAll(() => {
+                appContainer = getContainer()
+            })
+
+            const seedOffer = async (
+                tag: string,
+                prices: Array<{ amount: number; currency_code: string }>
+            ) => {
+                const { seller, member, headers } = await createSellerUser(
+                    appContainer,
+                    { email: `dangling-${tag}@test.com`, name: `Seller ${tag}` }
+                )
+
+                const stockLocation = (
+                    await api.post(
+                        `/vendor/stock-locations`,
+                        { name: `WH ${tag}` },
+                        headers
+                    )
+                ).data.stock_location
+
+                const shippingProfile = (
+                    await api.post(
+                        `/vendor/shipping-profiles`,
+                        { name: `Profile ${tag}`, type: "default" },
+                        headers
+                    )
+                ).data.shipping_profile
+
+                const product = await createVendorProduct(api, headers, {
+                    title: `Dangling Product ${tag}`,
+                    variants: [{ title: `V ${tag}` }],
+                })
+
+                const { result } = await createOffersWorkflow(
+                    appContainer
+                ).run({
+                    input: {
+                        offers: [
+                            {
+                                seller_id: seller.id,
+                                created_by: member.id,
+                                variant_id: product.variants[0].id,
+                                shipping_profile_id: shippingProfile.id,
+                                sku: `SKU-${tag}`,
+                                inventory_items: [
+                                    {
+                                        sku: `SKU-${tag}`,
+                                        stock_levels: [
+                                            {
+                                                location_id: stockLocation.id,
+                                                stocked_quantity: 100,
+                                            },
+                                        ],
+                                    },
+                                ],
+                                prices,
+                            },
+                        ],
+                    },
+                })
+
+                return result[0]
+            }
+
+            const listPrices = async (offerId: string) => {
+                const query = appContainer.resolve(
+                    ContainerRegistrationKeys.QUERY
+                )
+                const { data } = await query.graph({
+                    entity: "offer",
+                    fields: ["id", "prices.id", "prices.amount"],
+                    filters: { id: offerId },
+                })
+
+                return ((data[0]?.prices ?? []) as Array<{
+                    id: string
+                    amount: number
+                } | null>).filter(
+                    (p): p is { id: string; amount: number } => !!p?.id
+                )
+            }
+
+            // The offer↔price link survives a price row that no longer
+            // resolves, and `query.graph` then yields a null element. The
+            // dangling link must not break the price diff.
+            const danglePrice = async (priceId: string) => {
+                const pricing = appContainer.resolve(Modules.PRICING)
+                await pricing.softDeletePrices([priceId])
+            }
+
+            it("updates an offer that holds one resolvable price and one dangling link", async () => {
+                const tag = `a${Date.now()}`
+                const offer = await seedOffer(tag, [
+                    { amount: 1000, currency_code: "usd" },
+                    { amount: 2000, currency_code: "eur" },
+                ])
+
+                const prices = await listPrices(offer.id)
+                expect(prices).toHaveLength(2)
+
+                const kept = prices.find((p) => p.amount === 1000)!
+                const dangling = prices.find((p) => p.amount === 2000)!
+                await danglePrice(dangling.id)
+
+                await updateOffersWorkflow(appContainer).run({
+                    input: {
+                        offers: [
+                            {
+                                id: offer.id,
+                                prices: [
+                                    {
+                                        id: kept.id,
+                                        amount: 1500,
+                                        currency_code: "usd",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                })
+
+                const after = await listPrices(offer.id)
+                expect(after).toHaveLength(1)
+                expect(after[0]).toEqual(
+                    expect.objectContaining({ id: kept.id, amount: 1500 })
+                )
+            })
+
+            it("accepts a fresh price on an offer whose only price link is dangling", async () => {
+                const tag = `b${Date.now()}`
+                const offer = await seedOffer(tag, [
+                    { amount: 1000, currency_code: "usd" },
+                ])
+
+                const [only] = await listPrices(offer.id)
+                await danglePrice(only.id)
+                expect(await listPrices(offer.id)).toHaveLength(0)
+
+                await updateOffersWorkflow(appContainer).run({
+                    input: {
+                        offers: [
+                            {
+                                id: offer.id,
+                                prices: [
+                                    { amount: 3000, currency_code: "usd" },
+                                ],
+                            },
+                        ],
+                    },
+                })
+
+                const after = await listPrices(offer.id)
+                expect(after).toHaveLength(1)
+                expect(after[0].amount).toEqual(3000)
+            })
+
+            it("still replaces prices for an offer with no dangling links", async () => {
+                const tag = `c${Date.now()}`
+                const offer = await seedOffer(tag, [
+                    { amount: 1000, currency_code: "usd" },
+                    { amount: 2000, currency_code: "eur" },
+                ])
+
+                const prices = await listPrices(offer.id)
+                const kept = prices.find((p) => p.amount === 1000)!
+
+                await updateOffersWorkflow(appContainer).run({
+                    input: {
+                        offers: [
+                            {
+                                id: offer.id,
+                                prices: [
+                                    {
+                                        id: kept.id,
+                                        amount: 1100,
+                                        currency_code: "usd",
+                                    },
+                                    { amount: 900, currency_code: "gbp" },
+                                ],
+                            },
+                        ],
+                    },
+                })
+
+                const after = await listPrices(offer.id)
+                expect(after).toHaveLength(2)
+                expect(
+                    after.map((p) => p.amount).sort((a, b) => a - b)
+                ).toEqual([900, 1100])
+            })
+        })
+    },
+})

--- a/packages/core/src/workflows/offer/workflows/update-offers.ts
+++ b/packages/core/src/workflows/offer/workflows/update-offers.ts
@@ -98,7 +98,7 @@ export const updateOffersWorkflow: ReturnWorkflow<
             product_variant?: {
               price_set?: { id?: string } | null
             } | null
-            prices?: Array<{ id: string }> | null
+            prices?: Array<{ id: string } | null> | null
           }>).map((o) => [o.id, o]),
         )
 
@@ -130,8 +130,13 @@ export const updateOffersWorkflow: ReturnWorkflow<
             )
           }
 
+          // `prices` comes through the offer <-> price link, so a link row
+          // whose price no longer resolves yields a null element. Such a
+          // dangling link takes no part in the diff.
           const ownedIds = new Set(
-            (loaded.prices ?? []).map((p) => p.id),
+            (loaded.prices ?? [])
+              .filter((p): p is { id: string } => !!p?.id)
+              .map((p) => p.id),
           )
           const incomingIds = offer.prices
             .map((p) => p.id)
@@ -210,15 +215,19 @@ export const updateOffersWorkflow: ReturnWorkflow<
       { pricingDiff },
       ({ pricingDiff }) => pricingDiff.toRemoveIds,
     )
-    removeOfferPricesStep(toRemoveIds)
 
     const removedLinks = transform(
       { pricingDiff },
       ({ pricingDiff }) => pricingDiff.removedLinks,
     )
+    // Dismiss the links before deleting the prices: a failure between the two
+    // then leaves an orphaned price rather than a dangling link, which would
+    // make the offer permanently unupdatable.
     dismissRemoteLinkStep(removedLinks).config({
       name: "dismiss-removed-offer-price-links",
     })
+
+    removeOfferPricesStep(toRemoveIds)
 
     const newLinks = transform(
       { pricingDiff, upsertedPriceSets },


### PR DESCRIPTION
## Problem

`updateOffersWorkflow` fails with `TypeError: Cannot read properties of undefined (reading 'id')` for any offer that holds a dangling price link.

An offer's prices come through the `offer_offer_pricing_price` link, so a link row whose `price_id` no longer resolves to a live `price` row yields `prices: [null]`. The existing guard covered a null **array**, not null **elements**:

```ts
const ownedIds = new Set((loaded.prices ?? []).map((p) => p.id))
```

The throw happens inside a `transform`, so the whole run fails. It is not recoverable through the vendor API — every write path that would repair the offer goes through this workflow.

Offers in this state can be found with:

```sql
select o.sku,
       count(l.price_id)               as links,
       count(p.id)                     as resolvable,
       count(l.price_id) - count(p.id) as dangling
from offer o
left join offer_offer_pricing_price l on l.offer_id = o.id and l.deleted_at is null
left join price p on p.id = l.price_id and p.deleted_at is null
where o.deleted_at is null
group by o.sku having count(l.price_id) - count(p.id) > 0;
```

## How the state is reachable

`update-offers.ts` removed prices (`removeOfferPricesStep`) and dismissed their links (`dismissRemoteLinkStep`) as two separate steps, in that order. A run failing between them left the price gone and the link behind; the compensation of `removeOfferPricesStep` is not a link-aware inverse, so it restores neither.

## Changes

- Filter out unresolvable entries before building the owned-price set. A dangling link now takes no part in the diff — neither kept nor removed — and the update succeeds. This also fixes `assertOfferPriceOwnership`, which took `owned_price_ids` from the same set and could reject a legitimate price id when a sibling link dangled.
- Dismiss the links **before** deleting the prices. A torn write then leaves an orphaned price (invisible to the offer) rather than a dangling link (which makes the offer permanently unupdatable).

Repairing existing rows is a data fix, not part of this change:

```sql
delete from offer_offer_pricing_price l
where l.deleted_at is null
  and not exists (
    select 1 from price p where p.id = l.price_id and p.deleted_at is null
  );
```

## Tests

`integration-tests/http/offer/vendor/update-offers-dangling-price-link.spec.ts`:

- an offer with one resolvable price and one dangling link updates successfully
- an offer whose only price link is dangling accepts a fresh price
- behaviour for offers with no dangling links is unchanged

Both dangling cases reproduce the `TypeError` on the unpatched workflow and pass with the fix. The full `http/offer` suite is green (62 passed, 10 skipped).