### PR TITLE
feat: let a plugin set split-order initial status and lock actions on requires_action orders

### DIFF
--- a/integration-tests/http/order/store/split-order-status-hook.spec.ts
+++ b/integration-tests/http/order/store/split-order-status-hook.spec.ts
@@ -1,0 +1,252 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import {
+    IRegionModuleService,
+    ISalesChannelModuleService,
+    MedusaContainer,
+} from "@medusajs/framework/types"
+import {
+    ContainerRegistrationKeys,
+    Modules,
+    OrderStatus,
+} from "@medusajs/framework/utils"
+import { StepResponse } from "@medusajs/framework/workflows-sdk"
+import {
+    completeCartWithSplitOrdersWorkflow,
+    SetOrderStatusHookResult,
+} from "@mercurjs/core/workflows"
+import { createCustomerUser } from "../../../helpers/create-customer-user"
+import {
+    adminHeaders,
+    createAdminUser,
+    generatePublishableKey,
+    generateStoreHeaders,
+} from "../../../helpers/create-admin-user"
+import { seedSellerOfferWithShipping } from "../../../helpers/split-order-checkout"
+
+jest.setTimeout(180000)
+
+// A workflow hook accepts a single handler, so it is registered once and each
+// test swaps the result it hands back.
+let hookResult: ((sellerIds: string[]) => SetOrderStatusHookResult) | null = null
+
+completeCartWithSplitOrdersWorkflow.hooks.setOrderStatus(({ cart }) => {
+    const sellerIds = Array.from(
+        new Set(
+            (cart.items ?? [])
+                .map((item: { offer?: { seller_id?: string } }) => item.offer?.seller_id)
+                .filter((id): id is string => typeof id === "string")
+        )
+    )
+    return new StepResponse(hookResult ? hookResult(sellerIds) : undefined)
+})
+
+medusaIntegrationTestRunner({
+    testSuite: ({ getContainer, api, dbConnection }) => {
+        describe("Store - split order initial status hook", () => {
+            let appContainer: MedusaContainer
+            let storeHeaders: { headers: Record<string, string> }
+            let customerEmail: string
+            let region: { id: string }
+            let salesChannel: { id: string }
+            let sellerA: Awaited<ReturnType<typeof seedSellerOfferWithShipping>>
+            let sellerB: Awaited<ReturnType<typeof seedSellerOfferWithShipping>>
+
+            beforeAll(async () => {
+                appContainer = getContainer()
+            })
+
+            beforeEach(async () => {
+                hookResult = null
+                await createAdminUser(dbConnection, adminHeaders, appContainer)
+
+                const customerResult = await createCustomerUser(appContainer, {
+                    email: "statushookbuyer@test.com",
+                    first_name: "Status",
+                    last_name: "Buyer",
+                })
+                customerEmail = customerResult.customer.email!
+                const apiKey = await generatePublishableKey(appContainer)
+                const baseStoreHeaders = generateStoreHeaders({
+                    publishableKey: apiKey,
+                })
+                storeHeaders = {
+                    headers: {
+                        ...baseStoreHeaders.headers,
+                        ...customerResult.headers.headers,
+                    },
+                }
+
+                salesChannel = await appContainer
+                    .resolve<ISalesChannelModuleService>(Modules.SALES_CHANNEL)
+                    .createSalesChannels({ name: "Status Hook Channel" })
+
+                region = await appContainer
+                    .resolve<IRegionModuleService>(Modules.REGION)
+                    .createRegions({
+                        name: "Status Hook Region",
+                        currency_code: "usd",
+                        countries: ["us"],
+                    })
+
+                await appContainer.resolve(ContainerRegistrationKeys.LINK).create({
+                    [Modules.REGION]: { region_id: region.id },
+                    [Modules.PAYMENT]: { payment_provider_id: "pp_system_default" },
+                })
+
+                sellerA = await seedSellerOfferWithShipping({
+                    container: appContainer,
+                    api,
+                    salesChannelId: salesChannel.id,
+                    email: "status-hook-a@test.com",
+                    name: "StatusHookA",
+                    stocked: 10,
+                    offerPrice: 1000,
+                })
+                sellerB = await seedSellerOfferWithShipping({
+                    container: appContainer,
+                    api,
+                    salesChannelId: salesChannel.id,
+                    email: "status-hook-b@test.com",
+                    name: "StatusHookB",
+                    stocked: 10,
+                    offerPrice: 2000,
+                })
+            })
+
+            const checkout = async (): Promise<Record<string, string>> => {
+                const cart = (
+                    await api.post(
+                        `/store/carts`,
+                        {
+                            region_id: region.id,
+                            sales_channel_id: salesChannel.id,
+                            currency_code: "usd",
+                        },
+                        storeHeaders
+                    )
+                ).data.cart
+
+                for (const offerId of [sellerA.offer.id, sellerB.offer.id]) {
+                    await api.post(
+                        `/store/carts/${cart.id}/line-items`,
+                        { offer_id: offerId, quantity: 1 },
+                        storeHeaders
+                    )
+                }
+
+                const address = {
+                    first_name: "Buyer",
+                    last_name: "Test",
+                    address_1: "123 Main St",
+                    city: "New York",
+                    country_code: "us",
+                    postal_code: "10001",
+                }
+                await api.post(
+                    `/store/carts/${cart.id}`,
+                    {
+                        email: customerEmail,
+                        shipping_address: address,
+                        billing_address: address,
+                    },
+                    storeHeaders
+                )
+
+                const options = Object.values(
+                    (
+                        await api.get(
+                            `/store/shipping-options?cart_id=${cart.id}`,
+                            storeHeaders
+                        )
+                    ).data.shipping_options as Record<string, { id: string }[]>
+                ).flat()
+                for (const option of options) {
+                    await api.post(
+                        `/store/carts/${cart.id}/shipping-methods`,
+                        { option_id: option.id },
+                        storeHeaders
+                    )
+                }
+
+                const paymentCollection = (
+                    await api.post(
+                        `/store/payment-collections`,
+                        { cart_id: cart.id },
+                        storeHeaders
+                    )
+                ).data.payment_collection
+                await api.post(
+                    `/store/payment-collections/${paymentCollection.id}/payment-sessions`,
+                    { provider_id: "pp_system_default" },
+                    storeHeaders
+                )
+
+                const orderGroupId = (
+                    await api.post(`/store/carts/${cart.id}/complete`, {}, storeHeaders)
+                ).data.order_group.id
+
+                const { data } = await appContainer
+                    .resolve(ContainerRegistrationKeys.QUERY)
+                    .graph({
+                        entity: "order_group",
+                        filters: { id: orderGroupId },
+                        fields: ["orders.id"],
+                    })
+                const groupOrderIds = new Set(
+                    (data[0] as { orders: { id: string }[] }).orders.map((o) => o.id)
+                )
+                expect(groupOrderIds.size).toBe(2)
+
+                const statusBySeller: Record<string, string> = {}
+                for (const seller of [sellerA, sellerB]) {
+                    const orders = (
+                        await api.get(`/vendor/orders?fields=id,status`, seller.headers)
+                    ).data.orders as { id: string; status: string }[]
+                    const order = orders.find((o) => groupOrderIds.has(o.id))
+                    statusBySeller[seller.sellerId] = order!.status
+                }
+                return statusBySeller
+            }
+
+            it("keeps every order pending when the handler returns nothing", async () => {
+                const statuses = await checkout()
+
+                expect(statuses).toEqual({
+                    [sellerA.sellerId]: OrderStatus.PENDING,
+                    [sellerB.sellerId]: OrderStatus.PENDING,
+                })
+            })
+
+            it("applies a single status to every order", async () => {
+                hookResult = () => ({ status: OrderStatus.REQUIRES_ACTION })
+
+                const statuses = await checkout()
+
+                expect(statuses).toEqual({
+                    [sellerA.sellerId]: OrderStatus.REQUIRES_ACTION,
+                    [sellerB.sellerId]: OrderStatus.REQUIRES_ACTION,
+                })
+            })
+
+            it("applies a per-seller status and falls back to pending for other sellers", async () => {
+                hookResult = (sellerIds) => {
+                    expect(sellerIds).toEqual(
+                        expect.arrayContaining([sellerA.sellerId, sellerB.sellerId])
+                    )
+                    return {
+                        status_by_seller_id: {
+                            [sellerA.sellerId]: OrderStatus.REQUIRES_ACTION,
+                        },
+                    }
+                }
+
+                const statuses = await checkout()
+
+                expect(statuses).toEqual({
+                    [sellerA.sellerId]: OrderStatus.REQUIRES_ACTION,
+                    [sellerB.sellerId]: OrderStatus.PENDING,
+                })
+            })
+        })
+    },
+})

