### PR TITLE
feat(product-edit): expose a validate hook on the vendor edit workflows

### DIFF
--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-attributes.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-attributes.ts
@@ -31,6 +31,7 @@ export type ProductEditUpdateAttributesWorkflowInput = {
 } & AdditionalData
 
 export type ProductEditUpdateAttributesWorkflowHooks = [
+  Hook<"validate", { input: ProductEditUpdateAttributesWorkflowInput }, unknown>,
   Hook<
     "productChangeCreated",
     {
@@ -80,6 +81,8 @@ export const productEditUpdateAttributesWorkflow: ReturnWorkflow<
 > = createWorkflow(
   productEditUpdateAttributesWorkflowId,
   function (input: ProductEditUpdateAttributesWorkflowInput) {
+    const validate = createHook("validate", { input })
+
     validateNoPendingProductChangeStep(
       transform({ input }, ({ input }) => ({
         product_ids: [input.product_id],
@@ -226,7 +229,7 @@ export const productEditUpdateAttributesWorkflow: ReturnWorkflow<
     })
 
     return new WorkflowResponse(change, {
-      hooks: [productChangeCreated],
+      hooks: [validate, productChangeCreated],
     })
   },
 )

--- a/packages/core/src/workflows/product-edit/workflows/product-edit-update-product.ts
+++ b/packages/core/src/workflows/product-edit/workflows/product-edit-update-product.ts
@@ -25,6 +25,7 @@ export type ProductEditUpdateProductWorkflowInput = {
 } & AdditionalData
 
 export type ProductEditUpdateProductWorkflowHooks = [
+  Hook<"validate", { input: ProductEditUpdateProductWorkflowInput }, unknown>,
   Hook<
     "productChangeCreated",
     {
@@ -69,6 +70,8 @@ export const productEditUpdateProductWorkflow: ReturnWorkflow<
 > = createWorkflow(
   productEditUpdateProductWorkflowId,
   function (input: ProductEditUpdateProductWorkflowInput) {
+    const validate = createHook("validate", { input })
+
     validateNoPendingProductChangeStep(
       transform({ input }, ({ input }) => ({
         product_ids: [input.product_id],
@@ -188,7 +191,7 @@ export const productEditUpdateProductWorkflow: ReturnWorkflow<
     })
 
     return new WorkflowResponse(change, {
-      hooks: [productChangeCreated],
+      hooks: [validate, productChangeCreated],
     })
   },
 )


### PR DESCRIPTION
`productEditUpdateProductWorkflow` and `productEditUpdateAttributesWorkflow` export only `productChangeCreated`, which fires after staging. Every other workflow in that folder — cancel, confirm, reject, create-product-change — also exposes `validate`, declared before its guards. These two are the outliers, and the asymmetry leaves a consumer no seam ahead of `validateNoPendingProductChangeStep`.

That matters because a product allows one active request per actor. A request nobody resolves makes the product permanently uneditable for that seller, from every surface, and there is nowhere to intervene: by the time `productChangeCreated` runs, the submission has already been refused.

Adds `validate` to both, declared first, so a consumer can settle the product's edit state while the submission is still rejectable — retiring a stale request of the caller's own, for instance.

No behaviour change for existing callers: an unregistered hook is a no-op, and the guard's own semantics are untouched. The suite's "rejects a second pending edit while one is already open" still passes unchanged.

## Verification

`tsc --noEmit` on `packages/core` is clean. The full `bun run build` and the integration suite were not run locally (worktree deps aren't installed) — relying on CI.