### PR TITLE
chore: v2.3.4-canary.6

### DIFF
--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/storefront",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
@@ -15,8 +15,8 @@
     "@medusajs/medusa": "2.20.1",
     "@medusajs/types": "2.20.1",
     "@medusajs/ui": "^4.0.33",
-    "@mercurjs/client": "2.3.4-canary.5",
-    "@mercurjs/types": "2.3.4-canary.5",
+    "@mercurjs/client": "2.3.4-canary.6",
+    "@mercurjs/types": "2.3.4-canary.6",
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.1.0",
     "@talkjs/react": "^0.1.11",

--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
     },
     "apps/storefront": {
       "name": "@mercurjs/storefront",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@headlessui/react": "^2.2.1",
         "@hookform/resolvers": "^3.10.0",
@@ -278,7 +278,7 @@
     },
     "packages/admin": {
       "name": "@mercurjs/admin",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
         "@babel/runtime": "^8.0.0",
@@ -342,7 +342,7 @@
     },
     "packages/cli": {
       "name": "@mercurjs/cli",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "bin": {
         "mercurjs": "./dist/index.js",
       },
@@ -378,7 +378,7 @@
     },
     "packages/client": {
       "name": "@mercurjs/client",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@tanstack/react-query": "^5.64.2",
         "qs": "^6.12.1",
@@ -395,7 +395,7 @@
     },
     "packages/core": {
       "name": "@mercurjs/core",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@orama/orama": "^3.1.18",
         "pkg-dir": "4",
@@ -444,7 +444,7 @@
     },
     "packages/create-mercur-app": {
       "name": "create-mercur-app",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "bin": {
         "create-mercur-app": "./dist/index.js",
       },
@@ -476,7 +476,7 @@
     },
     "packages/dashboard-sdk": {
       "name": "@mercurjs/dashboard-sdk",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@babel/parser": "8.0.4",
         "@babel/traverse": "7.25.6",
@@ -493,7 +493,7 @@
     },
     "packages/dashboard-shared": {
       "name": "@mercurjs/dashboard-shared",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
         "@babel/runtime": "^8.0.0",
@@ -553,11 +553,11 @@
     },
     "packages/docs": {
       "name": "@mercurjs/docs",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
     },
     "packages/providers/payout-stripe-connect": {
       "name": "@mercurjs/payout-stripe-connect",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "stripe": "^15.5.0",
       },
@@ -572,7 +572,7 @@
     },
     "packages/registry": {
       "name": "@mercurjs/registry",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@medusajs/core-flows": "2.20.1",
@@ -615,7 +615,7 @@
     },
     "packages/types": {
       "name": "@mercurjs/types",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@medusajs/types": "2.20.1",
       },
