### PR TITLE
fix(dashboard-sdk): stub virtual:medusa/search-entities

### DIFF
--- a/packages/dashboard-sdk/src/plugin.ts
+++ b/packages/dashboard-sdk/src/plugin.ts
@@ -55,6 +55,7 @@ const MEDUSA_VIRTUAL_MODULES = [
     "virtual:medusa/routes",
     "virtual:medusa/widgets",
     "virtual:medusa/links",
+    "virtual:medusa/search-entities",
 ];
 
 function isMedusaVirtualModule(id: string): boolean {


### PR DESCRIPTION
## Problem

Starting a dashboard app against `@medusajs/dashboard` 2.20.x crashes the Vite dev server:

```
✘ [ERROR] Could not resolve "virtual:medusa/search-entities"
    node_modules/@medusajs/dashboard/dist/app.mjs:89:7:
      89 │ import "virtual:medusa/search-entities";
```

`MEDUSA_VIRTUAL_MODULES` in `packages/dashboard-sdk/src/plugin.ts` lists the nine `virtual:medusa/*` modules that existed at Medusa 2.18. Medusa 2.20 added a tenth — `search-entities`, for plugin-contributed command-palette entities — and `app.mjs` imports it as a bare side-effect import. Missing from the allowlist, `resolveId` returns null and esbuild's dependency scan dies at startup.

Absent from published `@mercurjs/dashboard-sdk` through `2.3.4-canary.4`, so there is no version a consumer can upgrade to.

## Fix

One entry added to the allowlist. The existing machinery covers the rest: `resolveId` prefixes with `\0`, `load` returns `export default {}`, and `optimizeDeps.exclude` picks it up via the `...MEDUSA_VIRTUAL_MODULES` spread.

`export default {}` is the correct body, not a placeholder — Medusa's own generator emits exactly that when no source contributes a `search-entities.tsx`. The dashboard's built-in search entities come from `src/lib/search/default-search-entities.ts` inside its bundle, not from this module, so the command palette is unaffected.

## Verification

- Rebuilt the SDK; `grep -roh "virtual:medusa/[a-z-]*" dist/` lists all ten stubs.
- Exercised the built plugin directly: `resolveId("virtual:medusa/search-entities")` → `"\0virtual:medusa/search-entities"`, `load()` on that → `"export default {}"`.
- `packages/admin`, `packages/vendor` and `apps/api` all pin `@medusajs/dashboard": "2.20.1"`, so this is needed on both panels.

**Not verified:** the dev server actually reaching "ready" with the panel rendering and Cmd+K opening. That needs an installed checkout — worth a manual pass before release, since it's the check that proves the crash is gone.

## Note

The allowlist is why this broke: it fails closed on every new Medusa virtual module, with a hard startup crash as the failure mode. A `id.startsWith("virtual:medusa/")` prefix match would be self-maintaining, but it would turn future gaps into silently empty modules discovered at runtime instead of loudly at startup — kept the allowlist deliberately. Longer term, a `peerDependencies` range on `@medusajs/dashboard` would surface the version skew at install time; left out of this PR as a separate distribution-contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)