--- a/packages/admin/src/hooks/table/filters/use-order-table-filters.tsx
+++ b/packages/admin/src/hooks/table/filters/use-order-table-filters.tsx
@@ -17,7 +17,20 @@ export const useOrderTableFilters = (): Filter[] => {
     fields: "id,name",
   })
 
-  let filters: Filter[] = []
+  const statusFilter: Filter = {
+    key: "status",
+    label: t("fields.status"),
+    type: "select",
+    multiple: true,
+    options: [
+      { label: t("orders.status.pending"), value: "pending" },
+      { label: t("orders.status.completed"), value: "completed" },
+      { label: t("orders.status.requires_action"), value: "requires_action" },
+      { label: t("orders.status.canceled"), value: "canceled" },
+    ],
+  }
+
+  let filters: Filter[] = [statusFilter]
 
   if (regions) {
     const regionFilter: Filter = {

--- a/packages/admin/src/i18n/translations/en.json
+++ b/packages/admin/src/i18n/translations/en.json
@@ -1351,6 +1351,9 @@
     }
   },
   "orders": {
+    "requiresAction": {
+      "actionUnavailable": "Not available until this order is accepted"
+    },
     "group": {
       "heading": "Orders in group",
       "noOtherOrders": "No other orders in this group"

--- a/packages/admin/src/pages/orders/order-detail/components/order-payment-section/order-payment-section.tsx
+++ b/packages/admin/src/pages/orders/order-detail/components/order-payment-section/order-payment-section.tsx
@@ -1,6 +1,7 @@
 import { ActionMenu } from "@components/common/action-menu";
 import DisplayId from "@components/common/display-id/display-id";
 import { useCapturePayment } from "@hooks/api";
+import { isOrderActionable } from "@mercurjs/dashboard-shared";
 import { formatCurrency } from "@lib/format-currency";
 import { getLocaleAmount, getStylizedAmount } from "@lib/money-amount-helpers";
 import { getOrderPaymentStatus } from "@lib/order-helpers";
@@ -201,7 +202,9 @@ const Payment = ({
   ];
 
   const showCapture =
-    payment.captured_at === null && payment.canceled_at === null;
+    isOrderActionable(order) &&
+    payment.captured_at === null &&
+    payment.canceled_at === null;
 
   const totalRefunded =
     payment.refunds?.reduce((acc, next) => next.amount + acc, 0) ?? 0;
@@ -272,6 +275,7 @@ const Payment = ({
                   icon: <XCircle />,
                   to: `/orders/${order.id}/refund?paymentId=${payment.id}`,
                   disabled:
+                    !isOrderActionable(order) ||
                     !payment.captured_at ||
                     !!payment.canceled_at ||
                     totalRefunded >= payment.amount,

--- a/packages/admin/src/pages/orders/order-detail/components/order-summary-section/order-summary-section.tsx
+++ b/packages/admin/src/pages/orders/order-detail/components/order-summary-section/order-summary-section.tsx
@@ -36,7 +36,11 @@ import {
 } from "@medusajs/ui";
 
 import type { AdminReservation } from "@medusajs/types";
-import { DisplayExtensionZone } from "@mercurjs/dashboard-shared";
+import {
+  DisplayExtensionZone,
+  isOrderActionable,
+  isOrderAwaitingAction,
+} from "@mercurjs/dashboard-shared";
 import { format } from "date-fns";
 import { ActionMenu } from "../../../../../components/common/action-menu/index.ts";
 import DisplayId from "../../../../../components/common/display-id/display-id.tsx";
@@ -233,8 +237,11 @@ const Header = ({
                 ),
                 to: `/orders/${order.id}/edits`,
                 icon: <PencilSquare />,
+                disabledTooltip: isOrderAwaitingAction(order)
+                  ? t("orders.requiresAction.actionUnavailable")
+                  : undefined,
                 disabled:
-                  order.status === "canceled" ||
+                  !isOrderActionable(order) ||
                   (orderPreview?.order_change &&
                     orderPreview?.order_change?.change_type !== "edit") ||
                   (orderPreview?.order_change?.change_type === "edit" &&
@@ -248,7 +255,11 @@ const Header = ({
                 label: t("orders.returns.create"),
                 to: `/orders/${order.id}/returns`,
                 icon: <ArrowUturnLeft />,
+                disabledTooltip: isOrderAwaitingAction(order)
+                  ? t("orders.requiresAction.actionUnavailable")
+                  : undefined,
                 disabled:
+                  !isOrderActionable(order) ||
                   shouldDisableReturn ||
                   isOrderEditActive ||
                   !!orderPreview?.order_change?.exchange_id ||
@@ -262,7 +273,11 @@ const Header = ({
                     : t("orders.exchanges.create"),
                 to: `/orders/${order.id}/exchanges`,
                 icon: <ArrowPath />,
+                disabledTooltip: isOrderAwaitingAction(order)
+                  ? t("orders.requiresAction.actionUnavailable")
+                  : undefined,
                 disabled:
+                  !isOrderActionable(order) ||
                   shouldDisableReturn ||
                   isOrderEditActive ||
                   (!!orderPreview?.order_change?.return_id &&
@@ -277,7 +292,11 @@ const Header = ({
                     : t("orders.claims.create"),
                 to: `/orders/${order.id}/claims`,
                 icon: <ExclamationCircle />,
+                disabledTooltip: isOrderAwaitingAction(order)
+                  ? t("orders.requiresAction.actionUnavailable")
+                  : undefined,
                 disabled:
+                  !isOrderActionable(order) ||
                   shouldDisableReturn ||
                   isOrderEditActive ||
                   (!!orderPreview?.order_change?.return_id &&

--- a/packages/core/src/workflows/cart/workflows/complete-cart-with-split-orders.ts
+++ b/packages/core/src/workflows/cart/workflows/complete-cart-with-split-orders.ts
@@ -60,6 +60,14 @@ type CompleteCartWithSplitOrdersWorkflowInput = {
     cart_id: string
 }
 
+export type SetOrderStatusHookResult =
+    | {
+          status?: OrderStatus
+          /** Keyed by seller id; takes precedence over `status`. */
+          status_by_seller_id?: Record<string, OrderStatus>
+      }
+    | undefined
+
 export const THREE_DAYS = 3 * 24 * 60 * 60 * 1000
 export const THIRTY_SECONDS = 30 * 1000
 export const TWO_MINUTES = 2 * 60 * 1000
@@ -110,6 +118,15 @@ export const completeCartWithSplitOrdersWorkflow = createWorkflow(
             cart: cartData.data,
         })
 
+        /**
+         * Decides the initial status of the orders this cart splits into, e.g.
+         * `REQUIRES_ACTION` when a seller must accept an order before fulfilment.
+         * Returning nothing keeps `PENDING`.
+         */
+        const setOrderStatus = createHook("setOrderStatus", {
+            cart: cartData.data,
+        })
+
         const createdOrderGroup = when("create-order-group", { orderGroupId }, ({ orderGroupId }) => {
             return !orderGroupId
         }).then(() => {
@@ -144,7 +161,10 @@ export const completeCartWithSplitOrdersWorkflow = createWorkflow(
                 }
             )
 
-            const { ordersToCreate, sellerOrdersMap, offerIdsByOrderId } = transform({ cart: cartData.data, shippingOptionsData: shippingOptionsData.data }, ({ cart, shippingOptionsData }) => {
+            const orderStatusResult = setOrderStatus.getResult()
+
+            const { ordersToCreate, sellerOrdersMap, offerIdsByOrderId } = transform({ cart: cartData.data, shippingOptionsData: shippingOptionsData.data, orderStatusResult }, ({ cart, shippingOptionsData, orderStatusResult }) => {
+                const statusResult = orderStatusResult as SetOrderStatusHookResult
                 const cartSellerIds = new Set<string>(
                     (cart.items ?? [])
                         .map((item: any) => item.offer?.seller_id)
@@ -255,12 +275,17 @@ export const completeCartWithSplitOrdersWorkflow = createWorkflow(
                     }
 
                     const orderId = generateEntityId(undefined, 'order')
+                    const status =
+                        statusResult?.status_by_seller_id?.[sellerId] ??
+                        statusResult?.status ??
+                        OrderStatus.PENDING
+
                     ordersToCreate.push({
                         id: orderId,
                         region_id: cart.region?.id,
                         customer_id: cart.customer?.id,
                         sales_channel_id: cart.sales_channel_id,
-                        status: OrderStatus.PENDING,
+                        status,
                         email: cart.email,
                         currency_code: cart.currency_code,
                         locale: cart.locale,
@@ -625,7 +650,7 @@ export const completeCartWithSplitOrdersWorkflow = createWorkflow(
         })
 
         return new WorkflowResponse(result, {
-            hooks: [validate],
+            hooks: [validate, setOrderStatus],
         })
     }
 )

--- a/packages/dashboard-shared/src/index.ts
+++ b/packages/dashboard-shared/src/index.ts
@@ -22,6 +22,7 @@ export {
   type VariantGroup,
 } from "./lib/product-change-diff"
 export * from "./lib/addresses"
+export * from "./lib/order-status"
 export * from "./lib/data/countries"
 export * from "./lib/data/currencies"
 export * from "./lib/money-amount-helpers"

--- a/packages/dashboard-shared/src/lib/order-status.ts
+++ b/packages/dashboard-shared/src/lib/order-status.ts
@@ -1,0 +1,13 @@
+import type { AdminOrder } from "@medusajs/types"
+
+/**
+ * An order in `requires_action` is awaiting a decision (e.g. a seller accepting it), so
+ * fulfilment, edits, returns, claims, exchanges and payment actions stay unavailable until it
+ * leaves that status, the same way they are on a canceled order.
+ */
+export const isOrderActionable = (order: Pick<AdminOrder, "status">): boolean =>
+  order.status !== "canceled" && order.status !== "requires_action"
+
+export const isOrderAwaitingAction = (
+  order: Pick<AdminOrder, "status">
+): boolean => order.status === "requires_action"

--- a/packages/vendor/src/hooks/table/filters/use-order-table-filters.tsx
+++ b/packages/vendor/src/hooks/table/filters/use-order-table-filters.tsx
@@ -10,7 +10,20 @@ export const useOrderTableFilters = (): Filter[] => {
   const { t } = useTranslation();
 
   return useMemo(() => {
-    const filters: Filter[] = [];
+    const filters: Filter[] = [
+      {
+        key: "status",
+        label: t("fields.status"),
+        type: "select",
+        multiple: true,
+        options: [
+          { label: t("orders.status.pending"), value: "pending" },
+          { label: t("orders.status.completed"), value: "completed" },
+          { label: t("orders.status.requires_action"), value: "requires_action" },
+          { label: t("orders.status.canceled"), value: "canceled" },
+        ],
+      },
+    ];
 
     const dateFilters: Filter[] = [
       { label: t("fields.createdAt"), key: "created_at" },

--- a/packages/vendor/src/i18n/translations/en.json
+++ b/packages/vendor/src/i18n/translations/en.json
@@ -1452,6 +1452,9 @@
     }
   },
   "orders": {
+    "requiresAction": {
+      "actionUnavailable": "Not available until this order is accepted"
+    },
     "giftCardsStoreCreditLines": "Gift cards & credit lines",
     "creditLines": {
       "title": "Credit lines",

--- a/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -15,7 +15,10 @@ import { format } from "date-fns"
 import { useTranslation } from "react-i18next"
 import { Link, useNavigate } from "react-router-dom"
 import { ActionMenu } from "@components/common/action-menu"
-import { DisplayExtensionZone } from "@mercurjs/dashboard-shared"
+import {
+  DisplayExtensionZone,
+  isOrderAwaitingAction,
+} from "@mercurjs/dashboard-shared"
 import { Skeleton } from "@components/common/skeleton"
 import { Thumbnail } from "@components/common/thumbnail"
 import {
@@ -187,6 +190,10 @@ const UnfulfilledItemDisplay = ({
                     label: t("orders.fulfillment.fulfillItems"),
                     icon: <Buildings />,
                     to: `/orders/${order.id}/fulfillment?requires_shipping=${requiresShipping}`,
+                    disabled: isOrderAwaitingAction(order),
+                    disabledTooltip: isOrderAwaitingAction(order)
+                      ? t("orders.requiresAction.actionUnavailable")
+                      : undefined,
                   },
                 ],
               },

--- a/packages/vendor/src/pages/orders/[id]/_components/order-payment-section/order-payment-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-payment-section/order-payment-section.tsx
@@ -17,6 +17,7 @@ import DisplayId from "@components/common/display-id/display-id"
 import { getLocaleAmount, getStylizedAmount } from "@lib/money-amount-helpers"
 import { getOrderPaymentStatus } from "@lib/order-helpers"
 import { getTotalCaptured, getTotalPending } from "@lib/payment"
+import { isOrderActionable } from "@mercurjs/dashboard-shared"
 import { useDate } from "@hooks/use-date"
 
 type PaymentRefund = {
@@ -142,6 +143,7 @@ const PaymentRow = ({
   const isFullyRefunded =
     refundedAmount > 0 && refundedAmount >= (payment.amount as number)
   const canRefund =
+    isOrderActionable(order) &&
     !!payment.captured_at && !payment.canceled_at && !isFullyRefunded
 
   return (

--- a/packages/vendor/src/pages/orders/[id]/_components/order-summary-section/order-summary-section.tsx
+++ b/packages/vendor/src/pages/orders/[id]/_components/order-summary-section/order-summary-section.tsx
@@ -36,6 +36,7 @@ import {
 
 import { DisplayExtensionZone, WidgetZone } from "@mercurjs/dashboard-shared"
 import { ActionMenu } from "@components/common/action-menu"
+import { isOrderAwaitingAction } from "@mercurjs/dashboard-shared"
 import {
   useOrderCommissionLines,
   useOrderPreview,
@@ -237,7 +238,11 @@ const Header = ({
 }) => {
   const { t } = useTranslation()
 
-  const isCanceled = !!order.canceled_at
+  const isAwaitingAction = isOrderAwaitingAction(order)
+  const isLocked = !!order.canceled_at || isAwaitingAction
+  const awaitingActionTooltip = isAwaitingAction
+    ? t("orders.requiresAction.actionUnavailable")
+    : undefined
   const returnOutOfPolicy = isOutsidePolicyWindow(order, RETURN_POLICY_DAYS)
   const exchangeOutOfPolicy = isOutsidePolicyWindow(
     order,
@@ -255,7 +260,7 @@ const Header = ({
     orderChange?.change_type === "edit" && orderChange?.status === "pending"
 
   const editDisabled =
-    isCanceled ||
+    isLocked ||
     (!!orderChange && orderChange.change_type !== "edit") ||
     (orderChange?.change_type === "edit" && orderChange?.status === "requested")
 
@@ -289,6 +294,7 @@ const Header = ({
                 ),
                 to: "edit",
                 disabled: editDisabled,
+                disabledTooltip: awaitingActionTooltip,
                 icon: <PencilSquare />,
               },
             ],
@@ -299,15 +305,17 @@ const Header = ({
                 label: t("orders.returns.create"),
                 to: "returns/create",
                 disabled:
-                  isCanceled ||
+                  isLocked ||
                   returnOutOfPolicy ||
                   shouldDisableReturn ||
                   returnDisabledByChange,
-                disabledTooltip: returnOutOfPolicy
-                  ? t("orders.returns.outOfPolicy", {
-                      days: RETURN_POLICY_DAYS,
-                    })
-                  : undefined,
+                disabledTooltip:
+                  awaitingActionTooltip ??
+                  (returnOutOfPolicy
+                    ? t("orders.returns.outOfPolicy", {
+                        days: RETURN_POLICY_DAYS,
+                      })
+                    : undefined),
                 icon: <ArrowUturnLeft />,
               },
               {
@@ -317,15 +325,17 @@ const Header = ({
                     : t("orders.exchanges.create"),
                 to: "exchanges/create",
                 disabled:
-                  isCanceled ||
+                  isLocked ||
                   exchangeOutOfPolicy ||
                   shouldDisableReturn ||
                   exchangeDisabledByChange,
-                disabledTooltip: exchangeOutOfPolicy
-                  ? t("orders.exchanges.outOfPolicy", {
-                      days: EXCHANGE_POLICY_DAYS,
-                    })
-                  : undefined,
+                disabledTooltip:
+                  awaitingActionTooltip ??
+                  (exchangeOutOfPolicy
+                    ? t("orders.exchanges.outOfPolicy", {
+                        days: EXCHANGE_POLICY_DAYS,
+                      })
+                    : undefined),
                 icon: <ArrowPath />,
               },
               {
@@ -335,15 +345,17 @@ const Header = ({
                     : t("orders.claims.create"),
                 to: "claims/create",
                 disabled:
-                  isCanceled ||
+                  isLocked ||
                   claimOutOfPolicy ||
                   shouldDisableReturn ||
                   claimDisabledByChange,
-                disabledTooltip: claimOutOfPolicy
-                  ? t("orders.claims.outOfPolicy", {
-                      days: CLAIM_POLICY_DAYS,
-                    })
-                  : undefined,
+                disabledTooltip:
+                  awaitingActionTooltip ??
+                  (claimOutOfPolicy
+                    ? t("orders.claims.outOfPolicy", {
+                        days: CLAIM_POLICY_DAYS,
+                      })
+                    : undefined),
                 icon: <ExclamationCircle />,
               },
             ],


### PR DESCRIPTION
## Summary

Finishes a seam that is already half there. `requires_action` is a Medusa order status that both dashboards already render, but nothing could set it, and the dashboards still offered every action on it. Nothing changes for an install with no plugin: every default is today's hard-coded value.

### 1. `setOrderStatus` hook on `completeCartWithSplitOrdersWorkflow`
- New hook, called with the `cart`. Its result is read with `getResult()` and merged over the default, the same way Medusa's `setPricingContext` works.
- The handler returns `{ status?, status_by_seller_id? }`. Resolution order: `status_by_seller_id[sellerId]`, then `status`, then `OrderStatus.PENDING`.
- It works per seller because one cart splits across sellers with different configurations.
- Exported type: `SetOrderStatusHookResult`.

### 2. Dashboards stop acting on `requires_action` orders
- `isOrderActionable` and `isOrderAwaitingAction` are added to `@mercurjs/dashboard-shared`.
- Vendor and admin disable these actions on `requires_action` orders: fulfil items (vendor), edit, return, exchange, claim, capture (admin) and refund.
- The disabled actions stay visible with a tooltip, `orders.requiresAction.actionUnavailable` ("Not available until this order is accepted").

### 3. Status filter on order tables
- Adds a `status` multi-select filter to vendor and admin `useOrderTableFilters`. The API already accepted `status`.
- Labels reuse the existing `orders.status.*` keys.

## Tests
- New `integration-tests/http/order/store/split-order-status-hook.spec.ts` checks a two-seller cart:
  - no handler / `undefined`: both orders `pending` (regression case)
  - `{ status }`: both orders `requires_action`
  - `{ status_by_seller_id }`: seller A `requires_action`, seller B `pending`
- `tsc --noEmit` passes for `packages/core`. The integration suite has not been run locally yet; relying on CI.