@@ -625,7 +625,7 @@
     },
     "packages/vendor": {
       "name": "@mercurjs/vendor",
-      "version": "2.3.4-canary.5",
+      "version": "2.3.4-canary.6",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
         "@babel/runtime": "^8.0.0",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/admin",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",
@@ -34,8 +34,8 @@
     "lint": "oxlint --max-warnings 0"
   },
   "dependencies": {
-    "@mercurjs/dashboard-shared": "2.3.4-canary.5",
-    "@mercurjs/client": "2.3.4-canary.5",
+    "@mercurjs/dashboard-shared": "2.3.4-canary.6",
+    "@mercurjs/client": "2.3.4-canary.6",
     "@ariakit/react": "^0.4.15",
     "@babel/runtime": "^8.0.0",
     "@dnd-kit/core": "^6.1.0",
@@ -88,9 +88,9 @@
     "tsup": "^8.0.2",
     "typescript": "5.9.3",
     "@medusajs/types": "2.20.1",
-    "@mercurjs/core": "2.3.4-canary.5",
-    "@mercurjs/dashboard-sdk": "2.3.4-canary.5",
-    "@mercurjs/types": "2.3.4-canary.5",
+    "@mercurjs/core": "2.3.4-canary.6",
+    "@mercurjs/dashboard-sdk": "2.3.4-canary.6",
+    "@mercurjs/types": "2.3.4-canary.6",
     "react-router-dom": "7.18.1"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/cli",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",
@@ -41,7 +41,7 @@
     "@antfu/ni": "^30.3.0",
     "@medusajs/admin-bundler": "2.20.1",
     "@medusajs/framework": "2.20.1",
-    "@mercurjs/dashboard-sdk": "2.3.4-canary.5",
+    "@mercurjs/dashboard-sdk": "2.3.4-canary.6",
     "@vitejs/plugin-react": "^6.0.3",
     "commander": "^15.0.0",
     "cosmiconfig": "^9.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/client",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/core",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",
@@ -61,7 +61,7 @@
     "@medusajs/medusa": "2.20.1",
     "@medusajs/test-utils": "2.20.1",
     "@medusajs/ui": "4.2.3",
-    "@mercurjs/types": "2.3.4-canary.5",
+    "@mercurjs/types": "2.3.4-canary.6",
     "@swc/core": "^1.7.28",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
@@ -80,7 +80,7 @@
     "multer": "^2.0.2",
     "http-proxy-middleware": "^3.0.3",
     "jsonwebtoken": "^9.0.2",
-    "@mercurjs/cli": "2.3.4-canary.5"
+    "@mercurjs/cli": "2.3.4-canary.6"
   },
   "peerDependencies": {
     "@medusajs/admin-sdk": ">=2.20.1",

--- a/packages/create-mercur-app/package.json
+++ b/packages/create-mercur-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mercur-app",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/dashboard-sdk/package.json
+++ b/packages/dashboard-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/dashboard-sdk",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/dashboard-shared/package.json
+++ b/packages/dashboard-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/dashboard-shared",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",
@@ -23,7 +23,7 @@
     "build": "tsup"
   },
   "dependencies": {
-    "@mercurjs/client": "2.3.4-canary.5",
+    "@mercurjs/client": "2.3.4-canary.6",
     "@ariakit/react": "^0.4.15",
     "@babel/runtime": "^8.0.0",
     "@dnd-kit/core": "^6.1.0",
@@ -63,9 +63,9 @@
   },
   "devDependencies": {
     "@medusajs/types": "2.20.1",
-    "@mercurjs/core": "2.3.4-canary.5",
-    "@mercurjs/dashboard-sdk": "2.3.4-canary.5",
-    "@mercurjs/types": "2.3.4-canary.5",
+    "@mercurjs/core": "2.3.4-canary.6",
+    "@mercurjs/dashboard-sdk": "2.3.4-canary.6",
+    "@mercurjs/types": "2.3.4-canary.6",
     "@types/lodash.debounce": "^4.0.8",
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.2.22",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/docs",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/providers/payout-stripe-connect/package.json
+++ b/packages/providers/payout-stripe-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/payout-stripe-connect",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "description": "Stripe Connect payment provider for Mercur",
   "private": false,
   "type": "module",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@medusajs/framework": "2.20.1",
-    "@mercurjs/types": "2.3.4-canary.5",
+    "@mercurjs/types": "2.3.4-canary.6",
     "tsup": "^8.5.0"
   },
   "dependencies": {

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/registry",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "private": true,
   "type": "module",
   "scripts": {
@@ -12,18 +12,18 @@
   "dependencies": {
     "@medusajs/framework": "2.20.1",
     "@medusajs/medusa": "2.20.1",
-    "@mercurjs/dashboard-shared": "2.3.4-canary.5",
-    "@mercurjs/dashboard-sdk": "2.3.4-canary.5",
+    "@mercurjs/dashboard-shared": "2.3.4-canary.6",
+    "@mercurjs/dashboard-sdk": "2.3.4-canary.6",
     "@medusajs/ui": "4.2.3",
     "@medusajs/icons": "2.20.1",
     "@tanstack/react-query": "5.64.2",
     "react-i18next": "17.0.8",
     "react-router-dom": "7.18.1",
     "@tanstack/react-table": "8.21.3",
-    "@mercurjs/client": "2.3.4-canary.5",
+    "@mercurjs/client": "2.3.4-canary.6",
     "zod": "4.4.3",
-    "@mercurjs/core": "2.3.4-canary.5",
-    "@mercurjs/vendor": "2.3.4-canary.5",
+    "@mercurjs/core": "2.3.4-canary.6",
+    "@mercurjs/vendor": "2.3.4-canary.6",
     "@medusajs/core-flows": "2.20.1",
     "react-hook-form": "7.49.1",
     "@hookform/resolvers": "5.4.0",
@@ -34,8 +34,8 @@
     "@talkjs/react": "^0.1.11"
   },
   "devDependencies": {
-    "@mercurjs/types": "2.3.4-canary.5",
-    "@mercurjs/cli": "2.3.4-canary.5",
+    "@mercurjs/types": "2.3.4-canary.6",
+    "@mercurjs/cli": "2.3.4-canary.6",
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.2.22",
     "@types/node": "^26",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/types",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",

--- a/packages/vendor/package.json
+++ b/packages/vendor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurjs/vendor",
-  "version": "2.3.4-canary.5",
+  "version": "2.3.4-canary.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/mercurjs/mercur",
@@ -37,8 +37,8 @@
     "lint": "oxlint --max-warnings 0"
   },
   "dependencies": {
-    "@mercurjs/dashboard-shared": "2.3.4-canary.5",
-    "@mercurjs/client": "2.3.4-canary.5",
+    "@mercurjs/dashboard-shared": "2.3.4-canary.6",
+    "@mercurjs/client": "2.3.4-canary.6",
     "@ariakit/react": "^0.4.15",
     "@babel/runtime": "^8.0.0",
     "@dnd-kit/core": "^6.1.0",
@@ -91,9 +91,9 @@
     "tsup": "^8.0.2",
     "typescript": "5.9.3",
     "@medusajs/types": "2.20.1",
-    "@mercurjs/core": "2.3.4-canary.5",
-    "@mercurjs/dashboard-sdk": "2.3.4-canary.5",
-    "@mercurjs/types": "2.3.4-canary.5",
+    "@mercurjs/core": "2.3.4-canary.6",
+    "@mercurjs/dashboard-sdk": "2.3.4-canary.6",
+    "@mercurjs/types": "2.3.4-canary.6",
     "react-router-dom": "7.18.1"
   }
 }


### PR DESCRIPTION
Version bump to `2.3.4-canary.6` across all published packages, plus the workspace `bun.lock` and `apps/storefront`.

Ships [#1495](https://github.com/mercurjs/mercur/pull/1495) — the `virtual:medusa/search-entities` stub that unbreaks Vite dev-server startup against `@medusajs/dashboard` 2.20.x. That fix is currently unreleasable: it is absent from every published `@mercurjs/dashboard-sdk` through `2.3.4-canary.4`, so consumers on 2.20 have no version to upgrade to.

Same shape as [#1493](https://github.com/mercurjs/mercur/pull/1493): 14 files, 53 lines, version strings only.

Publishing happens on the `v2.3.4-canary.6` tag (`.github/workflows/release.yml` → npm `canary` tag). Tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)